### PR TITLE
feat(#3): 定义六类 formal object 与运行时 bundle 的 Pydantic schema

### DIFF
--- a/src/main_core/common/schemas/__init__.py
+++ b/src/main_core/common/schemas/__init__.py
@@ -1,13 +1,23 @@
 """Pydantic schema objects shared across main-core layers."""
 
-from main_core.common.schemas.alpha import AlphaResultSnapshot, AlphaStatus, AnalyzerType
+from main_core.common.schemas.alpha import (
+    AlphaResultSnapshot,
+    AlphaStatus,
+    AnalyzerType,
+    single_prompt_result,
+)
 from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.schemas.dashboard import DashboardSnapshot
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.schemas.override import OverrideRecord
+from main_core.common.schemas.pool import OfficialAlphaPool
+from main_core.common.schemas.publish import PublishBundle
 from main_core.common.schemas.recommendation import (
     ActionType,
     RecommendationSnapshot,
     TriggerSource,
 )
+from main_core.common.schemas.report import FormalReport
 from main_core.common.schemas.world_state import WorldStateSnapshot
 
 __all__ = [
@@ -15,9 +25,15 @@ __all__ = [
     "AlphaResultSnapshot",
     "AlphaStatus",
     "AnalyzerType",
+    "DashboardSnapshot",
     "FeatureSignalBundle",
     "FormalObjectBase",
+    "FormalReport",
+    "OfficialAlphaPool",
+    "OverrideRecord",
+    "PublishBundle",
     "RecommendationSnapshot",
     "TriggerSource",
     "WorldStateSnapshot",
+    "single_prompt_result",
 ]

--- a/src/main_core/common/schemas/alpha.py
+++ b/src/main_core/common/schemas/alpha.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from pydantic import model_validator
+
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId, EntityId
 
@@ -23,5 +25,19 @@ class AlphaResultSnapshot(FormalObjectBase):
     similar_cases: list[dict[str, Any]]
     status: AlphaStatus
 
+    @model_validator(mode="after")
+    def validate_inconclusive_score(self) -> AlphaResultSnapshot:
+        """Inconclusive analysis must not carry a usable score."""
 
-__all__ = ["AlphaResultSnapshot", "AlphaStatus", "AnalyzerType"]
+        if self.status == "inconclusive" and self.score is not None:
+            raise ValueError("inconclusive alpha results must have score=None")
+        return self
+
+
+def single_prompt_result(**fields: Any) -> AlphaResultSnapshot:
+    """Build a P2 single-prompt alpha result."""
+
+    return AlphaResultSnapshot(**{**fields, "analyzer_type": "single_prompt_v1"})
+
+
+__all__ = ["AlphaResultSnapshot", "AlphaStatus", "AnalyzerType", "single_prompt_result"]

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
+from copy import deepcopy
 from types import MappingProxyType
 from typing import Any, Self
 
@@ -80,6 +81,21 @@ class FormalObjectBase(BaseModel):
             field_name: _thaw_value(getattr(self, field_name))
             for field_name in type(self).model_fields
         }
+
+    def model_copy(
+        self,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Self:
+        """Copy through full validation so update values cannot bypass invariants."""
+
+        payload = self.model_dump(mode="python")
+        if update:
+            payload.update(update)
+        if deep:
+            payload = deepcopy(payload)
+        return type(self).model_validate(payload)
 
     def to_json(self) -> str:
         """Serialize the object using Pydantic's JSON representation."""

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict
 class FormalObjectBase(BaseModel):
     """Frozen schema base for formal and runtime contract objects."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
     def to_json(self) -> str:
         """Serialize the object using Pydantic's JSON representation."""

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -2,15 +2,84 @@
 
 from __future__ import annotations
 
-from typing import Self
+from collections.abc import Iterator, Mapping
+from types import MappingProxyType
+from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_serializer, model_validator
+
+
+class FrozenDict(Mapping[Any, Any]):
+    """Immutable mapping used to deep-freeze validated schema payloads."""
+
+    def __init__(self, items: Mapping[Any, Any] | list[tuple[Any, Any]]) -> None:
+        self._data = MappingProxyType(dict(items))
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Mapping):
+            return dict(self.items()) == dict(other.items())
+        return False
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({dict(self._data)!r})"
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self._data.items()))
+
+
+def _freeze_value(value: Any) -> Any:
+    frozen_value = value
+    if isinstance(value, FrozenDict):
+        frozen_value = value
+    elif isinstance(value, Mapping):
+        frozen_value = FrozenDict([(key, _freeze_value(item)) for key, item in value.items()])
+    elif isinstance(value, (list, tuple)):
+        frozen_value = tuple(_freeze_value(item) for item in value)
+    elif isinstance(value, (frozenset, set)):
+        frozen_value = frozenset(_freeze_value(item) for item in value)
+    return frozen_value
+
+
+def _thaw_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_value(item) for item in value]
+    if isinstance(value, frozenset):
+        return [_thaw_value(item) for item in value]
+    return value
 
 
 class FormalObjectBase(BaseModel):
     """Frozen schema base for formal and runtime contract objects."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    @model_validator(mode="after")
+    def freeze_nested_containers(self) -> Self:
+        """Recursively freeze validated container fields before sharing objects."""
+
+        for field_name in type(self).model_fields:
+            object.__setattr__(self, field_name, _freeze_value(getattr(self, field_name)))
+        return self
+
+    @model_serializer(mode="plain")
+    def serialize_frozen_containers(self) -> dict[str, Any]:
+        """Serialize immutable containers as ordinary JSON-compatible containers."""
+
+        return {
+            field_name: _thaw_value(getattr(self, field_name))
+            for field_name in type(self).model_fields
+        }
 
     def to_json(self) -> str:
         """Serialize the object using Pydantic's JSON representation."""

