### PR TITLE
feat(#21): [milestone-0 review] P0: Common schema package weakens layer boundaries

### DIFF
--- a/src/main_core/common/schemas/__init__.py
+++ b/src/main_core/common/schemas/__init__.py
@@ -1,5 +1,8 @@
 """Pydantic schema objects shared across main-core layers."""
 
+from types import MappingProxyType
+from typing import Final
+
 from main_core.common.schemas.alpha import (
     AlphaResultSnapshot,
     AlphaStatus,
@@ -20,6 +23,70 @@ from main_core.common.schemas.recommendation import (
 from main_core.common.schemas.report import FormalReport
 from main_core.common.schemas.world_state import WorldStateSnapshot
 
+SCHEMA_COMMON_EXPORTS: Final = frozenset({"FormalObjectBase"})
+SCHEMA_COMMON_MODULES: Final = frozenset({"base"})
+
+_SCHEMA_LAYER_SEQUENCE: Final = (
+    "l1_l2_basis",
+    "l3_features",
+    "l4_world_state",
+    "l5_universe",
+    "l6_alpha",
+    "l7_recommendation",
+    "l8_publish",
+)
+_SCHEMA_LAYER_ORDER: Final = {
+    layer_name: layer_index
+    for layer_index, layer_name in enumerate(_SCHEMA_LAYER_SEQUENCE)
+}
+
+SCHEMA_CONTRACT_LAYER: Final = MappingProxyType(
+    {
+        "FeatureSignalBundle": "l3_features",
+        "WorldStateSnapshot": "l4_world_state",
+        "OfficialAlphaPool": "l5_universe",
+        "AlphaResultSnapshot": "l6_alpha",
+        "AlphaStatus": "l6_alpha",
+        "AnalyzerType": "l6_alpha",
+        "single_prompt_result": "l6_alpha",
+        "ActionType": "l7_recommendation",
+        "OverrideRecord": "l7_recommendation",
+        "RecommendationSnapshot": "l7_recommendation",
+        "TriggerSource": "l7_recommendation",
+        "DashboardSnapshot": "l8_publish",
+        "FormalReport": "l8_publish",
+        "PublishBundle": "l8_publish",
+    }
+)
+
+SCHEMA_MODULE_LAYER: Final = MappingProxyType(
+    {
+        "alpha": "l6_alpha",
+        "dashboard": "l8_publish",
+        "feature_bundle": "l3_features",
+        "override": "l7_recommendation",
+        "pool": "l5_universe",
+        "publish": "l8_publish",
+        "recommendation": "l7_recommendation",
+        "report": "l8_publish",
+        "world_state": "l4_world_state",
+    }
+)
+
+LAYER_SCHEMA_IMPORT_POLICY: Final = MappingProxyType(
+    {
+        consumer_layer: frozenset(
+            SCHEMA_COMMON_EXPORTS
+            | {
+                schema_name
+                for schema_name, owner_layer in SCHEMA_CONTRACT_LAYER.items()
+                if _SCHEMA_LAYER_ORDER[owner_layer] <= _SCHEMA_LAYER_ORDER[consumer_layer]
+            }
+        )
+        for consumer_layer in _SCHEMA_LAYER_SEQUENCE
+    }
+)
+
 __all__ = [
     "ActionType",
     "AlphaResultSnapshot",
@@ -29,10 +96,15 @@ __all__ = [
     "FeatureSignalBundle",
     "FormalObjectBase",
     "FormalReport",
+    "LAYER_SCHEMA_IMPORT_POLICY",
     "OfficialAlphaPool",
     "OverrideRecord",
     "PublishBundle",
     "RecommendationSnapshot",
+    "SCHEMA_COMMON_EXPORTS",
+    "SCHEMA_COMMON_MODULES",
+    "SCHEMA_CONTRACT_LAYER",
+    "SCHEMA_MODULE_LAYER",
     "TriggerSource",
     "WorldStateSnapshot",
     "single_prompt_result",

--- a/tests/test_package_boundaries.py
+++ b/tests/test_package_boundaries.py
@@ -89,7 +89,15 @@ def _schema_import_violations(package_root: Path) -> list[SchemaImportViolation]
                 if isinstance(node, ast.Import):
                     violations.extend(_check_schema_import_node(path, layer, node))
                 elif isinstance(node, ast.ImportFrom):
-                    violations.extend(_check_schema_import_from_node(path, layer, node))
+                    importing_package = _importing_package_name(package_root, path)
+                    violations.extend(
+                        _check_schema_import_from_node(
+                            path,
+                            layer,
+                            node,
+                            importing_package,
+                        )
+                    )
     return violations
 
 
@@ -123,8 +131,9 @@ def _check_schema_import_from_node(
     path: Path,
     layer: str,
     node: ast.ImportFrom,
+    importing_package: str,
 ) -> list[SchemaImportViolation]:
-    module = _absolute_import_from_module(node)
+    module = _absolute_import_from_module(node, importing_package)
     if module is None:
         return []
 
@@ -176,12 +185,27 @@ def _check_schema_import_from_node(
     return violations
 
 
-def _absolute_import_from_module(node: ast.ImportFrom) -> str | None:
-    if node.module is None:
-        return None
+def _importing_package_name(package_root: Path, path: Path) -> str:
+    relative_path = path.relative_to(package_root)
+    package_parts = relative_path.parent.parts
+    return ".".join((package_root.name, *package_parts))
+
+
+def _absolute_import_from_module(
+    node: ast.ImportFrom,
+    importing_package: str,
+) -> str | None:
     if node.level == 0:
         return node.module
-    return None
+
+    package_parts = importing_package.split(".")
+    if node.level > len(package_parts):
+        return None
+
+    absolute_package = ".".join(package_parts[: len(package_parts) - node.level + 1])
+    if node.module is None:
+        return absolute_package
+    return f"{absolute_package}.{node.module}"
 
 
 def _check_schema_export(
@@ -329,6 +353,26 @@ def test_schema_policy_triggers_on_synthetic_downstream_import(tmp_path: Path) -
 
     assert [violation.imported_name for violation in violations] == [
         "main_core.common.schemas",
+        "RecommendationSnapshot",
+        "PublishBundle",
+    ]
+
+
+def test_schema_policy_triggers_on_synthetic_relative_downstream_import(
+    tmp_path: Path,
+) -> None:
+    synthetic_root = tmp_path / "main_core"
+    synthetic_layer = synthetic_root / "l3_features"
+    synthetic_layer.mkdir(parents=True)
+    (synthetic_layer / "__init__.py").write_text(
+        "from ..common.schemas import RecommendationSnapshot\n"
+        "from ..common.schemas.publish import PublishBundle\n",
+        encoding="utf-8",
+    )
+
+    violations = _schema_import_violations(synthetic_root)
+
+    assert [violation.imported_name for violation in violations] == [
         "RecommendationSnapshot",
         "PublishBundle",
     ]

--- a/tests/test_package_boundaries.py
+++ b/tests/test_package_boundaries.py
@@ -2,16 +2,28 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import os
 import shutil
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
+from main_core.common.schemas import (
+    LAYER_SCHEMA_IMPORT_POLICY,
+    SCHEMA_COMMON_EXPORTS,
+    SCHEMA_COMMON_MODULES,
+    SCHEMA_CONTRACT_LAYER,
+    SCHEMA_MODULE_LAYER,
+)
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 EXIT_SUCCESS = 0
+SCHEMA_PACKAGE = "main_core.common.schemas"
+COMMON_PACKAGE = "main_core.common"
 
 LAYER_PACKAGES = (
     "l1_l2_basis",
@@ -22,6 +34,21 @@ LAYER_PACKAGES = (
     "l7_recommendation",
     "l8_publish",
 )
+
+
+@dataclass(frozen=True)
+class SchemaImportViolation:
+    path: Path
+    line_number: int
+    layer: str
+    imported_name: str
+    reason: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line_number}: {self.layer} imports "
+            f"{self.imported_name}: {self.reason}"
+        )
 
 
 def _format_process_output(result: subprocess.CompletedProcess[str]) -> str:
@@ -47,6 +74,187 @@ def _run_lint_imports(cwd: Path) -> subprocess.CompletedProcess[str]:
         check=False,
         capture_output=True,
         text=True,
+    )
+
+
+def _schema_import_violations(package_root: Path) -> list[SchemaImportViolation]:
+    violations: list[SchemaImportViolation] = []
+    for layer in LAYER_PACKAGES:
+        layer_root = package_root / layer
+        if not layer_root.exists():
+            continue
+        for path in sorted(layer_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    violations.extend(_check_schema_import_node(path, layer, node))
+                elif isinstance(node, ast.ImportFrom):
+                    violations.extend(_check_schema_import_from_node(path, layer, node))
+    return violations
+
+
+def _check_schema_import_node(
+    path: Path,
+    layer: str,
+    node: ast.Import,
+) -> list[SchemaImportViolation]:
+    violations: list[SchemaImportViolation] = []
+    for alias in node.names:
+        if alias.name == SCHEMA_PACKAGE:
+            violations.append(
+                _violation(
+                    path,
+                    node.lineno,
+                    layer,
+                    alias.name,
+                    "package namespace import exposes every schema contract",
+                )
+            )
+            continue
+        if alias.name.startswith(f"{SCHEMA_PACKAGE}."):
+            module_name = alias.name.removeprefix(f"{SCHEMA_PACKAGE}.").split(".", 1)[0]
+            violation = _check_schema_module(path, node.lineno, layer, module_name)
+            if violation is not None:
+                violations.append(violation)
+    return violations
+
+
+def _check_schema_import_from_node(
+    path: Path,
+    layer: str,
+    node: ast.ImportFrom,
+) -> list[SchemaImportViolation]:
+    module = _absolute_import_from_module(node)
+    if module is None:
+        return []
+
+    violations: list[SchemaImportViolation] = []
+    if module == COMMON_PACKAGE:
+        for alias in node.names:
+            if alias.name == "schemas":
+                violations.append(
+                    _violation(
+                        path,
+                        node.lineno,
+                        layer,
+                        f"{module}.{alias.name}",
+                        "package namespace import exposes every schema contract",
+                    )
+                )
+        return violations
+
+    if module == SCHEMA_PACKAGE:
+        for alias in node.names:
+            if alias.name == "*":
+                violations.append(
+                    _violation(
+                        path,
+                        node.lineno,
+                        layer,
+                        f"{module}.*",
+                        "wildcard import exposes every schema contract",
+                    )
+                )
+                continue
+            if alias.name in SCHEMA_COMMON_MODULES or alias.name in SCHEMA_MODULE_LAYER:
+                violation = _check_schema_module(path, node.lineno, layer, alias.name)
+            else:
+                violation = _check_schema_export(path, node.lineno, layer, alias.name)
+            if violation is not None:
+                violations.append(violation)
+        return violations
+
+    if module.startswith(f"{SCHEMA_PACKAGE}."):
+        module_name = module.removeprefix(f"{SCHEMA_PACKAGE}.").split(".", 1)[0]
+        for alias in node.names:
+            if alias.name in SCHEMA_CONTRACT_LAYER or alias.name in SCHEMA_COMMON_EXPORTS:
+                violation = _check_schema_export(path, node.lineno, layer, alias.name)
+            else:
+                violation = _check_schema_module(path, node.lineno, layer, module_name)
+            if violation is not None:
+                violations.append(violation)
+    return violations
+
+
+def _absolute_import_from_module(node: ast.ImportFrom) -> str | None:
+    if node.module is None:
+        return None
+    if node.level == 0:
+        return node.module
+    return None
+
+
+def _check_schema_export(
+    path: Path,
+    line_number: int,
+    layer: str,
+    schema_name: str,
+) -> SchemaImportViolation | None:
+    if schema_name not in SCHEMA_COMMON_EXPORTS and schema_name not in SCHEMA_CONTRACT_LAYER:
+        return _violation(
+            path,
+            line_number,
+            layer,
+            schema_name,
+            "schema export is missing explicit layer ownership",
+        )
+    if schema_name in LAYER_SCHEMA_IMPORT_POLICY[layer]:
+        return None
+    return _violation(
+        path,
+        line_number,
+        layer,
+        schema_name,
+        f"owned by downstream layer {SCHEMA_CONTRACT_LAYER[schema_name]}",
+    )
+
+
+def _check_schema_module(
+    path: Path,
+    line_number: int,
+    layer: str,
+    module_name: str,
+) -> SchemaImportViolation | None:
+    if module_name in SCHEMA_COMMON_MODULES:
+        return None
+    if module_name not in SCHEMA_MODULE_LAYER:
+        return _violation(
+            path,
+            line_number,
+            layer,
+            module_name,
+            "schema module is missing explicit layer ownership",
+        )
+
+    owner_layer = SCHEMA_MODULE_LAYER[module_name]
+    if any(
+        schema_name in LAYER_SCHEMA_IMPORT_POLICY[layer]
+        for schema_name, schema_owner in SCHEMA_CONTRACT_LAYER.items()
+        if schema_owner == owner_layer
+    ):
+        return None
+    return _violation(
+        path,
+        line_number,
+        layer,
+        module_name,
+        f"module is owned by downstream layer {owner_layer}",
+    )
+
+
+def _violation(
+    path: Path,
+    line_number: int,
+    layer: str,
+    imported_name: str,
+    reason: str,
+) -> SchemaImportViolation:
+    return SchemaImportViolation(
+        path=path,
+        line_number=line_number,
+        layer=layer,
+        imported_name=imported_name,
+        reason=reason,
     )
 
 
@@ -79,3 +287,48 @@ def test_forbidden_contract_triggers_on_synthetic_violation(tmp_path: Path) -> N
     result = _run_lint_imports(tmp_path)
 
     assert result.returncode != EXIT_SUCCESS, _format_process_output(result)
+
+
+def test_layer_schema_import_policy_passes() -> None:
+    violations = _schema_import_violations(PROJECT_ROOT / "src" / "main_core")
+
+    assert not violations, "\n".join(violation.format() for violation in violations)
+
+
+def test_schema_exports_are_declared_in_boundary_policy() -> None:
+    import main_core.common.schemas as schemas
+
+    metadata_exports = {
+        "LAYER_SCHEMA_IMPORT_POLICY",
+        "SCHEMA_COMMON_EXPORTS",
+        "SCHEMA_COMMON_MODULES",
+        "SCHEMA_CONTRACT_LAYER",
+        "SCHEMA_MODULE_LAYER",
+    }
+    declared_exports = (
+        set(SCHEMA_COMMON_EXPORTS)
+        | set(SCHEMA_CONTRACT_LAYER)
+        | metadata_exports
+    )
+
+    assert set(schemas.__all__) <= declared_exports
+
+
+def test_schema_policy_triggers_on_synthetic_downstream_import(tmp_path: Path) -> None:
+    synthetic_root = tmp_path / "main_core"
+    synthetic_layer = synthetic_root / "l3_features"
+    synthetic_layer.mkdir(parents=True)
+    (synthetic_layer / "__init__.py").write_text(
+        "import main_core.common.schemas as schemas\n"
+        "from main_core.common.schemas import RecommendationSnapshot\n"
+        "from main_core.common.schemas.publish import PublishBundle\n",
+        encoding="utf-8",
+    )
+
+    violations = _schema_import_violations(synthetic_root)
+
+    assert [violation.imported_name for violation in violations] == [
+        "main_core.common.schemas",
+        "RecommendationSnapshot",
+        "PublishBundle",
+    ]


### PR DESCRIPTION
Closes #21

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
## 背景与目标
Milestone review for milestone-0 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
All formal objects and runtime bundles are placed under main_core.common.schemas, and all layers can import every schema directly. This bypasses the intended L1-L8 contract direction: lower layers can now depend on downstream objects such as RecommendationSnapshot, PublishBundle, DashboardSnapshot, or FormalReport without tripping import-linter. The current boundary checks only restrict main_core.l* imports and do not enforce which layer may consume which schema contracts.

## 实现范围
- 修改文件: `src/main_core/common/schemas/__init__.py`
- Add boundary contracts or tests for schema usage, for example by splitting layer-owned contracts into layer-specific modules with a narrow common export policy, or by adding static AST/import checks that forbid lower layers from importing downstream formal objects.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
