### PR TITLE
feat(#20): [milestone-0 review] P0: Analyzer protocol signature does not match the documented contract

### DIFF
--- a/src/main_core/common/protocols/analyzer.py
+++ b/src/main_core/common/protocols/analyzer.py
@@ -7,6 +7,7 @@ from typing import ClassVar, Protocol, runtime_checkable
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.schemas import AlphaResultSnapshot
+from main_core.common.types import EntityId
 
 
 @runtime_checkable
@@ -19,8 +20,12 @@ class AnalyzerInterface(Protocol):
 
     analyzer_type: ClassVar[str]
 
-    def analyze(self, context: AlphaAnalysisContext) -> AlphaResultSnapshot:
-        """Analyze one stock using a typed runtime context."""
+    def analyze(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        """Analyze one stock using an explicit entity and typed runtime context."""
 
 
 class AnalyzerBase(ABC):
@@ -32,8 +37,12 @@ class AnalyzerBase(ABC):
         """Return the analyzer implementation identifier."""
 
     @abstractmethod
-    def analyze(self, context: AlphaAnalysisContext) -> AlphaResultSnapshot:
-        """Analyze one stock using a typed runtime context."""
+    def analyze(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        """Analyze one stock using an explicit entity and typed runtime context."""
 
 
 __all__ = ["AnalyzerBase", "AnalyzerInterface"]

--- a/src/main_core/l6_alpha/stubs.py
+++ b/src/main_core/l6_alpha/stubs.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot
+from main_core.common.types import EntityId
 
 
 class SinglePromptAnalyzerStub(AnalyzerBase):
@@ -14,7 +15,11 @@ class SinglePromptAnalyzerStub(AnalyzerBase):
 
     analyzer_type: ClassVar[str] = "single_prompt_v1"
 
-    def analyze(self, context: AlphaAnalysisContext) -> AlphaResultSnapshot:
+    def analyze(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
         """Reserve the L6 analyzer contract until the real implementation lands."""
 
         raise NotImplementedError("implemented in #9")

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from inspect import signature
+
 import pytest
 
 from main_core.common.contexts import AlphaAnalysisContext
@@ -60,8 +62,16 @@ def test_single_prompt_stub_matches_runtime_protocol() -> None:
     assert analyzer.analyzer_type == SINGLE_PROMPT_ANALYZER
 
 
+def test_analyzer_protocol_requires_explicit_entity_argument() -> None:
+    expected_parameters = ["self", "entity_id", "context"]
+
+    assert list(signature(AnalyzerInterface.analyze).parameters) == expected_parameters
+    assert list(signature(AnalyzerBase.analyze).parameters) == expected_parameters
+    assert list(signature(SinglePromptAnalyzerStub.analyze).parameters) == expected_parameters
+
+
 def test_single_prompt_stub_analyze_placeholder_raises() -> None:
     analyzer = SinglePromptAnalyzerStub()
 
     with pytest.raises(NotImplementedError, match="#9"):
-        analyzer.analyze(_analysis_context())
+        analyzer.analyze(ENTITY_ID, _analysis_context())


### PR DESCRIPTION
Closes #20

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
## 背景与目标
Milestone review for milestone-0 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The milestone requires AnalyzerInterface to expose analyze(stock, context) / analyze_stock(entity_id, context), but the implemented Protocol and ABC expose analyze(context) only. Entity identity is embedded inside AlphaAnalysisContext, which makes the protocol diverge from both the issue description and AGENTS.md §16.1/§16.2. If milestone-1/milestone-2 implement analyzers against this shape, the public L6 boundary will be hard to unwind.

## 实现范围
- 修改文件: `src/main_core/common/protocols/analyzer.py`
- Change AnalyzerInterface and AnalyzerBase to accept an explicit stock/entity argument plus AlphaAnalysisContext, then update SinglePromptAnalyzerStub and protocol tests to lock the documented signature.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
