### PR TITLE
feat(#2): 搭建 main-core 单项目强 package 骨架与边界静态检查

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,32 @@
+[importlinter]
+root_package = main_core
+
+[importlinter:contract:l1_l8_layers]
+name = L1-L8 layered package boundaries
+type = layers
+layers =
+    main_core.l8_publish
+    main_core.l7_recommendation
+    main_core.l6_alpha
+    main_core.l5_universe
+    main_core.l4_world_state
+    main_core.l3_features
+    main_core.l1_l2_basis
+
+[importlinter:contract:l3_downstream_forbidden]
+name = L3 features must not import downstream analysis or publish layers
+type = forbidden
+source_modules =
+    main_core.l3_features
+forbidden_modules =
+    main_core.l6_alpha
+    main_core.l7_recommendation
+    main_core.l8_publish
+
+[importlinter:contract:l4_publish_forbidden]
+name = L4 world state must not import publish assembly
+type = forbidden
+source_modules =
+    main_core.l4_world_state
+forbidden_modules =
+    main_core.l8_publish

--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ Execution rule:
 1. read the project doc first
 2. keep work inside this module unless the issue explicitly targets shared contracts
 3. do not treat this scaffold as finished implementation
+
+Boundary checks:
+
+- After installing development dependencies, run `bash scripts/check_boundaries.sh` to execute
+  Ruff, import-linter, and the package boundary tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,20 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = []
 
-[tool.setuptools]
-packages = []
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-cov>=5",
+    "ruff>=0.5",
+    "import-linter>=2.0",
+    "pydantic>=2.6",
+]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 100
+target-version = "py311"
+
+[lint]
+select = ["E", "F", "I", "B", "UP", "PL"]

--- a/scripts/check_boundaries.sh
+++ b/scripts/check_boundaries.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ruff check .
+lint-imports
+
+if command -v pytest >/dev/null 2>&1; then
+  pytest tests/test_package_boundaries.py
+else
+  python3 -m pytest tests/test_package_boundaries.py
+fi

--- a/src/main_core/__init__.py
+++ b/src/main_core/__init__.py
@@ -1,0 +1,1 @@
+"""Main-core package root."""

