### PR TITLE
feat(#4): 定义 AnalyzerInterface / WorldStatePolicy / RecommendationConstraintProvider 三类协议接口

### DIFF
--- a/src/main_core/common/contexts.py
+++ b/src/main_core/common/contexts.py
@@ -1,0 +1,52 @@
+"""Runtime context models passed through explicit main-core protocols."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from main_core.common.schemas import (
+    FeatureSignalBundle,
+    WorldStateSnapshot,
+)
+from main_core.common.types import CycleId, EntityId
+
+
+class AlphaAnalysisContext(BaseModel):
+    """Frozen L6 runtime context for analyzer protocol calls."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    feature_bundle: FeatureSignalBundle
+    world_state: WorldStateSnapshot
+    similar_cases: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class WorldStateInputs(BaseModel):
+    """Frozen L4 runtime inputs for world-state policy evaluation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    cycle_id: CycleId
+    feature_bundle: FeatureSignalBundle
+    macro_context: dict[str, Any] = Field(default_factory=dict)
+    graph_impact: dict[str, Any] = Field(default_factory=dict)
+
+
+class RecommendationConstraintInputs(BaseModel):
+    """Frozen L7 runtime inputs for recommendation constraint gates."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    world_state: WorldStateSnapshot
+    risk_context: dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = [
+    "AlphaAnalysisContext",
+    "RecommendationConstraintInputs",
+    "WorldStateInputs",
+]

--- a/src/main_core/common/protocols/__init__.py
+++ b/src/main_core/common/protocols/__init__.py
@@ -1,0 +1,22 @@
+"""Explicit protocol contracts shared by main-core layers."""
+
+from main_core.common.protocols.analyzer import AnalyzerBase, AnalyzerInterface
+from main_core.common.protocols.constraint_provider import (
+    RecommendationConstraintProvider,
+    RecommendationConstraintProviderBase,
+)
+from main_core.common.protocols.world_state_policy import (
+    BoundedLlmDelta,
+    WorldStatePolicy,
+    WorldStatePolicyBase,
+)
+
+__all__ = [
+    "AnalyzerBase",
+    "AnalyzerInterface",
+    "BoundedLlmDelta",
+    "RecommendationConstraintProvider",
+    "RecommendationConstraintProviderBase",
+    "WorldStatePolicy",
+    "WorldStatePolicyBase",
+]

--- a/src/main_core/common/protocols/analyzer.py
+++ b/src/main_core/common/protocols/analyzer.py
@@ -1,0 +1,39 @@
+"""Analyzer protocol contracts for §16.2."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar, Protocol, runtime_checkable
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.schemas import AlphaResultSnapshot
+
+
+@runtime_checkable
+class AnalyzerInterface(Protocol):
+    """L6 pluggable analyzer interface from §16.2.
+
+    P2 analyzer implementations must use analyzer_type ``single_prompt_v1`` by
+    default, as required by §16.3.
+    """
+
+    analyzer_type: ClassVar[str]
+
+    def analyze(self, context: AlphaAnalysisContext) -> AlphaResultSnapshot:
+        """Analyze one stock using a typed runtime context."""
+
+
+class AnalyzerBase(ABC):
+    """ABC inheritance entry point for concrete §16.2 analyzers."""
+
+    @property
+    @abstractmethod
+    def analyzer_type(self) -> str:
+        """Return the analyzer implementation identifier."""
+
+    @abstractmethod
+    def analyze(self, context: AlphaAnalysisContext) -> AlphaResultSnapshot:
+        """Analyze one stock using a typed runtime context."""
+
+
+__all__ = ["AnalyzerBase", "AnalyzerInterface"]

--- a/src/main_core/common/protocols/constraint_provider.py
+++ b/src/main_core/common/protocols/constraint_provider.py
@@ -1,0 +1,39 @@
+"""Recommendation constraint protocol contracts for §16.2."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Protocol, runtime_checkable
+
+from main_core.common.contexts import RecommendationConstraintInputs
+from main_core.common.schemas import RecommendationSnapshot
+
+
+@runtime_checkable
+class RecommendationConstraintProvider(Protocol):
+    """L7 regime and risk constraint interface from §16.2.
+
+    Per §12.3, constraint gates take precedence over override handling.
+    """
+
+    def gate(
+        self,
+        inputs: RecommendationConstraintInputs,
+        candidate: RecommendationSnapshot,
+    ) -> RecommendationSnapshot:
+        """Apply gate constraints to a typed recommendation candidate."""
+
+
+class RecommendationConstraintProviderBase(ABC):
+    """ABC inheritance entry point for concrete §16.2 constraint providers."""
+
+    @abstractmethod
+    def gate(
+        self,
+        inputs: RecommendationConstraintInputs,
+        candidate: RecommendationSnapshot,
+    ) -> RecommendationSnapshot:
+        """Apply gate constraints to a typed recommendation candidate."""
+
+
+__all__ = ["RecommendationConstraintProvider", "RecommendationConstraintProviderBase"]

--- a/src/main_core/common/protocols/world_state_policy.py
+++ b/src/main_core/common/protocols/world_state_policy.py
@@ -1,0 +1,44 @@
+"""World-state policy protocol contracts for §16.2."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Literal, Protocol, runtime_checkable
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.types import Regime
+
+BoundedLlmDelta = Literal[-1, 0, 1]
+
+
+@runtime_checkable
+class WorldStatePolicy(Protocol):
+    """L4 rule skeleton and correction constraint interface from §16.2."""
+
+    def baseline(self, inputs: WorldStateInputs) -> Regime:
+        """Derive the baseline market regime from typed world-state inputs."""
+
+    def bound_delta(self, raw_delta: int) -> BoundedLlmDelta:
+        """Clamp a raw LLM delta to the formal ``-1`` / ``0`` / ``+1`` range."""
+
+    def compose(self, baseline: Regime, delta: BoundedLlmDelta) -> Regime:
+        """Compose a baseline regime and bounded LLM delta into a final regime."""
+
+
+class WorldStatePolicyBase(ABC):
+    """ABC inheritance entry point for concrete §16.2 world-state policies."""
+
+    @abstractmethod
+    def baseline(self, inputs: WorldStateInputs) -> Regime:
+        """Derive the baseline market regime from typed world-state inputs."""
+
+    @abstractmethod
+    def bound_delta(self, raw_delta: int) -> BoundedLlmDelta:
+        """Clamp a raw LLM delta to the formal range."""
+
+    @abstractmethod
+    def compose(self, baseline: Regime, delta: BoundedLlmDelta) -> Regime:
+        """Compose baseline regime and bounded delta."""
+
+
+__all__ = ["BoundedLlmDelta", "WorldStatePolicy", "WorldStatePolicyBase"]

--- a/src/main_core/common/schemas/__init__.py
+++ b/src/main_core/common/schemas/__init__.py
@@ -1,0 +1,23 @@
+"""Pydantic schema objects shared across main-core layers."""
+
+from main_core.common.schemas.alpha import AlphaResultSnapshot, AlphaStatus, AnalyzerType
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.schemas.recommendation import (
+    ActionType,
+    RecommendationSnapshot,
+    TriggerSource,
+)
+from main_core.common.schemas.world_state import WorldStateSnapshot
+
+__all__ = [
+    "ActionType",
+    "AlphaResultSnapshot",
+    "AlphaStatus",
+    "AnalyzerType",
+    "FeatureSignalBundle",
+    "FormalObjectBase",
+    "RecommendationSnapshot",
+    "TriggerSource",
+    "WorldStateSnapshot",
+]

--- a/src/main_core/common/schemas/alpha.py
+++ b/src/main_core/common/schemas/alpha.py
@@ -1,0 +1,27 @@
+"""L6 formal alpha analysis result schema."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+AnalyzerType = Literal["single_prompt_v1", "multi_agent_v1"]
+AlphaStatus = Literal["ok", "inconclusive"]
+
+
+class AlphaResultSnapshot(FormalObjectBase):
+    """Formal L6 alpha result snapshot described in §9.3."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    analyzer_type: AnalyzerType = "single_prompt_v1"
+    score: float | None
+    confidence: float
+    rationale: str
+    similar_cases: list[dict[str, Any]]
+    status: AlphaStatus
+
+
+__all__ = ["AlphaResultSnapshot", "AlphaStatus", "AnalyzerType"]

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -1,0 +1,27 @@
+"""Shared Pydantic base class for main-core schema objects."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict
+
+
+class FormalObjectBase(BaseModel):
+    """Frozen schema base for formal and runtime contract objects."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    def to_json(self) -> str:
+        """Serialize the object using Pydantic's JSON representation."""
+
+        return self.model_dump_json()
+
+    @classmethod
+    def from_json(cls, payload: str) -> Self:
+        """Deserialize an object from Pydantic JSON."""
+
+        return cls.model_validate_json(payload)
+
+
+__all__ = ["FormalObjectBase"]

--- a/src/main_core/common/schemas/feature_bundle.py
+++ b/src/main_core/common/schemas/feature_bundle.py
@@ -1,0 +1,30 @@
+"""L3 runtime feature signal bundle schema."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import Field
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class FeatureSignalBundle(FormalObjectBase):
+    """Runtime L3 feature and signal bundle described in §9.3."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    feature_values: dict[str, float]
+    signal_values: dict[str, Any]
+    graph_features: dict[str, Any]
+    feature_weight_multiplier: dict[str, float]
+    generated_at: datetime = Field(default_factory=_utc_now)
+
+
+__all__ = ["FeatureSignalBundle"]

--- a/src/main_core/common/schemas/recommendation.py
+++ b/src/main_core/common/schemas/recommendation.py
@@ -1,0 +1,27 @@
+"""L7 formal recommendation schema."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+ActionType = Literal["buy", "hold", "reduce", "inconclusive"]
+TriggerSource = Literal["system", "human_decision"]
+
+
+class RecommendationSnapshot(FormalObjectBase):
+    """Formal L7 recommendation snapshot described in §9.3."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    action_type: ActionType
+    rating: str | None
+    confidence: float | None
+    triggered_by: TriggerSource
+    override_applied: bool
+    constraints_applied: dict[str, Any]
+
+
+__all__ = ["ActionType", "RecommendationSnapshot", "TriggerSource"]

--- a/src/main_core/common/schemas/world_state.py
+++ b/src/main_core/common/schemas/world_state.py
@@ -1,0 +1,24 @@
+"""L4 formal world state schema."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId, Regime
+
+
+class WorldStateSnapshot(FormalObjectBase):
+    """Formal L4 shared world state snapshot described in §9.3."""
+
+    cycle_id: CycleId
+    baseline_regime: Regime
+    llm_delta: Literal[-1, 0, 1]
+    final_regime: Regime
+    llm_rationale: str
+    actual_model_used: str
+    actual_provider: str
+    fallback_path: list[str]
+
+
+__all__ = ["WorldStateSnapshot"]

--- a/src/main_core/l4_world_state/stubs.py
+++ b/src/main_core/l4_world_state/stubs.py
@@ -1,0 +1,33 @@
+"""P2 world-state policy stubs for L4."""
+
+from __future__ import annotations
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.protocols import BoundedLlmDelta, WorldStatePolicyBase
+from main_core.common.types import Regime
+
+
+class DefaultWorldStatePolicyStub(WorldStatePolicyBase):
+    """P2 placeholder, wired in milestone-2."""
+
+    def baseline(self, inputs: WorldStateInputs) -> Regime:
+        """Reserve baseline regime selection for the real L4 implementation."""
+
+        raise NotImplementedError("implemented in #7")
+
+    def bound_delta(self, raw_delta: int) -> BoundedLlmDelta:
+        """Clamp raw LLM deltas to the hard formal ``-1`` / ``0`` / ``+1`` range."""
+
+        if raw_delta < 0:
+            return -1
+        if raw_delta > 0:
+            return 1
+        return 0
+
+    def compose(self, baseline: Regime, delta: BoundedLlmDelta) -> Regime:
+        """Reserve final regime composition for the real L4 implementation."""
+
+        raise NotImplementedError("implemented in #7")
+
+
+__all__ = ["DefaultWorldStatePolicyStub"]

--- a/src/main_core/l6_alpha/stubs.py
+++ b/src/main_core/l6_alpha/stubs.py
@@ -1,0 +1,23 @@
+"""P2 analyzer stubs for L6 alpha analysis."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.protocols import AnalyzerBase
+from main_core.common.schemas import AlphaResultSnapshot
+
+
+class SinglePromptAnalyzerStub(AnalyzerBase):
+    """P2 placeholder, wired in milestone-2."""
+
+    analyzer_type: ClassVar[str] = "single_prompt_v1"
+
+    def analyze(self, context: AlphaAnalysisContext) -> AlphaResultSnapshot:
+        """Reserve the L6 analyzer contract until the real implementation lands."""
+
+        raise NotImplementedError("implemented in #9")
+
+
+__all__ = ["SinglePromptAnalyzerStub"]

--- a/src/main_core/l7_recommendation/stubs.py
+++ b/src/main_core/l7_recommendation/stubs.py
@@ -1,0 +1,23 @@
+"""P2 recommendation constraint stubs for L7."""
+
+from __future__ import annotations
+
+from main_core.common.contexts import RecommendationConstraintInputs
+from main_core.common.protocols import RecommendationConstraintProviderBase
+from main_core.common.schemas import RecommendationSnapshot
+
+
+class NullConstraintProviderStub(RecommendationConstraintProviderBase):
+    """P2 placeholder, wired in milestone-2."""
+
+    def gate(
+        self,
+        inputs: RecommendationConstraintInputs,
+        candidate: RecommendationSnapshot,
+    ) -> RecommendationSnapshot:
+        """Return the candidate unchanged until real regime/risk gates land."""
+
+        return candidate
+
+
+__all__ = ["NullConstraintProviderStub"]

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -1,0 +1,1 @@
+"""Protocol contract tests."""

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -1,0 +1,67 @@
+"""Tests for the L6 analyzer protocol contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.protocols import AnalyzerBase, AnalyzerInterface
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.l6_alpha.stubs import SinglePromptAnalyzerStub
+
+CYCLE_ID = "cycle_001"
+ENTITY_ID = "ENT_001"
+SINGLE_PROMPT_ANALYZER = "single_prompt_v1"
+
+
+def _feature_bundle() -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id=CYCLE_ID,
+        entity_id=ENTITY_ID,
+        feature_values={"momentum": 0.42},
+        signal_values={"signal": "positive"},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+
+
+def _world_state() -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id=CYCLE_ID,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="stub",
+        actual_model_used="none",
+        actual_provider="none",
+        fallback_path=[],
+    )
+
+
+def _analysis_context() -> AlphaAnalysisContext:
+    return AlphaAnalysisContext(
+        cycle_id=CYCLE_ID,
+        entity_id=ENTITY_ID,
+        feature_bundle=_feature_bundle(),
+        world_state=_world_state(),
+        similar_cases=[],
+    )
+
+
+def test_analyzer_protocol_imports() -> None:
+    assert AnalyzerInterface is not None
+    assert AnalyzerBase is not None
+
+
+def test_single_prompt_stub_matches_runtime_protocol() -> None:
+    analyzer = SinglePromptAnalyzerStub()
+
+    assert isinstance(analyzer, AnalyzerInterface)
+    assert analyzer.analyzer_type == SINGLE_PROMPT_ANALYZER
+
+
+def test_single_prompt_stub_analyze_placeholder_raises() -> None:
+    analyzer = SinglePromptAnalyzerStub()
+
+    with pytest.raises(NotImplementedError, match="#9"):
+        analyzer.analyze(_analysis_context())

--- a/tests/protocols/test_constraint_provider.py
+++ b/tests/protocols/test_constraint_provider.py
@@ -1,0 +1,77 @@
+"""Tests for the L7 recommendation constraint provider protocol contract."""
+
+from __future__ import annotations
+
+from typing import get_type_hints
+
+from main_core.common.contexts import RecommendationConstraintInputs
+from main_core.common.protocols import (
+    RecommendationConstraintProvider,
+    RecommendationConstraintProviderBase,
+)
+from main_core.common.schemas import RecommendationSnapshot, WorldStateSnapshot
+from main_core.l7_recommendation.stubs import NullConstraintProviderStub
+
+CYCLE_ID = "cycle_001"
+ENTITY_ID = "ENT_001"
+
+
+def _world_state() -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id=CYCLE_ID,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="stub",
+        actual_model_used="none",
+        actual_provider="none",
+        fallback_path=[],
+    )
+
+
+def _constraint_inputs() -> RecommendationConstraintInputs:
+    return RecommendationConstraintInputs(
+        world_state=_world_state(),
+        risk_context={"gross_exposure": 0.0},
+    )
+
+
+def _candidate() -> RecommendationSnapshot:
+    return RecommendationSnapshot(
+        cycle_id=CYCLE_ID,
+        entity_id=ENTITY_ID,
+        action_type="hold",
+        rating="neutral",
+        confidence=0.5,
+        triggered_by="system",
+        override_applied=False,
+        constraints_applied={},
+    )
+
+
+def test_constraint_provider_protocol_imports() -> None:
+    assert RecommendationConstraintProvider is not None
+    assert RecommendationConstraintProviderBase is not None
+
+
+def test_null_constraint_provider_matches_runtime_protocol() -> None:
+    provider = NullConstraintProviderStub()
+
+    assert isinstance(provider, RecommendationConstraintProvider)
+
+
+def test_null_constraint_provider_returns_candidate_unchanged() -> None:
+    provider = NullConstraintProviderStub()
+    candidate = _candidate()
+
+    gated_candidate = provider.gate(_constraint_inputs(), candidate)
+
+    assert gated_candidate is candidate
+
+
+def test_gate_signature_uses_pydantic_models() -> None:
+    annotations = get_type_hints(RecommendationConstraintProvider.gate)
+
+    assert annotations["inputs"] is RecommendationConstraintInputs
+    assert annotations["candidate"] is RecommendationSnapshot
+    assert annotations["return"] is RecommendationSnapshot

--- a/tests/protocols/test_world_state_policy.py
+++ b/tests/protocols/test_world_state_policy.py
@@ -1,0 +1,68 @@
+"""Tests for the L4 world-state policy protocol contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.protocols import BoundedLlmDelta, WorldStatePolicy
+from main_core.common.schemas import FeatureSignalBundle
+from main_core.l4_world_state.stubs import DefaultWorldStatePolicyStub
+
+CYCLE_ID = "cycle_001"
+ENTITY_ID = "ENT_001"
+EXPECTED_NEGATIVE_DELTA = -1
+EXPECTED_NEUTRAL_DELTA = 0
+EXPECTED_POSITIVE_DELTA = 1
+
+
+def _world_state_inputs() -> WorldStateInputs:
+    return WorldStateInputs(
+        cycle_id=CYCLE_ID,
+        feature_bundle=FeatureSignalBundle(
+            cycle_id=CYCLE_ID,
+            entity_id=ENTITY_ID,
+            feature_values={"volatility": 0.2},
+            signal_values={},
+            graph_features={},
+            feature_weight_multiplier={"volatility": 1.0},
+        ),
+        macro_context={},
+        graph_impact={},
+    )
+
+
+def test_world_state_policy_protocol_imports() -> None:
+    assert WorldStatePolicy is not None
+    assert BoundedLlmDelta is not None
+
+
+def test_default_world_state_policy_stub_matches_runtime_protocol() -> None:
+    policy = DefaultWorldStatePolicyStub()
+
+    assert isinstance(policy, WorldStatePolicy)
+
+
+@pytest.mark.parametrize(
+    ("raw_delta", "expected_delta"),
+    [
+        (-5, EXPECTED_NEGATIVE_DELTA),
+        (-2, EXPECTED_NEGATIVE_DELTA),
+        (-1, EXPECTED_NEGATIVE_DELTA),
+        (0, EXPECTED_NEUTRAL_DELTA),
+        (1, EXPECTED_POSITIVE_DELTA),
+        (2, EXPECTED_POSITIVE_DELTA),
+        (5, EXPECTED_POSITIVE_DELTA),
+    ],
+)
+def test_bound_delta_clamps_to_formal_range(raw_delta: int, expected_delta: int) -> None:
+    policy = DefaultWorldStatePolicyStub()
+
+    assert policy.bound_delta(raw_delta) == expected_delta
+
+
+def test_baseline_placeholder_raises() -> None:
+    policy = DefaultWorldStatePolicyStub()
+
+    with pytest.raises(NotImplementedError, match="#7"):
+        policy.baseline(_world_state_inputs())


### PR DESCRIPTION
Closes #4

Implemented by Codex.

---
## 背景与目标
项目文档 §16.2、§25.2 明确：L6 的可插拔分析、L4 的规则骨架、L7 的 regime/risk 约束必须通过**显式协议接口**暴露，而不是散落在具体实现里。本 issue 负责把这三类协议用 `typing.Protocol` + `abc` 双重方式固定下来，并给出 P2 阶段的最小 `SinglePromptAnalyzerStub`、`DefaultWorldStatePolicyStub`、`NullConstraintProviderStub`——`Stub` 仅做签名占位返回 `NotImplementedError` 或可预期的空对象，供后续 milestone-2 的 issue 替换为真实实现。协议必须满足 §16.3 的三个兼容硬约束：`SinglePromptAnalyzer` 与 `MultiAgentAnalyzer` 必须共享同一 `AnalyzerInterface`；`analyzer_type` 在 P2 默认 `single_prompt_v1`；协议入参出参必须全部使用 #3 的 Pydantic schema，不允许裸 dict。本 issue 与 #3 合并完成 milestone-0 的"包骨架 + formal object + AnalyzerInterface"三件套（§25.2 第 1 步）。

## 所属模块
- primary writable paths：
  - `src/main_core/common/protocols/__init__.py`
  - `src/main_core/common/protocols/analyzer.py`
  - `src/main_core/common/protocols/world_state_policy.py`
  - `src/main_core/common/protocols/constraint_provider.py`
  - `src/main_core/common/contexts.py`（放 `AlphaAnalysisContext` 等运行时上下文对象）
  - `src/main_core/l6_alpha/stubs.py`（`SinglePromptAnalyzerStub`）
  - `src/main_core/l4_world_state/stubs.py`（`DefaultWorldStatePolicyStub`）
  - `src/main_core/l7_recommendation/stubs.py`（`NullConstraintProviderStub`）
  - `tests/protocols/__init__.py`
  - `tests/protocols/test_analyzer_interface.py`
  - `tests/protocols/test_world_state_policy.py`
  - `tests/protocols/test_constraint_provider.py`
- adjacent read-only paths：
  - `src/main_core/common/schemas/*`（#3 已落地）
  - `docs/main-core.project-doc.md` §11、§16.2、§16.3
- off-limits paths：
  - 任何真实 LLM 调用实现（归 milestone-2 `l6_alpha` 的后续 issue）。
  - `reasoner-runtime` adapter / provider SDK（§4.2 禁区）。
  - `l5_universe` pool selection 逻辑、`l4_world_state` 真实 regime 规则——本 issue 只落 policy 接口。
  - #3 schema 文件（本 issue 只 import，不改动）。

## 实现范围
- **运行时上下文**（`common/contexts.py`）：
  - `class AlphaAnalysisContext(BaseModel)`：`cycle_id`、`entity_id`、`feature_bundle: FeatureSignalBundle`、`world_state: WorldStateSnapshot`、`similar_cases: list[dict]`；`frozen=True`。
  - `class WorldStateInputs(BaseModel)`：`cycle_id`、`feature_b