### PR TITLE
feat(#5): 实现 l1_l2_basis 基础数据读取层

### DIFF
--- a/src/main_core/l1_l2_basis/__init__.py
+++ b/src/main_core/l1_l2_basis/__init__.py
@@ -1,1 +1,18 @@
-"""L1/L2 package — basis reads; see §14 of main-core.project-doc.md."""
+"""L1/L2 package: basis data read DTOs, ports, and readers."""
+
+from main_core.l1_l2_basis.errors import DataPlatformReadError, L1L2BasisError
+from main_core.l1_l2_basis.models import CalendarDay, EntityMasterRow, MarketBar
+from main_core.l1_l2_basis.ports import DataPlatformPort
+from main_core.l1_l2_basis.readers import read_calendar, read_entity_master, read_market_bars
+
+__all__ = [
+    "CalendarDay",
+    "DataPlatformPort",
+    "DataPlatformReadError",
+    "EntityMasterRow",
+    "L1L2BasisError",
+    "MarketBar",
+    "read_calendar",
+    "read_entity_master",
+    "read_market_bars",
+]

--- a/src/main_core/l1_l2_basis/errors.py
+++ b/src/main_core/l1_l2_basis/errors.py
@@ -1,0 +1,16 @@
+"""Local exception types for L1/L2 basis reads."""
+
+from __future__ import annotations
+
+from main_core.common.errors import MainCoreError
+
+
+class L1L2BasisError(MainCoreError):
+    """Base exception for L1/L2 basis read failures."""
+
+
+class DataPlatformReadError(L1L2BasisError):
+    """Raised when a data-platform port returns invalid basis data."""
+
+
+__all__ = ["DataPlatformReadError", "L1L2BasisError"]

--- a/src/main_core/l1_l2_basis/models.py
+++ b/src/main_core/l1_l2_basis/models.py
@@ -1,0 +1,81 @@
+"""Pydantic DTOs for L1/L2 basis data reads."""
+
+from __future__ import annotations
+
+from datetime import date
+from math import isfinite
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from main_core.common.types import CycleId, EntityId
+
+
+class _L1L2BasisDTO(BaseModel):
+    """Frozen strict DTO base local to the L1/L2 basis layer."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class MarketBar(_L1L2BasisDTO):
+    """Market OHLCV row returned by the injected data-platform port."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    as_of_date: date
+    open_price: float | None = None
+    high_price: float | None = None
+    low_price: float | None = None
+    close_price: float
+    volume: float
+    return_1d: float | None = None
+
+    @field_validator(
+        "open_price",
+        "high_price",
+        "low_price",
+        "close_price",
+        "volume",
+        "return_1d",
+    )
+    @classmethod
+    def validate_finite_numeric_value(cls, value: float | None) -> float | None:
+        """Reject non-finite numeric payloads before L3 derives features."""
+
+        if value is not None and not isfinite(value):
+            raise ValueError("numeric market bar values must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def validate_non_negative_close_and_volume(self) -> Self:
+        """Reject impossible price and volume payloads."""
+
+        if self.close_price < 0:
+            raise ValueError("close_price must be non-negative")
+        if self.volume < 0:
+            raise ValueError("volume must be non-negative")
+        return self
+
+
+class CalendarDay(_L1L2BasisDTO):
+    """Trading calendar metadata for one cycle."""
+
+    cycle_id: CycleId
+    trading_date: date
+    is_trading_day: bool
+    previous_trading_date: date | None = None
+    next_trading_date: date | None = None
+
+
+class EntityMasterRow(_L1L2BasisDTO):
+    """Minimal entity master row required by P2a L3 feature reads."""
+
+    entity_id: EntityId
+    ticker: str
+    name: str
+    exchange: str
+    is_active: bool = True
+    sector: str | None = None
+
+
+__all__ = ["CalendarDay", "EntityMasterRow", "MarketBar"]

--- a/src/main_core/l1_l2_basis/ports.py
+++ b/src/main_core/l1_l2_basis/ports.py
@@ -1,0 +1,26 @@
+"""Ports for external L1/L2 data providers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from main_core.common.types import CycleId
+from main_core.l1_l2_basis.models import CalendarDay, EntityMasterRow, MarketBar
+
+
+@runtime_checkable
+class DataPlatformPort(Protocol):
+    """Read-only boundary for data-platform basis data access."""
+
+    def read_market_bars(self, cycle_id: CycleId | str) -> Sequence[MarketBar]:
+        """Return market bars for the requested cycle."""
+
+    def read_calendar(self, cycle_id: CycleId | str) -> Sequence[CalendarDay]:
+        """Return trading calendar rows for the requested cycle."""
+
+    def read_entity_master(self, cycle_id: CycleId | str) -> Sequence[EntityMasterRow]:
+        """Return entity master rows visible to the requested cycle."""
+
+
+__all__ = ["DataPlatformPort"]

--- a/src/main_core/l1_l2_basis/readers.py
+++ b/src/main_core/l1_l2_basis/readers.py
@@ -1,0 +1,93 @@
+"""Reader functions for L1/L2 basis data."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+from main_core.common.types import CycleId
+from main_core.l1_l2_basis.errors import DataPlatformReadError
+from main_core.l1_l2_basis.models import CalendarDay, EntityMasterRow, MarketBar
+from main_core.l1_l2_basis.ports import DataPlatformPort
+
+BasisDTO = TypeVar("BasisDTO", MarketBar, CalendarDay, EntityMasterRow)
+
+
+def read_market_bars(cycle_id: CycleId | str, *, port: DataPlatformPort) -> list[MarketBar]:
+    """Read and validate market bars from the injected data-platform port."""
+
+    records = _read_from_port(cycle_id, port.read_market_bars, MarketBar)
+    _validate_cycle_ids(cycle_id, records, "market bars")
+    return sorted(records, key=lambda record: (record.entity_id, record.as_of_date))
+
+
+def read_calendar(cycle_id: CycleId | str, *, port: DataPlatformPort) -> list[CalendarDay]:
+    """Read and validate trading calendar rows from the injected data-platform port."""
+
+    records = _read_from_port(cycle_id, port.read_calendar, CalendarDay)
+    _validate_cycle_ids(cycle_id, records, "calendar")
+    return sorted(records, key=lambda record: record.trading_date)
+
+
+def read_entity_master(
+    cycle_id: CycleId | str,
+    *,
+    port: DataPlatformPort,
+) -> list[EntityMasterRow]:
+    """Read and validate entity master rows from the injected data-platform port."""
+
+    records = _read_from_port(cycle_id, port.read_entity_master, EntityMasterRow)
+    return sorted(records, key=lambda record: record.entity_id)
+
+
+def _read_from_port(
+    cycle_id: CycleId | str,
+    read: Callable[[CycleId | str], Sequence[BasisDTO]],
+    expected_type: type[BasisDTO],
+) -> list[BasisDTO]:
+    try:
+        records = read(cycle_id)
+    except DataPlatformReadError:
+        raise
+    except Exception as exc:
+        raise DataPlatformReadError("data-platform port failed while reading basis data") from exc
+
+    try:
+        normalized_records = list(records)
+    except TypeError as exc:
+        raise DataPlatformReadError(
+            "data-platform port returned a non-sequence basis payload"
+        ) from exc
+
+    invalid_records = [
+        index
+        for index, record in enumerate(normalized_records)
+        if not isinstance(record, expected_type)
+    ]
+    if invalid_records:
+        raise DataPlatformReadError(
+            f"data-platform port returned non-{expected_type.__name__} records "
+            f"at indexes {invalid_records}"
+        )
+    return normalized_records
+
+
+def _validate_cycle_ids(
+    requested_cycle_id: CycleId | str,
+    records: Sequence[MarketBar] | Sequence[CalendarDay],
+    dataset_name: str,
+) -> None:
+    requested = str(requested_cycle_id)
+    mismatched_records = [
+        index
+        for index, record in enumerate(records)
+        if str(record.cycle_id) != requested
+    ]
+    if mismatched_records:
+        raise DataPlatformReadError(
+            f"{dataset_name} contain records from a different cycle at indexes "
+            f"{mismatched_records}"
+        )
+
+
+__all__ = ["read_calendar", "read_entity_master", "read_market_bars"]

--- a/tests/l1_l2_basis/__init__.py
+++ b/tests/l1_l2_basis/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for L1/L2 basis readers."""

--- a/tests/l1_l2_basis/conftest.py
+++ b/tests/l1_l2_basis/conftest.py
@@ -1,0 +1,72 @@
+"""Fixtures for L1/L2 basis reader tests."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date
+
+import pytest
+
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import CalendarDay, EntityMasterRow, MarketBar
+
+
+@dataclass
+class FakeDataPlatformPort:
+    market_bars: Sequence[object] = field(default_factory=tuple)
+    calendar: Sequence[object] = field(default_factory=tuple)
+    entity_master: Sequence[object] = field(default_factory=tuple)
+    market_bar_calls: list[CycleId | str] = field(default_factory=list)
+    calendar_calls: list[CycleId | str] = field(default_factory=list)
+    entity_master_calls: list[CycleId | str] = field(default_factory=list)
+
+    def read_market_bars(self, cycle_id: CycleId | str) -> Sequence[object]:
+        self.market_bar_calls.append(cycle_id)
+        return self.market_bars
+
+    def read_calendar(self, cycle_id: CycleId | str) -> Sequence[object]:
+        self.calendar_calls.append(cycle_id)
+        return self.calendar
+
+    def read_entity_master(self, cycle_id: CycleId | str) -> Sequence[object]:
+        self.entity_master_calls.append(cycle_id)
+        return self.entity_master
+
+
+@pytest.fixture
+def cycle_id() -> CycleId:
+    return CycleId("cycle-001")
+
+
+@pytest.fixture
+def active_entity() -> EntityMasterRow:
+    return EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+        sector="technology",
+    )
+
+
+@pytest.fixture
+def market_bar(cycle_id: CycleId, active_entity: EntityMasterRow) -> MarketBar:
+    return MarketBar(
+        cycle_id=cycle_id,
+        entity_id=active_entity.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+    )
+
+
+@pytest.fixture
+def calendar_day(cycle_id: CycleId) -> CalendarDay:
+    return CalendarDay(
+        cycle_id=cycle_id,
+        trading_date=date(2026, 4, 17),
+        is_trading_day=True,
+        previous_trading_date=date(2026, 4, 16),
+        next_trading_date=date(2026, 4, 20),
+    )

--- a/tests/l1_l2_basis/test_l1_smoke.py
+++ b/tests/l1_l2_basis/test_l1_smoke.py
@@ -1,0 +1,55 @@
+"""Smoke test for the L1/L2 fake-port contract."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from main_core.common.types import CycleId
+from main_core.l1_l2_basis import read_calendar, read_entity_master, read_market_bars
+
+from .conftest import FakeDataPlatformPort
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+L1_PACKAGE_ROOT = PROJECT_ROOT / "src" / "main_core" / "l1_l2_basis"
+FORBIDDEN_STORAGE_IMPORTS = {"duckdb", "httpx", "psycopg", "pyiceberg", "requests"}
+
+
+def test_fake_port_smoke_returns_one_active_entity_with_market_data(
+    cycle_id: CycleId,
+    active_entity,
+    market_bar,
+    calendar_day,
+) -> None:
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        calendar=(calendar_day,),
+        entity_master=(active_entity,),
+    )
+
+    entities = read_entity_master(cycle_id, port=port)
+    market_bars = read_market_bars(cycle_id, port=port)
+    calendar = read_calendar(cycle_id, port=port)
+
+    assert [entity.entity_id for entity in entities if entity.is_active] == [
+        active_entity.entity_id
+    ]
+    assert market_bars == [market_bar]
+    assert calendar == [calendar_day]
+    assert port.entity_master_calls == [cycle_id]
+    assert port.market_bar_calls == [cycle_id]
+    assert port.calendar_calls == [cycle_id]
+
+
+def test_l1_l2_basis_does_not_import_storage_or_provider_clients() -> None:
+    imported_roots: set[str] = set()
+
+    for path in sorted(L1_PACKAGE_ROOT.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_roots.add(node.module.split(".", 1)[0])
+
+    assert imported_roots.isdisjoint(FORBIDDEN_STORAGE_IMPORTS)

--- a/tests/l1_l2_basis/test_models.py
+++ b/tests/l1_l2_basis/test_models.py
@@ -1,0 +1,90 @@
+"""Tests for L1/L2 basis DTO validation."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import CalendarDay, EntityMasterRow, MarketBar
+
+
+def _market_bar_payload() -> dict[str, object]:
+    return {
+        "cycle_id": CycleId("cycle-001"),
+        "entity_id": EntityId("ENT_AAPL"),
+        "as_of_date": date(2026, 4, 17),
+        "open_price": 99.0,
+        "high_price": 101.0,
+        "low_price": 98.0,
+        "close_price": 100.0,
+        "volume": 1000.0,
+        "return_1d": 0.01,
+    }
+
+
+def test_l1_dtos_are_frozen_strict_and_forbid_extra_fields() -> None:
+    for model in (MarketBar, CalendarDay, EntityMasterRow):
+        assert model.model_config["extra"] == "forbid"
+        assert model.model_config["frozen"] is True
+        assert model.model_config["strict"] is True
+
+    bar = MarketBar(**_market_bar_payload())
+
+    with pytest.raises(ValidationError):
+        MarketBar(**(_market_bar_payload() | {"unexpected": "field"}))
+    with pytest.raises(ValidationError):
+        bar.close_price = 101.0
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "match"),
+    [
+        ("open_price", float("nan"), "finite"),
+        ("high_price", float("inf"), "finite"),
+        ("low_price", float("-inf"), "finite"),
+        ("close_price", float("nan"), "finite"),
+        ("volume", float("inf"), "finite"),
+        ("return_1d", float("-inf"), "finite"),
+        ("close_price", -0.01, "close_price"),
+        ("volume", -1.0, "volume"),
+    ],
+)
+def test_market_bar_rejects_invalid_numeric_values(
+    field_name: str,
+    value: float,
+    match: str,
+) -> None:
+    payload = _market_bar_payload()
+    payload[field_name] = value
+
+    with pytest.raises(ValidationError, match=match):
+        MarketBar(**payload)
+
+
+def test_market_bar_requires_strict_field_types() -> None:
+    payload = _market_bar_payload()
+    payload["close_price"] = "100.0"
+
+    with pytest.raises(ValidationError):
+        MarketBar(**payload)
+
+
+def test_calendar_day_and_entity_master_happy_paths() -> None:
+    calendar_day = CalendarDay(
+        cycle_id=CycleId("cycle-001"),
+        trading_date=date(2026, 4, 17),
+        is_trading_day=True,
+    )
+    entity = EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+    )
+
+    assert calendar_day.previous_trading_date is None
+    assert entity.is_active is True
+    assert entity.sector is None

