### PR TITLE
feat(#3): 定义六类 formal object 与运行时 bundle 的 Pydantic schema

### DIFF
--- a/src/main_core/common/schemas/__init__.py
+++ b/src/main_core/common/schemas/__init__.py
@@ -1,0 +1,55 @@
+"""Pydantic schemas for main-core formal and runtime objects."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict
+
+
+class FormalObjectBase(BaseModel):
+    """Shared immutable base model for explicit cross-layer contracts."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    def to_json(self) -> str:
+        """Serialize the model to a JSON string."""
+        return self.model_dump_json()
+
+    @classmethod
+    def from_json(cls, s: str) -> Self:
+        """Deserialize a JSON string into the concrete model type."""
+        return cls.model_validate_json(s)
+
+
+from .alpha import (  # noqa: E402
+    AlphaResultSnapshot,
+    AlphaStatus,
+    AnalyzerType,
+    single_prompt_result,
+)
+from .dashboard import DashboardSnapshot  # noqa: E402
+from .feature_bundle import FeatureSignalBundle  # noqa: E402
+from .override import OverrideRecord  # noqa: E402
+from .pool import OfficialAlphaPool  # noqa: E402
+from .publish import PublishBundle  # noqa: E402
+from .recommendation import ActionType, RecommendationSnapshot  # noqa: E402
+from .report import FormalReport  # noqa: E402
+from .world_state import WorldStateSnapshot  # noqa: E402
+
+__all__ = [
+    "ActionType",
+    "AlphaResultSnapshot",
+    "AlphaStatus",
+    "AnalyzerType",
+    "DashboardSnapshot",
+    "FeatureSignalBundle",
+    "FormalObjectBase",
+    "FormalReport",
+    "OfficialAlphaPool",
+    "OverrideRecord",
+    "PublishBundle",
+    "RecommendationSnapshot",
+    "WorldStateSnapshot",
+    "single_prompt_result",
+]

--- a/src/main_core/common/schemas/alpha.py
+++ b/src/main_core/common/schemas/alpha.py
@@ -1,0 +1,55 @@
+"""Formal alpha analysis result schema."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import model_validator
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+AnalyzerType = Literal["single_prompt_v1", "multi_agent_v1"]
+AlphaStatus = Literal["ok", "inconclusive"]
+
+
+class AlphaResultSnapshot(FormalObjectBase):
+    """L6 formal deep analysis result for one entity."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    analyzer_type: AnalyzerType
+    score: float | None
+    confidence: float
+    rationale: str
+    similar_cases: list[dict[str, Any]]
+    status: AlphaStatus
+
+    @model_validator(mode="after")
+    def validate_inconclusive_score(self) -> AlphaResultSnapshot:
+        if self.status == "inconclusive" and self.score is not None:
+            raise ValueError("inconclusive alpha result must not include a score")
+        return self
+
+
+def single_prompt_result(  # noqa: PLR0913
+    *,
+    cycle_id: CycleId,
+    entity_id: EntityId,
+    score: float | None,
+    confidence: float,
+    rationale: str,
+    similar_cases: list[dict[str, Any]],
+    status: AlphaStatus = "ok",
+) -> AlphaResultSnapshot:
+    """Build a P2 default single-prompt alpha result."""
+    return AlphaResultSnapshot(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        analyzer_type="single_prompt_v1",
+        score=score,
+        confidence=confidence,
+        rationale=rationale,
+        similar_cases=similar_cases,
+        status=status,
+    )

--- a/src/main_core/common/schemas/dashboard.py
+++ b/src/main_core/common/schemas/dashboard.py
@@ -1,0 +1,18 @@
+"""Formal dashboard snapshot schema."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId
+
+
+class DashboardSnapshot(FormalObjectBase):
+    """L8 formal dashboard-facing snapshot."""
+
+    cycle_id: CycleId
+    world_state_ref: str
+    pool_ref: str
+    recommendation_ref: str
+    summary_cards: dict[str, Any]

--- a/src/main_core/common/schemas/feature_bundle.py
+++ b/src/main_core/common/schemas/feature_bundle.py
@@ -1,0 +1,34 @@
+"""Runtime feature and signal bundle schema."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Any
+
+from pydantic import field_validator
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+
+class FeatureSignalBundle(FormalObjectBase):
+    """L3 runtime bundle shared with downstream layers during one cycle."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    feature_values: dict[str, float]
+    signal_values: dict[str, Any]
+    graph_features: dict[str, Any]
+    feature_weight_multiplier: dict[str, float]
+    generated_at: datetime
+
+    @field_validator("feature_weight_multiplier")
+    @classmethod
+    def validate_positive_multipliers(cls, value: dict[str, float]) -> dict[str, float]:
+        for feature_name, multiplier in value.items():
+            if not math.isfinite(multiplier) or multiplier <= 0:
+                raise ValueError(
+                    f"feature_weight_multiplier[{feature_name!r}] must be finite and > 0"
+                )
+        return value

--- a/src/main_core/common/schemas/override.py
+++ b/src/main_core/common/schemas/override.py
@@ -1,0 +1,20 @@
+"""Override record schema."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.schemas.recommendation import ActionType
+from main_core.common.types import CycleId, EntityId
+
+
+class OverrideRecord(FormalObjectBase):
+    """Human-submitted override business record."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    submitted_by: str
+    action_type: ActionType
+    rationale: str
+    submitted_at: datetime

--- a/src/main_core/common/schemas/pool.py
+++ b/src/main_core/common/schemas/pool.py
@@ -1,0 +1,35 @@
+"""Formal official alpha pool schema."""
+
+from __future__ import annotations
+
+from pydantic import field_validator, model_validator
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+
+class OfficialAlphaPool(FormalObjectBase):
+    """L5 formal core pool and cycle-level change record."""
+
+    cycle_id: CycleId
+    observation_pool_size: int
+    official_alpha_pool_capacity: int = 100
+    selected_entities: list[EntityId]
+    added_entities: list[EntityId]
+    removed_entities: list[EntityId]
+    freeze_reason_map: dict[EntityId, str]
+
+    @field_validator("official_alpha_pool_capacity")
+    @classmethod
+    def validate_positive_capacity(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("official_alpha_pool_capacity must be > 0")
+        return value
+
+    @model_validator(mode="after")
+    def validate_selected_entity_capacity(self) -> OfficialAlphaPool:
+        if len(self.selected_entities) > self.official_alpha_pool_capacity:
+            raise ValueError(
+                "selected_entities length must be <= official_alpha_pool_capacity"
+            )
+        return self

--- a/src/main_core/common/schemas/publish.py
+++ b/src/main_core/common/schemas/publish.py
@@ -1,0 +1,18 @@
+"""Runtime publish bundle schema."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId
+
+
+class PublishBundle(FormalObjectBase):
+    """Phase 3 runtime bundle of formal object payloads and manifest data."""
+
+    cycle_id: CycleId
+    formal_objects: dict[str, Any]
+    manifest_candidate: dict[str, Any]
+    audit_payload: dict[str, Any]
+    retrospective_seed: dict[str, Any]

--- a/src/main_core/common/schemas/recommendation.py
+++ b/src/main_core/common/schemas/recommendation.py
@@ -1,0 +1,31 @@
+"""Formal recommendation snapshot schema."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import model_validator
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+ActionType = Literal["buy", "hold", "reduce", "inconclusive"]
+
+
+class RecommendationSnapshot(FormalObjectBase):
+    """L7 formal recommendation for one entity."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    action_type: ActionType
+    rating: str | None
+    confidence: float | None
+    triggered_by: Literal["system", "human_decision"]
+    override_applied: bool
+    constraints_applied: dict[str, Any]
+
+    @model_validator(mode="after")
+    def validate_inconclusive_confidence(self) -> RecommendationSnapshot:
+        if self.action_type == "inconclusive" and self.confidence is not None:
+            raise ValueError("inconclusive recommendation must not include confidence")
+        return self

--- a/src/main_core/common/schemas/report.py
+++ b/src/main_core/common/schemas/report.py
@@ -1,0 +1,18 @@
+"""Formal report schema."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId
+
+
+class FormalReport(FormalObjectBase):
+    """L8 formal report for human consumption."""
+
+    cycle_id: CycleId
+    report_type: str
+    recommendation_ref: str
+    narrative_sections: dict[str, Any]
+    appendix_refs: dict[str, Any]

--- a/src/main_core/common/schemas/world_state.py
+++ b/src/main_core/common/schemas/world_state.py
@@ -1,0 +1,42 @@
+"""Formal world state snapshot schema."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import model_validator
+
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId, Regime
+
+_REGIME_SEQUENCE: tuple[Regime, ...] = ("risk_off", "neutral", "risk_on")
+
+
+class WorldStateSnapshot(FormalObjectBase):
+    """L4 formal shared market state."""
+
+    cycle_id: CycleId
+    baseline_regime: Regime
+    llm_delta: Literal[-1, 0, 1]
+    final_regime: Regime
+    llm_rationale: str
+    actual_model_used: str
+    actual_provider: str
+    fallback_path: list[str]
+
+    @model_validator(mode="after")
+    def validate_final_regime(self) -> WorldStateSnapshot:
+        baseline_index = _REGIME_SEQUENCE.index(self.baseline_regime)
+        final_index = baseline_index + self.llm_delta
+
+        if final_index < 0 or final_index >= len(_REGIME_SEQUENCE):
+            raise ValueError("baseline_regime + llm_delta falls outside the regime sequence")
+
+        expected_final_regime = _REGIME_SEQUENCE[final_index]
+        if self.final_regime != expected_final_regime:
+            raise ValueError(
+                "final_regime must equal baseline_regime shifted by llm_delta "
+                f"({expected_final_regime!r})"
+            )
+
+        return self

--- a/tests/schemas/__init__.py
+++ b/tests/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Schema tests."""

--- a/tests/schemas/test_alpha.py
+++ b/tests/schemas/test_alpha.py
@@ -1,0 +1,81 @@
+"""Tests for AlphaResultSnapshot."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import AlphaResultSnapshot, FormalObjectBase, single_prompt_result
+
+
+def _alpha_result() -> AlphaResultSnapshot:
+    return AlphaResultSnapshot(
+        cycle_id="cycle-20260417",
+        entity_id="ENT_001",
+        analyzer_type="single_prompt_v1",
+        score=0.82,
+        confidence=0.76,
+        rationale="Earnings revision and price action align.",
+        similar_cases=[{"entity_id": "ENT_099", "score": 0.8}],
+        status="ok",
+    )
+
+
+def test_alpha_result_happy_path_and_round_trip() -> None:
+    result = _alpha_result()
+
+    assert isinstance(result, FormalObjectBase)
+    assert AlphaResultSnapshot.from_json(result.to_json()) == result
+
+
+def test_single_prompt_result_factory_uses_p2_default_analyzer() -> None:
+    result = single_prompt_result(
+        cycle_id="cycle-20260417",
+        entity_id="ENT_001",
+        score=0.9,
+        confidence=0.8,
+        rationale="Factory output.",
+        similar_cases=[],
+    )
+
+    assert result.analyzer_type == "single_prompt_v1"
+
+
+def test_alpha_result_rejects_missing_required_field() -> None:
+    payload = _alpha_result().model_dump()
+    payload.pop("rationale")
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)
+
+
+def test_alpha_result_rejects_unknown_analyzer_type() -> None:
+    payload = _alpha_result().model_dump()
+    payload["analyzer_type"] = "gpt5_v2"
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)
+
+
+def test_alpha_result_rejects_inconclusive_with_score() -> None:
+    payload = _alpha_result().model_dump()
+    payload["status"] = "inconclusive"
+    payload["score"] = 0.5
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)
+
+
+def test_alpha_result_accepts_inconclusive_without_score() -> None:
+    result = single_prompt_result(
+        cycle_id="cycle-20260417",
+        entity_id="ENT_001",
+        score=None,
+        confidence=0.0,
+        rationale="Provider timeout.",
+        similar_cases=[],
+        status="inconclusive",
+    )
+
+    assert result.score is None
+    assert result.status == "inconclusive"