--- a/src/main_core/common/__init__.py
+++ b/src/main_core/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared main-core primitives."""

--- a/src/main_core/common/errors.py
+++ b/src/main_core/common/errors.py
@@ -1,0 +1,25 @@
+"""Shared exception types for main-core."""
+
+
+class MainCoreError(Exception):
+    """Base exception for main-core failures."""
+
+
+class InconclusiveError(MainCoreError):
+    """Raised when a task must be marked inconclusive."""
+
+
+class ManifestPublishError(MainCoreError):
+    """Raised when manifest-backed publication fails."""
+
+
+class BoundaryViolationError(MainCoreError):
+    """Raised when a package boundary rule is violated."""
+
+
+__all__ = [
+    "BoundaryViolationError",
+    "InconclusiveError",
+    "MainCoreError",
+    "ManifestPublishError",
+]

--- a/src/main_core/common/types.py
+++ b/src/main_core/common/types.py
@@ -1,0 +1,9 @@
+"""Shared runtime type aliases for main-core."""
+
+from typing import Literal, NewType
+
+CycleId = NewType("CycleId", str)
+EntityId = NewType("EntityId", str)
+Regime = Literal["risk_off", "neutral", "risk_on"]
+
+__all__ = ["CycleId", "EntityId", "Regime"]

--- a/src/main_core/l1_l2_basis/_README.md
+++ b/src/main_core/l1_l2_basis/_README.md
@@ -1,0 +1,5 @@
+# L1/L2 Basis
+
+Responsibility: object, market, and calendar basis reads.
+
+Source: `docs/main-core.project-doc.md` §14, line 580.

--- a/src/main_core/l1_l2_basis/__init__.py
+++ b/src/main_core/l1_l2_basis/__init__.py
@@ -1,0 +1,1 @@
+"""L1/L2 package — basis reads; see §14 of main-core.project-doc.md."""

--- a/src/main_core/l3_features/_README.md
+++ b/src/main_core/l3_features/_README.md
@@ -1,0 +1,5 @@
+# L3 Features
+
+Responsibility: feature integration, signal bundle assembly, and online multiplier adjustment.
+
+Source: `docs/main-core.project-doc.md` §14, line 581.

--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -1,0 +1,1 @@
+"""L3 package — feature and signal bundle work; see §14 of main-core.project-doc.md."""

--- a/src/main_core/l4_world_state/_README.md
+++ b/src/main_core/l4_world_state/_README.md
@@ -1,0 +1,5 @@
+# L4 World State
+
+Responsibility: rule skeleton plus LLM-adjusted shared world state.
+
+Source: `docs/main-core.project-doc.md` §14, line 582.

--- a/src/main_core/l4_world_state/__init__.py
+++ b/src/main_core/l4_world_state/__init__.py
@@ -1,0 +1,1 @@
+"""L4 package — shared world state work; see §14 of main-core.project-doc.md."""

--- a/src/main_core/l5_universe/_README.md
+++ b/src/main_core/l5_universe/_README.md
@@ -1,0 +1,5 @@
+# L5 Universe
+
+Responsibility: observation and core pool management, freezing, and removals.
+
+Source: `docs/main-core.project-doc.md` §14, line 583.

--- a/src/main_core/l5_universe/__init__.py
+++ b/src/main_core/l5_universe/__init__.py
@@ -1,0 +1,1 @@
+"""L5 package — observation and core pool work; see §14 of main-core.project-doc.md."""

--- a/src/main_core/l6_alpha/_README.md
+++ b/src/main_core/l6_alpha/_README.md
@@ -1,0 +1,5 @@
+# L6 Alpha
+
+Responsibility: analyzer interface, SinglePromptAnalyzer, and MultiAgent slot.
+
+Source: `docs/main-core.project-doc.md` §14, line 584.

--- a/src/main_core/l6_alpha/__init__.py
+++ b/src/main_core/l6_alpha/__init__.py
@@ -1,0 +1,1 @@
+"""L6 package — analyzer work; see §14 of main-core.project-doc.md."""

--- a/src/main_core/l7_recommendation/_README.md
+++ b/src/main_core/l7_recommendation/_README.md
@@ -1,0 +1,5 @@
+# L7 Recommendation
+
+Responsibility: recommendation generation, override application, and inconclusive handling.
+
+Source: `docs/main-core.project-doc.md` §14, line 585.

--- a/src/main_core/l7_recommendation/__init__.py
+++ b/src/main_core/l7_recommendation/__init__.py
@@ -1,0 +1,1 @@
+"""L7 package — recommendation work; see §14 of main-core.project-doc.md."""

--- a/src/main_core/l8_publish/_README.md
+++ b/src/main_core/l8_publish/_README.md
@@ -1,0 +1,5 @@
+# L8 Publish
+
+Responsibility: formal object assembly, manifest initiation, and publish bundle assembly.
+
+Source: `docs/main-core.project-doc.md` §14, line 586.

--- a/src/main_core/l8_publish/__init__.py
+++ b/src/main_core/l8_publish/__init__.py
@@ -1,0 +1,1 @@
+"""L8 package — publish bundle work; see §14 of main-core.project-doc.md."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for main-core."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration for local src-layout imports."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))