--- a/tests/l1_l2_basis/test_readers.py
+++ b/tests/l1_l2_basis/test_readers.py
@@ -1,0 +1,156 @@
+"""Tests for L1/L2 basis reader functions."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import (
+    CalendarDay,
+    DataPlatformReadError,
+    EntityMasterRow,
+    MarketBar,
+    read_calendar,
+    read_entity_master,
+    read_market_bars,
+)
+
+from .conftest import FakeDataPlatformPort
+
+
+def test_read_market_bars_delegates_once_and_returns_sorted_list(cycle_id: CycleId) -> None:
+    later_aapl = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_AAPL"),
+        as_of_date=date(2026, 4, 18),
+        close_price=101.0,
+        volume=1100.0,
+    )
+    earlier_aapl = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_AAPL"),
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+    )
+    msft = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_MSFT"),
+        as_of_date=date(2026, 4, 17),
+        close_price=200.0,
+        volume=2000.0,
+    )
+    port = FakeDataPlatformPort(market_bars=(msft, later_aapl, earlier_aapl))
+
+    result = read_market_bars(cycle_id, port=port)
+
+    assert isinstance(result, list)
+    assert result == [earlier_aapl, later_aapl, msft]
+    assert port.market_bar_calls == [cycle_id]
+
+
+def test_read_calendar_delegates_once_and_returns_sorted_list(cycle_id: CycleId) -> None:
+    later = CalendarDay(
+        cycle_id=cycle_id,
+        trading_date=date(2026, 4, 20),
+        is_trading_day=True,
+    )
+    earlier = CalendarDay(
+        cycle_id=cycle_id,
+        trading_date=date(2026, 4, 17),
+        is_trading_day=True,
+    )
+    port = FakeDataPlatformPort(calendar=(later, earlier))
+
+    result = read_calendar(str(cycle_id), port=port)
+
+    assert result == [earlier, later]
+    assert port.calendar_calls == [str(cycle_id)]
+
+
+def test_read_entity_master_delegates_once_and_returns_sorted_list(cycle_id: CycleId) -> None:
+    msft = EntityMasterRow(
+        entity_id=EntityId("ENT_MSFT"),
+        ticker="MSFT",
+        name="Microsoft Corp.",
+        exchange="NASDAQ",
+    )
+    aapl = EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+    )
+    port = FakeDataPlatformPort(entity_master=(msft, aapl))
+
+    result = read_entity_master(cycle_id, port=port)
+
+    assert result == [aapl, msft]
+    assert port.entity_master_calls == [cycle_id]
+
+
+@pytest.mark.parametrize(
+    ("reader", "payload_name"),
+    [
+        (read_market_bars, "market_bars"),
+        (read_calendar, "calendar"),
+        (read_entity_master, "entity_master"),
+    ],
+)
+def test_readers_reject_invalid_port_payloads(
+    reader: object,
+    payload_name: str,
+    cycle_id: CycleId,
+) -> None:
+    port = FakeDataPlatformPort(**{payload_name: (object(),)})
+
+    with pytest.raises(DataPlatformReadError, match="non-"):
+        reader(cycle_id, port=port)
+
+
+@pytest.mark.parametrize(
+    ("reader", "payload_name", "record"),
+    [
+        (
+            read_market_bars,
+            "market_bars",
+            MarketBar(
+                cycle_id=CycleId("cycle-other"),
+                entity_id=EntityId("ENT_AAPL"),
+                as_of_date=date(2026, 4, 17),
+                close_price=100.0,
+                volume=1000.0,
+            ),
+        ),
+        (
+            read_calendar,
+            "calendar",
+            CalendarDay(
+                cycle_id=CycleId("cycle-other"),
+                trading_date=date(2026, 4, 17),
+                is_trading_day=True,
+            ),
+        ),
+    ],
+)
+def test_readers_reject_cycle_mismatches(
+    reader: object,
+    payload_name: str,
+    record: MarketBar | CalendarDay,
+    cycle_id: CycleId,
+) -> None:
+    port = FakeDataPlatformPort(**{payload_name: (record,)})
+
+    with pytest.raises(DataPlatformReadError, match="different cycle"):
+        reader(cycle_id, port=port)
+
+
+def test_reader_wraps_port_failures(cycle_id: CycleId) -> None:
+    class BrokenPort(FakeDataPlatformPort):
+        def read_market_bars(self, cycle_id: CycleId | str) -> object:
+            raise RuntimeError("provider unavailable")
+
+    with pytest.raises(DataPlatformReadError, match="port failed"):
+        read_market_bars(cycle_id, port=BrokenPort())


### PR DESCRIPTION
Closes #5

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
## 1. 背景与目标
项目文档 §21 阶段 0 要求先打通 P2a 纯数据骨架，`l1_l2_basis` 是 L3 之前唯一负责对象、市场、日历基础读取的层。现有 milestone-0 代码已经提供 `main_core.common.types.CycleId` / `EntityId` 以及 `main_core.common.schemas.*` formal/runtime schema，但还没有任何 L1 读取 DTO、port 或 reader 实现。本 issue 的目标是在不直连 DuckDB/Iceberg/HTTP provider 的前提下，建立可被 L3 fake/integration 测试消费的显式基础数据读取接口。

## 2. 所属模块
- primary writable paths:
  - `src/main_core/l1_l2_basis/__init__.py`
  - `src/main_core/l1_l2_basis/models.py`
  - `src/main_core/l1_l2_basis/ports.py`
  - `src/main_core/l1_l2_basis/readers.py`
  - `src/main_core/l1_l2_basis/errors.py`
  - `tests/l1_l2_basis/__init__.py`
  - `tests/l1_l2_basis/conftest.py`
  - `tests/l1_l2_basis/test_models.py`
  - `tests/l1_l2_basis/test_readers.py`
  - `tests/l1_l2_basis/test_l1_smoke.py`
- adjacent read-only / integration paths:
  - `src/main_core/common/types.py` (`CycleId`, `EntityId`)
  - `src/main_core/common/errors.py` (`MainCoreError`)
  - `src/main_core/common/schemas/**` (read-only; L1 DTOs must stay separate from formal schemas from #3)
  - `src/main_core/l3_features/**` (read-only; consumed by #6 only)
  - `tests/test_package_boundaries.py` and schema-boundary tests added by #21 (regression only)
- out of repository scope:
  - `data-platform`, `graph-engine`, `reasoner-runtime`, `audit-eval`, and any external serving API implementation.

## 3. 实现范围
- Create `src/main_core/l1_l2_basis/models.py` with Pydantic v2 DTOs using `ConfigDict(extra="forbid", frozen=True, strict=True)`, not `FormalObjectBase`: `MarketBar`, `CalendarDay`, and `EntityMasterRow`.
- Define `MarketBar` fields: `cycle_id: CycleId`, `entity_id: EntityId`, `as_of_date: date`, `open_price: float | None = None`, `high_price: float | None = None`, `low_price: float | None = None`, `close_price: float`, `volume: float`, `return_1d: float | None = None`; validate finite numeric values and reject negative `close_price` / `volume`.
- Define `CalendarDay` fields: `cycle_id: CycleId`, `trading_date: date`, `is_trading_day: b