--- a/tests/schemas/test_dashboard_report.py
+++ b/tests/schemas/test_dashboard_report.py
@@ -1,0 +1,115 @@
+"""Tests for DashboardSnapshot, FormalReport, and OverrideRecord."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import (
+    DashboardSnapshot,
+    FormalObjectBase,
+    FormalReport,
+    OverrideRecord,
+)
+
+
+def _dashboard() -> DashboardSnapshot:
+    return DashboardSnapshot(
+        cycle_id="cycle-20260417",
+        world_state_ref="world-state/cycle-20260417",
+        pool_ref="pool/cycle-20260417",
+        recommendation_ref="recommendation/cycle-20260417",
+        summary_cards={"top_actions": ["ENT_001"]},
+    )
+
+
+def _report() -> FormalReport:
+    return FormalReport(
+        cycle_id="cycle-20260417",
+        report_type="daily",
+        recommendation_ref="recommendation/cycle-20260417",
+        narrative_sections={"overview": "Risk appetite improved."},
+        appendix_refs={"audit": "audit/cycle-20260417"},
+    )
+
+
+def _override() -> OverrideRecord:
+    return OverrideRecord(
+        cycle_id="cycle-20260417",
+        entity_id="ENT_001",
+        submitted_by="analyst@example.com",
+        action_type="hold",
+        rationale="Human review reduced conviction.",
+        submitted_at=datetime(2026, 4, 17, tzinfo=UTC),
+    )
+
+
+def test_dashboard_happy_path_and_round_trip() -> None:
+    dashboard = _dashboard()
+
+    assert isinstance(dashboard, FormalObjectBase)
+    assert DashboardSnapshot.from_json(dashboard.to_json()) == dashboard
+
+
+def test_dashboard_rejects_missing_required_field() -> None:
+    payload = _dashboard().model_dump()
+    payload.pop("summary_cards")
+
+    with pytest.raises(ValidationError):
+        DashboardSnapshot(**payload)
+
+
+def test_dashboard_rejects_extra_field() -> None:
+    payload = _dashboard().model_dump()
+    payload["unexpected"] = "forbidden"
+
+    with pytest.raises(ValidationError):
+        DashboardSnapshot(**payload)
+
+
+def test_formal_report_happy_path_and_round_trip() -> None:
+    report = _report()
+
+    assert isinstance(report, FormalObjectBase)
+    assert FormalReport.from_json(report.to_json()) == report
+
+
+def test_formal_report_rejects_missing_required_field() -> None:
+    payload = _report().model_dump()
+    payload.pop("narrative_sections")
+
+    with pytest.raises(ValidationError):
+        FormalReport(**payload)
+
+
+def test_formal_report_rejects_wrong_json_field_type() -> None:
+    payload = _report().model_dump()
+    payload["appendix_refs"] = []
+
+    with pytest.raises(ValidationError):
+        FormalReport(**payload)
+
+
+def test_override_record_happy_path_and_round_trip() -> None:
+    override = _override()
+
+    assert isinstance(override, FormalObjectBase)
+    assert OverrideRecord.from_json(override.to_json()) == override
+
+
+def test_override_record_rejects_missing_required_field() -> None:
+    payload = _override().model_dump()
+    payload.pop("submitted_by")
+
+    with pytest.raises(ValidationError):
+        OverrideRecord(**payload)
+
+
+def test_override_record_rejects_unknown_action_type() -> None:
+    payload = _override().model_dump()
+    payload["action_type"] = "sell"
+
+    with pytest.raises(ValidationError):
+        OverrideRecord(**payload)

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -1,0 +1,48 @@
+"""Tests for FeatureSignalBundle."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import FeatureSignalBundle, FormalObjectBase
+
+
+def _feature_bundle() -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id="cycle-20260417",
+        entity_id="ENT_001",
+        feature_values={"momentum": 1.5},
+        signal_values={"breakout": True},
+        graph_features={"centrality": 0.7},
+        feature_weight_multiplier={"momentum": 1.2},
+        generated_at=datetime(2026, 4, 17, tzinfo=UTC),
+    )
+
+
+def test_feature_bundle_happy_path_and_round_trip() -> None:
+    bundle = _feature_bundle()
+
+    assert isinstance(bundle, FormalObjectBase)
+    assert FeatureSignalBundle.from_json(bundle.to_json()) == bundle
+
+
+def test_feature_bundle_rejects_missing_required_field() -> None:
+    payload = _feature_bundle().model_dump()
+    payload.pop("feature_values")
+
+    with pytest.raises(ValidationError):
+        FeatureSignalBundle(**payload)
+
+
+@pytest.mark.parametrize("multiplier", [0.0, -0.1, float("nan")])
+def test_feature_bundle_rejects_non_positive_or_non_finite_multiplier(
+    multiplier: float,
+) -> None:
+    payload = _feature_bundle().model_dump()
+    payload["feature_weight_multiplier"] = {"momentum": multiplier}
+
+    with pytest.raises(ValidationError):
+        FeatureSignalBundle(**payload)

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -1,0 +1,70 @@
+"""Tests for OfficialAlphaPool."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import FormalObjectBase, OfficialAlphaPool
+
+DEFAULT_OFFICIAL_ALPHA_POOL_CAPACITY = 100
+
+
+def _pool() -> OfficialAlphaPool:
+    return OfficialAlphaPool(
+        cycle_id="cycle-20260417",
+        observation_pool_size=250,
+        official_alpha_pool_capacity=3,
+        selected_entities=["ENT_001", "ENT_002"],
+        added_entities=["ENT_002"],
+        removed_entities=[],
+        freeze_reason_map={"ENT_001": "existing core holding"},
+    )
+
+
+def test_pool_happy_path_default_capacity_and_round_trip() -> None:
+    pool = _pool()
+    default_capacity_pool = OfficialAlphaPool(
+        cycle_id="cycle-20260417",
+        observation_pool_size=250,
+        selected_entities=["ENT_001"],
+        added_entities=[],
+        removed_entities=[],
+        freeze_reason_map={},
+    )
+
+    assert isinstance(pool, FormalObjectBase)
+    assert (
+        default_capacity_pool.official_alpha_pool_capacity
+        == DEFAULT_OFFICIAL_ALPHA_POOL_CAPACITY
+    )
+    assert OfficialAlphaPool.from_json(pool.to_json()) == pool
+
+
+def test_pool_rejects_missing_required_field() -> None:
+    payload = _pool().model_dump()
+    payload.pop("selected_entities")
+
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(**payload)
+
+
+def test_pool_rejects_non_positive_capacity() -> None:
+    payload = _pool().model_dump()
+    payload["official_alpha_pool_capacity"] = 0
+
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(**payload)
+
+
+def test_pool_rejects_selected_entities_over_capacity() -> None:
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(
+            cycle_id="cycle-20260417",
+            observation_pool_size=101,
+            official_alpha_pool_capacity=100,
+            selected_entities=[f"ENT_{index:03d}" for index in range(101)],
+            added_entities=[],
+            removed_entities=[],
+            freeze_reason_map={},
+        )

--- a/tests/schemas/test_publish.py
+++ b/tests/schemas/test_publish.py
@@ -1,0 +1,71 @@
+"""Tests for PublishBundle and schema exports."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    DashboardSnapshot,
+    FeatureSignalBundle,
+    FormalObjectBase,
+    FormalReport,
+    OfficialAlphaPool,
+    OverrideRecord,
+    PublishBundle,
+    RecommendationSnapshot,
+    WorldStateSnapshot,
+)
+
+
+def _publish_bundle() -> PublishBundle:
+    return PublishBundle(
+        cycle_id="cycle-20260417",
+        formal_objects={"world_state": {"ref": "world-state/cycle-20260417"}},
+        manifest_candidate={"formal_table_snapshots": {"world_state": "snapshot-1"}},
+        audit_payload={"actor": "system"},
+        retrospective_seed={"cycle_id": "cycle-20260417"},
+    )
+
+
+def test_publish_bundle_happy_path_and_round_trip() -> None:
+    bundle = _publish_bundle()
+
+    assert isinstance(bundle, FormalObjectBase)
+    assert PublishBundle.from_json(bundle.to_json()) == bundle
+
+
+def test_publish_bundle_rejects_missing_required_field() -> None:
+    payload = _publish_bundle().model_dump()
+    payload.pop("manifest_candidate")
+
+    with pytest.raises(ValidationError):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_wrong_payload_type() -> None:
+    payload = _publish_bundle().model_dump()
+    payload["formal_objects"] = []
+
+    with pytest.raises(ValidationError):
+        PublishBundle(**payload)
+
+
+def test_schema_package_reexports_expected_models() -> None:
+    exported_models = (
+        FeatureSignalBundle,
+        WorldStateSnapshot,
+        OfficialAlphaPool,
+        AlphaResultSnapshot,
+        RecommendationSnapshot,
+        DashboardSnapshot,
+        FormalReport,
+        PublishBundle,
+        OverrideRecord,
+    )
+
+    assert all(issubclass(model, FormalObjectBase) for model in exported_models)
+    assert all(model.model_config["extra"] == "forbid" for model in exported_models)
+    assert all(model.model_config["frozen"] is True for model in exported_models)
+    assert all(model.model_config["strict"] is True for model in exported_models)