--- a/tests/test_package_boundaries.py
+++ b/tests/test_package_boundaries.py
@@ -1,0 +1,81 @@
+"""Static package boundary checks for the main-core package skeleton."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+EXIT_SUCCESS = 0
+
+LAYER_PACKAGES = (
+    "l1_l2_basis",
+    "l3_features",
+    "l4_world_state",
+    "l5_universe",
+    "l6_alpha",
+    "l7_recommendation",
+    "l8_publish",
+)
+
+
+def _format_process_output(result: subprocess.CompletedProcess[str]) -> str:
+    return f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def _run_lint_imports(cwd: Path) -> subprocess.CompletedProcess[str]:
+    lint_imports = shutil.which("lint-imports")
+    if lint_imports is None:
+        pytest.skip("import-linter CLI is not installed; run `pip install -e .[dev]`")
+
+    env = os.environ.copy()
+    package_root = cwd / "src" if (cwd / "src").exists() else cwd
+    python_path = [str(package_root)]
+    if existing_python_path := env.get("PYTHONPATH"):
+        python_path.append(existing_python_path)
+    env["PYTHONPATH"] = os.pathsep.join(python_path)
+
+    return subprocess.run(
+        [lint_imports, "--config", ".importlinter"],
+        cwd=cwd,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_all_layers_importable() -> None:
+    for package in LAYER_PACKAGES:
+        importlib.import_module(f"main_core.{package}")
+
+
+def test_importlinter_contracts_pass() -> None:
+    result = _run_lint_imports(PROJECT_ROOT)
+
+    assert result.returncode == EXIT_SUCCESS, _format_process_output(result)
+
+
+def test_forbidden_contract_triggers_on_synthetic_violation(tmp_path: Path) -> None:
+    synthetic_root = tmp_path / "main_core"
+    synthetic_root.mkdir()
+    (synthetic_root / "__init__.py").write_text('"""Synthetic main-core package."""\n')
+
+    for package in LAYER_PACKAGES:
+        package_dir = synthetic_root / package
+        package_dir.mkdir()
+        package_body = '"""Synthetic layer package."""\n'
+        if package == "l3_features":
+            package_body += "from main_core.l6_alpha import *\n"
+        (package_dir / "__init__.py").write_text(package_body)
+
+    shutil.copyfile(PROJECT_ROOT / ".importlinter", tmp_path / ".importlinter")
+
+    result = _run_lint_imports(tmp_path)
+
+    assert result.returncode != EXIT_SUCCESS, _format_process_output(result)


### PR DESCRIPTION
Closes #2

Implemented by Codex.

---
## 背景与目标
按项目文档 §5.4 与 §14，`main-core` 必须在**同一个 Python 项目内**保留 L1-L8 的强 package 边界，不允许拆成 8 个子项目，也不允许跨层反向 import。本 issue 负责把当前空骨架扩展为带有 `main_core.l1_l2_basis` … `main_core.l8_publish` 七个子 package、共享 `main_core.common` 基础包、以及最关键的 **package 边界静态 lint** 的可运行 Python 项目。这是后续所有 formal object、analyzer、publish bundle 实现的承载基底，若 package 边界不先硬化，§6.2 反模式（L3 反向 import L6/L7）几乎必然发生。本 issue 同时落地 `pytest` / `ruff` / `import-linter` 的最小 CI 脚本，供后续每一个 issue 复用。

## 所属模块
- primary writable paths（本 issue 可写入）：
  - `pyproject.toml`
  - `src/main_core/__init__.py`
  - `src/main_core/common/__init__.py`, `src/main_core/common/types.py`, `src/main_core/common/errors.py`
  - `src/main_core/l1_l2_basis/__init__.py`
  - `src/main_core/l3_features/__init__.py`
  - `src/main_core/l4_world_state/__init__.py`
  - `src/main_core/l5_universe/__init__.py`
  - `src/main_core/l6_alpha/__init__.py`
  - `src/main_core/l7_recommendation/__init__.py`
  - `src/main_core/l8_publish/__init__.py`
  - `tests/__init__.py`, `tests/test_package_boundaries.py`, `tests/conftest.py`
  - `.importlinter`（或 `setup.cfg` 内 `[importlinter]` 段）
  - `ruff.toml`
  - `scripts/check_boundaries.sh`
- adjacent read-only / integration paths（可读不可写）：
  - `docs/main-core.project-doc.md`（参考 §5.4、§14）
  - `CLAUDE.md`（项目 OWN/BAN 约束）
- off-limits paths（本 issue 禁止触碰，留给后续 issue）：
  - `src/main_core/l*/` 内的任何业务实现文件（本 issue 只允许空 `__init__.py` + 占位 `README`）
  - 任何 `schemas.py` / `protocols.py`（归 #3 / #4）
  - `data-platform` / `graph-engine` / `reasoner-runtime` / `audit-eval` 相关 stub（跨模块禁区）

## 实现范围
- **项目元数据**：
  - `pyproject.toml`：在现有基础上新增 `[project.optional-dependencies]`，`dev = ["pytest>=8", "pytest-cov>=5", "ruff>=0.5", "import-linter>=2.0", "pydantic>=2.6"]`；`[tool.setuptools.packages.find]` 指向 `src`；`[tool.setuptools.package-dir] = {"" = "src"}`。
- **共享基础包**：
  - `src/main_core/common/types.py`：`CycleId = NewType("CycleId", str)`、`EntityId = NewType("EntityId", str)`、`Regime = Literal["risk_off", "neutral", "risk_on"]`（占位，实际取值可在 §9 对照后修