--- a/src/main_core/common/schemas/dashboard.py
+++ b/src/main_core/common/schemas/dashboard.py
@@ -1,0 +1,21 @@
+"""L8 formal dashboard snapshot schema."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId
+
+
+class DashboardSnapshot(FormalObjectBase):
+    """Formal L8 dashboard snapshot described in §9.3."""
+
+    cycle_id: CycleId
+    world_state_ref: str
+    pool_ref: str
+    recommendation_ref: str
+    summary_cards: dict[str, Any]
+
+
+__all__ = ["DashboardSnapshot"]

--- a/src/main_core/common/schemas/feature_bundle.py
+++ b/src/main_core/common/schemas/feature_bundle.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from math import isfinite
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId, EntityId
@@ -25,6 +26,20 @@ class FeatureSignalBundle(FormalObjectBase):
     graph_features: dict[str, Any]
     feature_weight_multiplier: dict[str, float]
     generated_at: datetime = Field(default_factory=_utc_now)
+
+    @field_validator("feature_weight_multiplier")
+    @classmethod
+    def validate_feature_weight_multiplier(cls, value: dict[str, float]) -> dict[str, float]:
+        """Require auditable positive finite feature multipliers."""
+
+        invalid_keys = [
+            feature_name
+            for feature_name, multiplier in value.items()
+            if not isfinite(multiplier) or multiplier <= 0
+        ]
+        if invalid_keys:
+            raise ValueError("feature_weight_multiplier values must be finite and > 0")
+        return value
 
 
 __all__ = ["FeatureSignalBundle"]

--- a/src/main_core/common/schemas/override.py
+++ b/src/main_core/common/schemas/override.py
@@ -1,0 +1,23 @@
+"""Override business record schema."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.schemas.recommendation import ActionType
+from main_core.common.types import CycleId, EntityId
+
+
+class OverrideRecord(FormalObjectBase):
+    """Human override record for L7 recommendation decisions."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    submitted_by: str
+    action_type: ActionType
+    rationale: str
+    submitted_at: datetime
+
+
+__all__ = ["OverrideRecord"]

--- a/src/main_core/common/schemas/pool.py
+++ b/src/main_core/common/schemas/pool.py
@@ -1,0 +1,31 @@
+"""L5 formal official alpha pool schema."""
+
+from __future__ import annotations
+
+from pydantic import Field, model_validator
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId, EntityId
+
+
+class OfficialAlphaPool(FormalObjectBase):
+    """Formal L5 official alpha pool described in §9.3."""
+
+    cycle_id: CycleId
+    observation_pool_size: int
+    official_alpha_pool_capacity: int = Field(default=100, ge=1, le=100)
+    selected_entities: list[EntityId]
+    added_entities: list[EntityId]
+    removed_entities: list[EntityId]
+    freeze_reason_map: dict[EntityId, str]
+
+    @model_validator(mode="after")
+    def validate_selected_entities_capacity(self) -> OfficialAlphaPool:
+        """Require selected_entities to fit within the official pool capacity."""
+
+        if len(self.selected_entities) > self.official_alpha_pool_capacity:
+            raise ValueError("selected_entities length must be <= official_alpha_pool_capacity")
+        return self
+
+
+__all__ = ["OfficialAlphaPool"]

--- a/src/main_core/common/schemas/publish.py
+++ b/src/main_core/common/schemas/publish.py
@@ -1,0 +1,21 @@
+"""L8 runtime publish bundle schema."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId
+
+
+class PublishBundle(FormalObjectBase):
+    """Runtime Phase 3 publish bundle described in §9.3."""
+
+    cycle_id: CycleId
+    formal_objects: dict[str, Any]
+    manifest_candidate: dict[str, Any]
+    audit_payload: dict[str, Any]
+    retrospective_seed: dict[str, Any]
+
+
+__all__ = ["PublishBundle"]