--- a/tests/schemas/test_recommendation.py
+++ b/tests/schemas/test_recommendation.py
@@ -1,0 +1,68 @@
+"""Tests for RecommendationSnapshot."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import FormalObjectBase, RecommendationSnapshot
+
+
+def _recommendation() -> RecommendationSnapshot:
+    return RecommendationSnapshot(
+        cycle_id="cycle-20260417",
+        entity_id="ENT_001",
+        action_type="buy",
+        rating="A",
+        confidence=0.72,
+        triggered_by="system",
+        override_applied=False,
+        constraints_applied={"regime": "risk_on"},
+    )
+
+
+def test_recommendation_happy_path_and_round_trip() -> None:
+    recommendation = _recommendation()
+
+    assert isinstance(recommendation, FormalObjectBase)
+    assert RecommendationSnapshot.from_json(recommendation.to_json()) == recommendation
+
+
+def test_recommendation_rejects_missing_required_field() -> None:
+    payload = _recommendation().model_dump()
+    payload.pop("triggered_by")
+
+    with pytest.raises(ValidationError):
+        RecommendationSnapshot(**payload)
+
+
+def test_recommendation_rejects_unknown_action_type() -> None:
+    payload = _recommendation().model_dump()
+    payload["action_type"] = "sell"
+
+    with pytest.raises(ValidationError):
+        RecommendationSnapshot(**payload)
+
+
+def test_recommendation_rejects_inconclusive_with_confidence() -> None:
+    payload = _recommendation().model_dump()
+    payload["action_type"] = "inconclusive"
+    payload["confidence"] = 0.2
+
+    with pytest.raises(ValidationError):
+        RecommendationSnapshot(**payload)
+
+
+def test_recommendation_accepts_inconclusive_without_confidence() -> None:
+    recommendation = RecommendationSnapshot(
+        cycle_id="cycle-20260417",
+        entity_id="ENT_001",
+        action_type="inconclusive",
+        rating=None,
+        confidence=None,
+        triggered_by="system",
+        override_applied=False,
+        constraints_applied={"reason": "alpha inconclusive"},
+    )
+
+    assert recommendation.confidence is None

--- a/tests/schemas/test_world_state.py
+++ b/tests/schemas/test_world_state.py
@@ -1,0 +1,62 @@
+"""Tests for WorldStateSnapshot."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import FormalObjectBase, WorldStateSnapshot
+
+
+def _world_state() -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id="cycle-20260417",
+        baseline_regime="neutral",
+        llm_delta=1,
+        final_regime="risk_on",
+        llm_rationale="Market breadth improved.",
+        actual_model_used="single-prompt-model",
+        actual_provider="reasoner-runtime",
+        fallback_path=[],
+    )
+
+
+def test_world_state_happy_path_and_round_trip() -> None:
+    snapshot = _world_state()
+
+    assert isinstance(snapshot, FormalObjectBase)
+    assert WorldStateSnapshot.from_json(snapshot.to_json()) == snapshot
+
+
+def test_world_state_rejects_missing_required_field() -> None:
+    payload = _world_state().model_dump()
+    payload.pop("actual_provider")
+
+    with pytest.raises(ValidationError):
+        WorldStateSnapshot(**payload)
+
+
+def test_world_state_rejects_llm_delta_outside_contract() -> None:
+    payload = _world_state().model_dump()
+    payload["llm_delta"] = 2
+
+    with pytest.raises(ValidationError):
+        WorldStateSnapshot(**payload)
+
+
+def test_world_state_rejects_impossible_final_regime_composition() -> None:
+    payload = _world_state().model_dump()
+    payload["final_regime"] = "risk_off"
+
+    with pytest.raises(ValidationError):
+        WorldStateSnapshot(**payload)
+
+
+def test_world_state_rejects_regime_sequence_overflow() -> None:
+    payload = _world_state().model_dump()
+    payload["baseline_regime"] = "risk_on"
+    payload["llm_delta"] = 1
+    payload["final_regime"] = "risk_on"
+
+    with pytest.raises(ValidationError):
+        WorldStateSnapshot(**payload)


### PR DESCRIPTION
Closes #3

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `unknown`


---
## 背景与目标
按项目文档 §9 与 §20.1，`main-core` OWN 的正式业务对象包括 `WorldStateSnapshot`、`OfficialAlphaPool`、`AlphaResultSnapshot`、`RecommendationSnapshot`、`DashboardSnapshot`、`FormalReport` 六类 formal object，以及 `FeatureSignalBundle` 与 `PublishBundle` 两类跨层运行时对象，加上 `OverrideRecord`。这些对象是 L1-L8 各层之间唯一的显式契约载体（§6.1 原则 3），若 schema 不先固化，后续 L3/L4/L6/L7 的实现会出现字段漂移。本 issue 只做 **Pydantic v2 model + 字段级校验 + JSON 序列化 + 单元测试**，不实现任何生成这些对象的业务逻辑。字段命名与语义严格对齐 §9.3 每张小表；其中三条硬约束必须在 validator 层就拦下：`llm_delta ∈ {-1,0,+1}`（§9 WorldStateSnapshot）、`analyzer_type ∈ {"single_prompt_v1","multi_agent_v1"}` 且 P2 阶段默认 `single_prompt_v1`（§16.3）、`official_alpha_pool.selected_entities` 长度 ≤ `official_alpha_pool_capacity`（§9 OfficialAlphaPool）。