--- a/src/main_core/common/schemas/recommendation.py
+++ b/src/main_core/common/schemas/recommendation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from pydantic import model_validator
+
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId, EntityId
 
@@ -22,6 +24,14 @@ class RecommendationSnapshot(FormalObjectBase):
     triggered_by: TriggerSource
     override_applied: bool
     constraints_applied: dict[str, Any]
+
+    @model_validator(mode="after")
+    def validate_inconclusive_confidence(self) -> RecommendationSnapshot:
+        """Inconclusive recommendations must not carry confidence."""
+
+        if self.action_type == "inconclusive" and self.confidence is not None:
+            raise ValueError("inconclusive recommendations must have confidence=None")
+        return self
 
 
 __all__ = ["ActionType", "RecommendationSnapshot", "TriggerSource"]

--- a/src/main_core/common/schemas/report.py
+++ b/src/main_core/common/schemas/report.py
@@ -1,0 +1,21 @@
+"""L8 formal report schema."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.schemas.base import FormalObjectBase
+from main_core.common.types import CycleId
+
+
+class FormalReport(FormalObjectBase):
+    """Formal L8 human-facing report described in §9.3."""
+
+    cycle_id: CycleId
+    report_type: str
+    recommendation_ref: str
+    narrative_sections: dict[str, Any]
+    appendix_refs: dict[str, Any]
+
+
+__all__ = ["FormalReport"]

--- a/src/main_core/common/schemas/world_state.py
+++ b/src/main_core/common/schemas/world_state.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from typing import Literal
 
+from pydantic import model_validator
+
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId, Regime
+
+REGIME_SEQUENCE: tuple[Regime, ...] = ("risk_off", "neutral", "risk_on")
 
 
 class WorldStateSnapshot(FormalObjectBase):
@@ -20,5 +24,20 @@ class WorldStateSnapshot(FormalObjectBase):
     actual_provider: str
     fallback_path: list[str]
 
+    @model_validator(mode="after")
+    def validate_final_regime(self) -> WorldStateSnapshot:
+        """Require final_regime to match baseline_regime shifted by llm_delta."""
 
-__all__ = ["WorldStateSnapshot"]
+        baseline_index = REGIME_SEQUENCE.index(self.baseline_regime)
+        final_index = baseline_index + self.llm_delta
+        if final_index < 0 or final_index >= len(REGIME_SEQUENCE):
+            raise ValueError("baseline_regime + llm_delta is outside the regime sequence")
+
+        expected_final_regime = REGIME_SEQUENCE[final_index]
+        if self.final_regime != expected_final_regime:
+            raise ValueError("final_regime must equal baseline_regime shifted by llm_delta")
+
+        return self
+
+
+__all__ = ["REGIME_SEQUENCE", "WorldStateSnapshot"]

--- a/tests/schemas/__init__.py
+++ b/tests/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Schema tests for main-core contract models."""

--- a/tests/schemas/test_alpha.py
+++ b/tests/schemas/test_alpha.py
@@ -1,0 +1,61 @@
+"""Tests for the L6 alpha result snapshot schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
+
+
+def _alpha_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "entity_id": "ENT_001",
+        "analyzer_type": "single_prompt_v1",
+        "score": 0.72,
+        "confidence": 0.81,
+        "rationale": "quality and momentum are aligned",
+        "similar_cases": [{"entity_id": "ENT_009", "score": 0.69}],
+        "status": "ok",
+    }
+
+
+def test_alpha_result_happy_path_round_trips_json() -> None:
+    result = AlphaResultSnapshot(**_alpha_payload())
+
+    assert AlphaResultSnapshot.from_json(result.to_json()) == result
+
+
+def test_single_prompt_result_factory_sets_p2_default_analyzer_type() -> None:
+    payload = _alpha_payload()
+    payload.pop("analyzer_type")
+
+    result = single_prompt_result(**payload)
+
+    assert result.analyzer_type == "single_prompt_v1"
+
+
+def test_alpha_result_missing_field_fails() -> None:
+    payload = _alpha_payload()
+    payload.pop("entity_id")
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)
+
+
+def test_alpha_result_rejects_unknown_analyzer_type() -> None:
+    payload = _alpha_payload()
+    payload["analyzer_type"] = "gpt5_v2"
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)
+
+
+def test_alpha_result_rejects_inconclusive_with_score() -> None:
+    payload = _alpha_payload()
+    payload["status"] = "inconclusive"
+    payload["score"] = 0.5
+
+    with pytest.raises(ValidationError, match="score=None"):
+        AlphaResultSnapshot(**payload)

--- a/tests/schemas/test_dashboard_report.py
+++ b/tests/schemas/test_dashboard_report.py
@@ -1,0 +1,72 @@
+"""Tests for L8 dashboard and formal report schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import DashboardSnapshot, FormalReport
+
+
+def _dashboard_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "world_state_ref": "world_state_snapshot/cycle_001",
+        "pool_ref": "official_alpha_pool/cycle_001",
+        "recommendation_ref": "recommendation_snapshot/cycle_001",
+        "summary_cards": {"top_action": "buy"},
+    }
+
+
+def _report_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "report_type": "daily",
+        "recommendation_ref": "recommendation_snapshot/cycle_001",
+        "narrative_sections": {"overview": "Market risk appetite improved."},
+        "appendix_refs": {"audit": "audit/cycle_001"},
+    }
+
+
+def test_dashboard_happy_path_round_trips_json() -> None:
+    dashboard = DashboardSnapshot(**_dashboard_payload())
+
+    assert DashboardSnapshot.from_json(dashboard.to_json()) == dashboard
+
+
+def test_dashboard_missing_field_fails() -> None:
+    payload = _dashboard_payload()
+    payload.pop("pool_ref")
+
+    with pytest.raises(ValidationError):
+        DashboardSnapshot(**payload)
+
+
+def test_dashboard_rejects_wrong_summary_cards_type() -> None:
+    payload = _dashboard_payload()
+    payload["summary_cards"] = []
+
+    with pytest.raises(ValidationError):
+        DashboardSnapshot(**payload)
+
+
+def test_formal_report_happy_path_round_trips_json() -> None:
+    report = FormalReport(**_report_payload())
+
+    assert FormalReport.from_json(report.to_json()) == report
+
+
+def test_formal_report_missing_field_fails() -> None:
+    payload = _report_payload()
+    payload.pop("report_type")
+
+    with pytest.raises(ValidationError):
+        FormalReport(**payload)
+
+
+def test_formal_report_rejects_wrong_narrative_sections_type() -> None:
+    payload = _report_payload()
+    payload["narrative_sections"] = []
+
+    with pytest.raises(ValidationError):
+        FormalReport(**payload)

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -33,6 +35,14 @@ def _bundle_payload() -> dict[str, object]:
     }
 
 
+def _append_late_mutation(value: Any) -> None:
+    value.append("late mutation")
+
+
+def _set_late_mutation(value: Any) -> None:
+    value["late"] = "mutation"
+
+
 def test_feature_signal_bundle_happy_path_round_trips_json() -> None:
     bundle = FeatureSignalBundle(**_bundle_payload())
 