## 所属模块
- primary writable paths：
  - `src/main_core/common/schemas/__init__.py`
  - `src/main_core/common/schemas/feature_bundle.py`
  - `src/main_core/common/schemas/world_state.py`
  - `src/main_core/common/schemas/pool.py`
  - `src/main_core/common/schemas/alpha.py`
  - `src/main_core/common/schemas/recommendation.py`
  - `src/main_core/common/schemas/dashboard.py`
  - `src/main_core/common/schemas/report.py`
  - `src/main_core/common/schemas/publish.py`
  - `src/main_core/common/schemas/override.py`
  - `tests/schemas/__init__.py`
  - `tests/schemas/test_feature_bundle.py`
  - `tests/schemas/test_world_state.py`
  - `tests/schemas/test_pool.py`
  - `tests/schemas/test_alpha.py`
  - `tests/schemas/test_recommendation.py`
  - `tests/schemas/test_dashboard_report.py`
  - `tests/schemas/test_publish.py`
- adjacent read-only paths：
  - `src/main_core/common/types.py`、`src/main_core/common/errors.py`（来自 #2）
  - `docs/main-core.project-doc.md` §9、§13、§16.3
- off-limits paths：
  - `src/main_core/l*/`（任何具体层的业务实现）
  - `src/main_core/common/schemas/protocols.py`（归 #4）
  - 任何 `data-platform` / `contracts` 外部仓库的 schema 文件（按 §4.2 归 `contracts` 模块，本模块只能引用不能重写）

## 实现范围
- **基础类型**（`common/schemas/__init__.py`）：
  - `re-export` 每个 model；提供 `class FormalObjectBase(pydantic.BaseModel)`：`m