@@ -59,6 +69,132 @@ def test_feature_signal_bundle_rejects_non_positive_or_non_finite_multiplier(
 
     with pytest.raises(ValidationError, match="finite and > 0"):
         FeatureSignalBundle(**payload)
+
+
+def test_feature_signal_bundle_deep_freezes_nested_payload_containers() -> None:
+    payload = _bundle_payload()
+    payload["signal_values"] = {"history": ["initial"]}
+    payload["graph_features"] = {"node": {"centrality": 0.5}}
+    bundle = FeatureSignalBundle(**payload)
+    before_json = bundle.to_json()
+
+    with pytest.raises(AttributeError):
+        bundle.signal_values["history"].append("late mutation")
+    with pytest.raises(TypeError):
+        bundle.graph_features["node"]["centrality"] = 0.9
+
+    assert bundle.to_json() == before_json
+
+
+@pytest.mark.parametrize(
+    ("instance", "field_name", "mutate"),
+    [
+        (
+            FeatureSignalBundle(**_bundle_payload()),
+            "feature_values",
+            _set_late_mutation,
+        ),
+        (
+            WorldStateSnapshot(
+                cycle_id="cycle_001",
+                baseline_regime="neutral",
+                llm_delta=0,
+                final_regime="neutral",
+                llm_rationale="baseline unchanged",
+                actual_model_used="reasoner-stub",
+                actual_provider="local",
+                fallback_path=["baseline"],
+            ),
+            "fallback_path",
+            _append_late_mutation,
+        ),
+        (
+            OfficialAlphaPool(
+                cycle_id="cycle_001",
+                observation_pool_size=1,
+                official_alpha_pool_capacity=1,
+                selected_entities=["ENT_001"],
+                added_entities=[],
+                removed_entities=[],
+                freeze_reason_map={},
+            ),
+            "selected_entities",
+            _append_late_mutation,
+        ),
+        (
+            AlphaResultSnapshot(
+                cycle_id="cycle_001",
+                entity_id="ENT_001",
+                analyzer_type="single_prompt_v1",
+                score=0.72,
+                confidence=0.81,
+                rationale="quality and momentum are aligned",
+                similar_cases=[{"entity_id": "ENT_009", "score": 0.69}],
+                status="ok",
+            ),
+            "similar_cases",
+            _append_late_mutation,
+        ),
+        (
+            RecommendationSnapshot(
+                cycle_id="cycle_001",
+                entity_id="ENT_001",
+                action_type="buy",
+                rating="A",
+                confidence=0.77,
+                triggered_by="system",
+                override_applied=False,
+                constraints_applied={"regime": "risk_on"},
+            ),
+            "constraints_applied",
+            _set_late_mutation,
+        ),
+        (
+            DashboardSnapshot(
+                cycle_id="cycle_001",
+                world_state_ref="world_state_snapshot/cycle_001",
+                pool_ref="official_alpha_pool/cycle_001",
+                recommendation_ref="recommendation_snapshot/cycle_001",
+                summary_cards={"top_action": "buy"},
+            ),
+            "summary_cards",
+            _set_late_mutation,
+        ),
+        (
+            FormalReport(
+                cycle_id="cycle_001",
+                report_type="daily",
+                recommendation_ref="recommendation_snapshot/cycle_001",
+                narrative_sections={"overview": "Market risk appetite improved."},
+                appendix_refs={"audit": "audit/cycle_001"},
+            ),
+            "narrative_sections",
+            _set_late_mutation,
+        ),
+        (
+            PublishBundle(
+                cycle_id="cycle_001",
+                formal_objects={"world_state": {"ref": "world_state_snapshot/cycle_001"}},
+                manifest_candidate={"snapshot_id": "snap_001"},
+                audit_payload={"actor": "system"},
+                retrospective_seed={"window": "1d"},
+            ),
+            "formal_objects",
+            _set_late_mutation,
+        ),
+    ],
+)
+def test_schema_container_fields_are_immutable_after_validation(
+    instance: FormalObjectBase,
+    field_name: str,
+    mutate: Callable[[Any], None],
+) -> None:
+    before_json = instance.to_json()
+
+    with pytest.raises((AttributeError, TypeError)):
+        mutate(getattr(instance, field_name))
+
+    assert instance.to_json() == before_json
 
 
 def test_all_schema_models_inherit_frozen_forbid_strict_base() -> None:

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -1,0 +1,81 @@
+"""Tests for the L3 feature signal bundle schema."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    DashboardSnapshot,
+    FeatureSignalBundle,
+    FormalObjectBase,
+    FormalReport,
+    OfficialAlphaPool,
+    OverrideRecord,
+    PublishBundle,
+    RecommendationSnapshot,
+    WorldStateSnapshot,
+)
+
+
+def _bundle_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "entity_id": "ENT_001",
+        "feature_values": {"momentum": 0.42},
+        "signal_values": {"direction": "positive"},
+        "graph_features": {"centrality": 0.5},
+        "feature_weight_multiplier": {"momentum": 1.2},
+        "generated_at": datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+    }
+
+
+def test_feature_signal_bundle_happy_path_round_trips_json() -> None:
+    bundle = FeatureSignalBundle(**_bundle_payload())
+
+    assert FeatureSignalBundle.from_json(bundle.to_json()) == bundle
+
+
+def test_feature_signal_bundle_missing_field_fails() -> None:
+    payload = _bundle_payload()
+    payload.pop("entity_id")
+
+    with pytest.raises(ValidationError):
+        FeatureSignalBundle(**payload)
+
+
+@pytest.mark.parametrize(
+    "multiplier",
+    [0.0, -0.1, float("inf")],
+)
+def test_feature_signal_bundle_rejects_non_positive_or_non_finite_multiplier(
+    multiplier: float,
+) -> None:
+    payload = _bundle_payload()
+    payload["feature_weight_multiplier"] = {"momentum": multiplier}
+
+    with pytest.raises(ValidationError, match="finite and > 0"):
+        FeatureSignalBundle(**payload)
+
+
+def test_all_schema_models_inherit_frozen_forbid_strict_base() -> None:
+    models = (
+        FeatureSignalBundle,
+        WorldStateSnapshot,
+        OfficialAlphaPool,
+        AlphaResultSnapshot,
+        RecommendationSnapshot,
+        DashboardSnapshot,
+        FormalReport,
+        PublishBundle,
+        OverrideRecord,
+    )
+
+    for model in models:
+        assert issubclass(model, FormalObjectBase)
+        assert model.model_config["frozen"] is True
+        assert model.model_config["extra"] == "forbid"
+        assert model.model_config["strict"] is True

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -1,0 +1,54 @@
+"""Tests for the L5 official alpha pool schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import OfficialAlphaPool
+
+
+def _pool_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "observation_pool_size": 12,
+        "official_alpha_pool_capacity": 2,
+        "selected_entities": ["ENT_001", "ENT_002"],
+        "added_entities": ["ENT_002"],
+        "removed_entities": [],
+        "freeze_reason_map": {"ENT_001": "existing core holding"},
+    }
+
+
+def test_official_alpha_pool_happy_path_round_trips_json() -> None:
+    pool = OfficialAlphaPool(**_pool_payload())
+
+    assert OfficialAlphaPool.from_json(pool.to_json()) == pool
+
+
+def test_official_alpha_pool_missing_field_fails() -> None:
+    payload = _pool_payload()
+    payload.pop("selected_entities")
+
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(**payload)
+
+
+def test_official_alpha_pool_rejects_selected_entities_over_capacity() -> None:
+    payload = _pool_payload()
+    payload["official_alpha_pool_capacity"] = 1
+
+    with pytest.raises(ValidationError, match="selected_entities length"):
+        OfficialAlphaPool(**payload)
+
+
+@pytest.mark.parametrize(
+    "capacity",
+    [0, 101],
+)
+def test_official_alpha_pool_rejects_capacity_outside_hard_bounds(capacity: int) -> None:
+    payload = _pool_payload()
+    payload["official_alpha_pool_capacity"] = capacity
+
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(**payload)

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -66,6 +66,38 @@ def test_official_alpha_pool_freeze_reason_map_is_immutable() -> None:
     assert pool.to_json() == before_json
 
 
+def test_official_alpha_pool_model_copy_revalidates_capacity_updates() -> None:
+    payload = _pool_payload()
+    payload["official_alpha_pool_capacity"] = 1
+    payload["selected_entities"] = ["ENT_001"]
+    pool = OfficialAlphaPool(**payload)
+
+    with pytest.raises(ValidationError, match="selected_entities length"):
+        pool.model_copy(update={"selected_entities": ["ENT_001", "ENT_002"]})
+
+
+def test_official_alpha_pool_model_copy_freezes_valid_update_values() -> None:
+    payload = _pool_payload()
+    payload["official_alpha_pool_capacity"] = 2
+    payload["selected_entities"] = ["ENT_001"]
+    pool = OfficialAlphaPool(**payload)
+
+    copied = pool.model_copy(
+        update={
+            "selected_entities": ["ENT_001", "ENT_002"],
+            "freeze_reason_map": {"ENT_002": "new frozen entity"},
+        }
+    )
+    before_json = copied.to_json()
+
+    with pytest.raises(AttributeError):
+        copied.selected_entities.append("ENT_003")
+    with pytest.raises(TypeError):
+        copied.freeze_reason_map["ENT_003"] = "late mutation"
+
+    assert copied.to_json() == before_json
+
+
 @pytest.mark.parametrize(
     "capacity",
     [0, 101],

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -42,6 +42,30 @@ def test_official_alpha_pool_rejects_selected_entities_over_capacity() -> None:
         OfficialAlphaPool(**payload)
 
 
+def test_official_alpha_pool_selected_entities_cannot_mutate_past_capacity() -> None:
+    payload = _pool_payload()
+    payload["official_alpha_pool_capacity"] = 1
+    payload["selected_entities"] = ["ENT_001"]
+    pool = OfficialAlphaPool(**payload)
+    before_json = pool.to_json()
+
+    with pytest.raises(AttributeError):
+        pool.selected_entities.append("ENT_002")
+
+    assert len(pool.selected_entities) == 1
+    assert pool.to_json() == before_json
+
+
+def test_official_alpha_pool_freeze_reason_map_is_immutable() -> None:
+    pool = OfficialAlphaPool(**_pool_payload())
+    before_json = pool.to_json()
+
+    with pytest.raises(TypeError):
+        pool.freeze_reason_map["ENT_002"] = "late mutation"
+
+    assert pool.to_json() == before_json
+
+
 @pytest.mark.parametrize(
     "capacity",
     [0, 101],

--- a/tests/schemas/test_publish.py
+++ b/tests/schemas/test_publish.py
@@ -1,0 +1,75 @@
+"""Tests for publish bundle and override record schemas."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import OverrideRecord, PublishBundle
+
+
+def _publish_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "formal_objects": {"world_state": {"ref": "world_state_snapshot/cycle_001"}},
+        "manifest_candidate": {"snapshot_id": "snap_001"},
+        "audit_payload": {"actor": "system"},
+        "retrospective_seed": {"window": "1d"},
+    }
+
+
+def _override_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "entity_id": "ENT_001",
+        "submitted_by": "analyst_001",
+        "action_type": "hold",
+        "rationale": "manual risk review",
+        "submitted_at": datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+    }
+
+
+def test_publish_bundle_happy_path_round_trips_json() -> None:
+    bundle = PublishBundle(**_publish_payload())
+
+    assert PublishBundle.from_json(bundle.to_json()) == bundle
+
+
+def test_publish_bundle_missing_field_fails() -> None:
+    payload = _publish_payload()
+    payload.pop("audit_payload")
+
+    with pytest.raises(ValidationError):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_wrong_formal_objects_type() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = []
+
+    with pytest.raises(ValidationError):
+        PublishBundle(**payload)
+
+
+def test_override_record_happy_path_round_trips_json() -> None:
+    override = OverrideRecord(**_override_payload())
+
+    assert OverrideRecord.from_json(override.to_json()) == override
+
+
+def test_override_record_missing_field_fails() -> None:
+    payload = _override_payload()
+    payload.pop("submitted_at")
+
+    with pytest.raises(ValidationError):
+        OverrideRecord(**payload)
+
+
+def test_override_record_rejects_unknown_action_type() -> None:
+    payload = _override_payload()
+    payload["action_type"] = "skip"
+
+    with pytest.raises(ValidationError):
+        OverrideRecord(**payload)

--- a/tests/schemas/test_recommendation.py
+++ b/tests/schemas/test_recommendation.py
@@ -1,0 +1,52 @@
+"""Tests for the L7 recommendation snapshot schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import RecommendationSnapshot
+
+
+def _recommendation_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "entity_id": "ENT_001",
+        "action_type": "buy",
+        "rating": "A",
+        "confidence": 0.77,
+        "triggered_by": "system",
+        "override_applied": False,
+        "constraints_applied": {"regime": "risk_on"},
+    }
+
+
+def test_recommendation_happy_path_round_trips_json() -> None:
+    recommendation = RecommendationSnapshot(**_recommendation_payload())
+
+    assert RecommendationSnapshot.from_json(recommendation.to_json()) == recommendation
+
+
+def test_recommendation_missing_field_fails() -> None:
+    payload = _recommendation_payload()
+    payload.pop("triggered_by")
+
+    with pytest.raises(ValidationError):
+        RecommendationSnapshot(**payload)
+
+
+def test_recommendation_rejects_unknown_action_type() -> None:
+    payload = _recommendation_payload()
+    payload["action_type"] = "sell"
+
+    with pytest.raises(ValidationError):
+        RecommendationSnapshot(**payload)
+
+
+def test_recommendation_rejects_inconclusive_with_confidence() -> None:
+    payload = _recommendation_payload()
+    payload["action_type"] = "inconclusive"
+    payload["confidence"] = 0.5
+
+    with pytest.raises(ValidationError, match="confidence=None"):
+        RecommendationSnapshot(**payload)

--- a/tests/schemas/test_world_state.py
+++ b/tests/schemas/test_world_state.py
@@ -1,0 +1,61 @@
+"""Tests for the L4 world state snapshot schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.schemas import WorldStateSnapshot
+
+
+def _world_state_payload() -> dict[str, object]:
+    return {
+        "cycle_id": "cycle_001",
+        "baseline_regime": "neutral",
+        "llm_delta": 1,
+        "final_regime": "risk_on",
+        "llm_rationale": "risk appetite improved",
+        "actual_model_used": "reasoner-stub",
+        "actual_provider": "local",
+        "fallback_path": [],
+    }
+
+
+def test_world_state_happy_path_round_trips_json() -> None:
+    snapshot = WorldStateSnapshot(**_world_state_payload())
+
+    assert WorldStateSnapshot.from_json(snapshot.to_json()) == snapshot
+
+
+def test_world_state_missing_field_fails() -> None:
+    payload = _world_state_payload()
+    payload.pop("fallback_path")
+
+    with pytest.raises(ValidationError):
+        WorldStateSnapshot(**payload)
+
+
+def test_world_state_rejects_llm_delta_outside_allowed_literal() -> None:
+    payload = _world_state_payload()
+    payload["llm_delta"] = 2
+
+    with pytest.raises(ValidationError):
+        WorldStateSnapshot(**payload)
+
+
+def test_world_state_rejects_final_regime_mismatch() -> None:
+    payload = _world_state_payload()
+    payload["final_regime"] = "neutral"
+
+    with pytest.raises(ValidationError, match="final_regime"):
+        WorldStateSnapshot(**payload)
+
+
+def test_world_state_rejects_regime_sequence_overflow() -> None:
+    payload = _world_state_payload()
+    payload["baseline_regime"] = "risk_on"
+    payload["llm_delta"] = 1
+    payload["final_regime"] = "risk_on"
+
+    with pytest.raises(ValidationError, match="outside the regime sequence"):
+        WorldStateSnapshot(**payload)


### PR DESCRIPTION
Closes #3

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/main_core/common/schemas/pool.py`, `unknown`


---
## 背景与目标
按项目文档 §9 与 §20.1，`main-core` OWN 的正式业务对象包括 `WorldStateSnapshot`、`OfficialAlphaPool`、`AlphaResultSnapshot`、`RecommendationSnapshot`、`DashboardSnapshot`、`FormalReport` 六类 formal object，以及 `FeatureSignalBundle` 与 `PublishBundle` 两类跨层运行时对象，加上 `OverrideRecord`。这些对象是 L1-L8 各层之间唯一的显式契约载体（§6.1 原则 3），若 schema 不先固化，后续 L3/L4/L6/L7 的实现会出现字段漂移。本 issue 只做 **Pydantic v2 model + 字段级校验 + JSON 序列化 + 单元测试**，不实现任何生成这些对象的业务逻辑。字段命名与语义严格对齐 §9.3 每张小表；其中三条硬约束必须在 validator 层就拦下：`llm_delta ∈ {-1,0,+1}`（§9 WorldStateSnapshot）、`analyzer_type ∈ {"single_prompt_v1","multi_agent_v1"}` 且 P2 阶段默认 `single_prompt_v1`（§16.3）、`official_alpha_pool.selected_entities` 长度 ≤ `official_alpha_pool_capacity`（§9 OfficialAlphaPool）。

## 所属模块
- primary writable paths：
  - `src/main_core/common/schemas/__init__.py`
  - `src/main_core/common/schemas/feature_bundle.py`
  - `src/main_core/common/schemas/world_state.py`
  - `src/main_core/common/schemas/pool.py`
  - `src/main_core/common/schemas/alpha.py`
  - `src/main_core/common/schemas/recommendation.py`
  - `src/main_core/common/schemas/dashboard.py`
  - `src/main_core/common/schemas/report.py`
  - `src/main_core/common/schemas/publish.py`
  - `src/main_core/common/schemas/override.py`
  - `tests/schemas/__init__.py`
  - `tests/schemas/test_feature_bundle.py`
  - `tests/schemas/test_world_state.py`
  - `tests/schemas/test_pool.py`
  - `tests/schemas/test_alpha.py`
  - `tests/schemas/test_recommendation.py`
  - `tests/schemas/test_dashboard_report.py`
  - `tests/schemas/test_publish.py`
- adjacent read-only paths：
  - `src/main_core/common/types.py`、`src/main_core/common/errors.py`（来自 #2）
  - `docs/main-core.project-doc.md` §9、§13、§16.3
- off-limits paths：
  - `src/main_core/l*/`（任何具体层的业务实现）
  - `src/main_core/common/schemas/protocols.py`（归 #4）
  - 任何 `data-platform` / `contracts` 外部仓库的 schema 文件（按 §4.2 归 `contracts` 模块，本模块只能引用不能重写）

## 实现范围
- **基础类型**（`common/schemas/__init__.py`）：
  - `re-export` 每个 model；提供 `class FormalObjectBase(pydantic.BaseModel)`：`m