### PR TITLE
feat(#6): 实现 l3_features 特征/信号主干与 feature_weight_multiplier 在线写入

### DIFF
--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -1,1 +1,19 @@
-"""L3 package — feature and signal bundle work; see §14 of main-core.project-doc.md."""
+"""L3 package: feature and signal bundle assembly."""
+
+from main_core.l3_features.builder import build_feature_signal_bundle
+from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
+from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+from main_core.l3_features.weight_api import (
+    apply_weight_multiplier,
+    get_feature_weight_multiplier,
+)
+
+__all__ = [
+    "InMemoryMultiplierStore",
+    "InvalidMultiplierError",
+    "L3FeatureError",
+    "MultiplierStore",
+    "apply_weight_multiplier",
+    "build_feature_signal_bundle",
+    "get_feature_weight_multiplier",
+]

--- a/src/main_core/l3_features/builder.py
+++ b/src/main_core/l3_features/builder.py
@@ -1,0 +1,76 @@
+"""Feature signal bundle builder for the L3 layer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis.models import MarketBar
+from main_core.l1_l2_basis.ports import DataPlatformPort
+from main_core.l1_l2_basis.readers import read_entity_master, read_market_bars
+from main_core.l3_features.feature_math import (
+    apply_feature_weight_multiplier,
+    market_bar_feature_values,
+)
+from main_core.l3_features.multiplier_store import MultiplierStore
+from main_core.l3_features.weight_api import get_feature_weight_multiplier
+
+
+def build_feature_signal_bundle(
+    cycle_id: CycleId | str,
+    *,
+    data_port: DataPlatformPort,
+    multiplier_store: MultiplierStore | None = None,
+    graph_impact: Mapping[str, Mapping[str, Any]] | None = None,
+    candidate_signals: Mapping[str, Mapping[str, Any]] | None = None,
+) -> list[FeatureSignalBundle]:
+    """Build one feature signal bundle per active entity with market data."""
+
+    entity_master = read_entity_master(cycle_id, port=data_port)
+    market_bars = read_market_bars(cycle_id, port=data_port)
+    active_entity_ids = {
+        str(entity.entity_id)
+        for entity in entity_master
+        if entity.is_active
+    }
+    latest_bars = _latest_market_bars_by_entity(market_bars)
+    multipliers = get_feature_weight_multiplier(cycle_id, store=multiplier_store)
+
+    bundles: list[FeatureSignalBundle] = []
+    for entity_id in sorted(active_entity_ids):
+        market_bar = latest_bars.get(entity_id)
+        if market_bar is None:
+            continue
+
+        base_feature_values = market_bar_feature_values(market_bar)
+        feature_values, effective_multipliers = apply_feature_weight_multiplier(
+            base_feature_values,
+            multipliers,
+        )
+        bundles.append(
+            FeatureSignalBundle(
+                cycle_id=cycle_id,
+                entity_id=EntityId(entity_id),
+                feature_values=feature_values,
+                signal_values=dict((candidate_signals or {}).get(entity_id, {})),
+                graph_features=dict((graph_impact or {}).get(entity_id, {})),
+                feature_weight_multiplier=effective_multipliers,
+            )
+        )
+
+    return bundles
+
+
+def _latest_market_bars_by_entity(market_bars: list[MarketBar]) -> dict[str, MarketBar]:
+    latest_bars: dict[str, MarketBar] = {}
+    for market_bar in market_bars:
+        entity_id = str(market_bar.entity_id)
+        previous_bar = latest_bars.get(entity_id)
+        if previous_bar is None or market_bar.as_of_date > previous_bar.as_of_date:
+            latest_bars[entity_id] = market_bar
+    return latest_bars
+
+
+__all__ = ["build_feature_signal_bundle"]

--- a/src/main_core/l3_features/errors.py
+++ b/src/main_core/l3_features/errors.py
@@ -1,0 +1,16 @@
+"""Local exception types for L3 feature assembly."""
+
+from __future__ import annotations
+
+from main_core.common.errors import MainCoreError
+
+
+class L3FeatureError(MainCoreError):
+    """Base exception for L3 feature and signal bundle failures."""
+
+
+class InvalidMultiplierError(L3FeatureError):
+    """Raised when a feature weight multiplier is non-positive or non-finite."""
+
+
+__all__ = ["InvalidMultiplierError", "L3FeatureError"]

--- a/src/main_core/l3_features/feature_math.py
+++ b/src/main_core/l3_features/feature_math.py
@@ -1,0 +1,39 @@
+"""Pure feature derivation helpers for L3 feature bundles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from main_core.l1_l2_basis.models import MarketBar
+
+
+def market_bar_feature_values(market_bar: MarketBar) -> dict[str, float]:
+    """Convert a validated latest market bar into base numeric feature values."""
+
+    feature_values = {
+        "close_price": market_bar.close_price,
+        "volume": market_bar.volume,
+    }
+    if market_bar.return_1d is not None:
+        feature_values["return_1d"] = market_bar.return_1d
+    return feature_values
+
+
+def apply_feature_weight_multiplier(
+    feature_values: Mapping[str, float],
+    multipliers: Mapping[str, float],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Apply known feature multipliers and return weighted features plus effective weights."""
+
+    effective_multipliers = {
+        feature_name: float(multipliers.get(feature_name, 1.0))
+        for feature_name in feature_values
+    }
+    weighted_feature_values = {
+        feature_name: feature_value * effective_multipliers[feature_name]
+        for feature_name, feature_value in feature_values.items()
+    }
+    return weighted_feature_values, effective_multipliers
+
+
+__all__ = ["apply_feature_weight_multiplier", "market_bar_feature_values"]

--- a/src/main_core/l3_features/feature_math.py
+++ b/src/main_core/l3_features/feature_math.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from math import isfinite
 
 from main_core.l1_l2_basis.models import MarketBar
+from main_core.l3_features.errors import InvalidMultiplierError
 
 
 def market_bar_feature_values(market_bar: MarketBar) -> dict[str, float]:
@@ -29,10 +31,14 @@ def apply_feature_weight_multiplier(
         feature_name: float(multipliers.get(feature_name, 1.0))
         for feature_name in feature_values
     }
-    weighted_feature_values = {
-        feature_name: feature_value * effective_multipliers[feature_name]
-        for feature_name, feature_value in feature_values.items()
-    }
+    weighted_feature_values = {}
+    for feature_name, feature_value in feature_values.items():
+        weighted_feature_value = feature_value * effective_multipliers[feature_name]
+        if not isfinite(weighted_feature_value):
+            raise InvalidMultiplierError(
+                "weighted feature values must be finite after applying multipliers"
+            )
+        weighted_feature_values[feature_name] = weighted_feature_value
     return weighted_feature_values, effective_multipliers
 
 

--- a/src/main_core/l3_features/multiplier_store.py
+++ b/src/main_core/l3_features/multiplier_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from math import isfinite
+from threading import Lock
 from typing import Protocol, runtime_checkable
 
 from main_core.common.types import CycleId
@@ -30,11 +31,13 @@ class InMemoryMultiplierStore:
 
     def __init__(self) -> None:
         self._multipliers_by_cycle: dict[str, dict[str, float]] = {}
+        self._lock = Lock()
 
     def get_multipliers(self, cycle_id: CycleId | str) -> dict[str, float]:
         """Return a defensive copy of the multipliers for the requested cycle."""
 
-        return dict(self._multipliers_by_cycle.get(str(cycle_id), {}))
+        with self._lock:
+            return dict(self._multipliers_by_cycle.get(str(cycle_id), {}))
 
     def put_multipliers(
         self,
@@ -45,9 +48,10 @@ class InMemoryMultiplierStore:
 
         validated_updates = _validated_multiplier_copy(updates)
         cycle_key = str(cycle_id)
-        current_multipliers = self.get_multipliers(cycle_key)
-        current_multipliers.update(validated_updates)
-        self._multipliers_by_cycle[cycle_key] = current_multipliers
+        with self._lock:
+            current_multipliers = dict(self._multipliers_by_cycle.get(cycle_key, {}))
+            current_multipliers.update(validated_updates)
+            self._multipliers_by_cycle[cycle_key] = current_multipliers
 
 
 def _validated_multiplier_copy(updates: Mapping[str, float]) -> dict[str, float]:

--- a/src/main_core/l3_features/multiplier_store.py
+++ b/src/main_core/l3_features/multiplier_store.py
@@ -1,0 +1,67 @@
+"""Cycle-scoped feature multiplier storage."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import isfinite
+from typing import Protocol, runtime_checkable
+
+from main_core.common.types import CycleId
+from main_core.l3_features.errors import InvalidMultiplierError
+
+
+@runtime_checkable
+class MultiplierStore(Protocol):
+    """Storage contract for online feature weight multiplier updates."""
+
+    def get_multipliers(self, cycle_id: CycleId | str) -> Mapping[str, float]:
+        """Return multipliers currently visible for a cycle."""
+
+    def put_multipliers(
+        self,
+        cycle_id: CycleId | str,
+        updates: Mapping[str, float],
+    ) -> None:
+        """Persist multiplier updates for a cycle."""
+
+
+class InMemoryMultiplierStore:
+    """In-process multiplier store with per-cycle isolation."""
+
+    def __init__(self) -> None:
+        self._multipliers_by_cycle: dict[str, dict[str, float]] = {}
+
+    def get_multipliers(self, cycle_id: CycleId | str) -> dict[str, float]:
+        """Return a defensive copy of the multipliers for the requested cycle."""
+
+        return dict(self._multipliers_by_cycle.get(str(cycle_id), {}))
+
+    def put_multipliers(
+        self,
+        cycle_id: CycleId | str,
+        updates: Mapping[str, float],
+    ) -> None:
+        """Validate and store multiplier updates for the requested cycle."""
+
+        validated_updates = _validated_multiplier_copy(updates)
+        cycle_key = str(cycle_id)
+        current_multipliers = self.get_multipliers(cycle_key)
+        current_multipliers.update(validated_updates)
+        self._multipliers_by_cycle[cycle_key] = current_multipliers
+
+
+def _validated_multiplier_copy(updates: Mapping[str, float]) -> dict[str, float]:
+    invalid_keys = [
+        feature_name
+        for feature_name, multiplier in updates.items()
+        if not isinstance(multiplier, int | float)
+        or isinstance(multiplier, bool)
+        or not isfinite(multiplier)
+        or multiplier <= 0
+    ]
+    if invalid_keys:
+        raise InvalidMultiplierError("feature weight multipliers must be finite and > 0")
+    return {feature_name: float(multiplier) for feature_name, multiplier in updates.items()}
+
+
+__all__ = ["InMemoryMultiplierStore", "MultiplierStore"]

--- a/src/main_core/l3_features/weight_api.py
+++ b/src/main_core/l3_features/weight_api.py
@@ -1,0 +1,38 @@
+"""Public API for online feature weight multiplier updates."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from main_core.common.types import CycleId
+from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+
+_DEFAULT_MULTIPLIER_STORE = InMemoryMultiplierStore()
+
+
+def apply_weight_multiplier(
+    cycle_id: CycleId | str,
+    updates: Mapping[str, float],
+    *,
+    store: MultiplierStore | None = None,
+) -> None:
+    """Apply feature weight multiplier updates for a cycle."""
+
+    _resolve_store(store).put_multipliers(cycle_id, updates)
+
+
+def get_feature_weight_multiplier(
+    cycle_id: CycleId | str,
+    *,
+    store: MultiplierStore | None = None,
+) -> dict[str, float]:
+    """Return the currently visible feature weight multipliers for a cycle."""
+
+    return dict(_resolve_store(store).get_multipliers(cycle_id))
+
+
+def _resolve_store(store: MultiplierStore | None) -> MultiplierStore:
+    return store if store is not None else _DEFAULT_MULTIPLIER_STORE
+
+
+__all__ = ["apply_weight_multiplier", "get_feature_weight_multiplier"]

--- a/tests/integration/test_l1_l3_feature_flow.py
+++ b/tests/integration/test_l1_l3_feature_flow.py
@@ -1,0 +1,75 @@
+"""Minimal pure-market L1 to L3 integration flow."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date
+
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import CalendarDay, EntityMasterRow, MarketBar
+from main_core.l3_features import build_feature_signal_bundle
+
+
+@dataclass
+class FakeDataPlatformPort:
+    market_bars: Sequence[object] = field(default_factory=tuple)
+    calendar: Sequence[object] = field(default_factory=tuple)
+    entity_master: Sequence[object] = field(default_factory=tuple)
+
+    def read_market_bars(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return self.market_bars
+
+    def read_calendar(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return self.calendar
+
+    def read_entity_master(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return self.entity_master
+
+
+def test_pure_market_l1_to_l3_flow_without_graph_or_candidate_signals() -> None:
+    cycle_id = CycleId("cycle-integration-001")
+    entity = EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+    )
+    port = FakeDataPlatformPort(
+        entity_master=(entity,),
+        market_bars=(
+            MarketBar(
+                cycle_id=cycle_id,
+                entity_id=entity.entity_id,
+                as_of_date=date(2026, 4, 17),
+                close_price=100.0,
+                volume=1000.0,
+                return_1d=0.01,
+            ),
+        ),
+        calendar=(
+            CalendarDay(
+                cycle_id=cycle_id,
+                trading_date=date(2026, 4, 17),
+                is_trading_day=True,
+            ),
+        ),
+    )
+
+    bundles = build_feature_signal_bundle(cycle_id, data_port=port)
+
+    assert len(bundles) == 1
+    assert bundles[0].cycle_id == cycle_id
+    assert bundles[0].entity_id == "ENT_AAPL"
+    assert bundles[0].feature_values == {
+        "close_price": 100.0,
+        "volume": 1000.0,
+        "return_1d": 0.01,
+    }
+    assert bundles[0].signal_values == {}
+    assert bundles[0].graph_features == {}
+    assert bundles[0].feature_weight_multiplier == {
+        "close_price": 1.0,
+        "volume": 1.0,
+        "return_1d": 1.0,
+    }

--- a/tests/l3_features/__init__.py
+++ b/tests/l3_features/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for L3 feature assembly."""

--- a/tests/l3_features/conftest.py
+++ b/tests/l3_features/conftest.py
@@ -1,0 +1,74 @@
+"""Fixtures for L3 feature builder tests."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date
+
+import pytest
+
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import EntityMasterRow, MarketBar
+
+
+@dataclass
+class FakeDataPlatformPort:
+    market_bars: Sequence[object] = field(default_factory=tuple)
+    calendar: Sequence[object] = field(default_factory=tuple)
+    entity_master: Sequence[object] = field(default_factory=tuple)
+    market_bar_calls: list[CycleId | str] = field(default_factory=list)
+    calendar_calls: list[CycleId | str] = field(default_factory=list)
+    entity_master_calls: list[CycleId | str] = field(default_factory=list)
+
+    def read_market_bars(self, cycle_id: CycleId | str) -> Sequence[object]:
+        self.market_bar_calls.append(cycle_id)
+        return self.market_bars
+
+    def read_calendar(self, cycle_id: CycleId | str) -> Sequence[object]:
+        self.calendar_calls.append(cycle_id)
+        return self.calendar
+
+    def read_entity_master(self, cycle_id: CycleId | str) -> Sequence[object]:
+        self.entity_master_calls.append(cycle_id)
+        return self.entity_master
+
+
+@pytest.fixture
+def cycle_id() -> CycleId:
+    return CycleId("cycle-l3-001")
+
+
+@pytest.fixture
+def active_entity() -> EntityMasterRow:
+    return EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+        sector="technology",
+    )
+
+
+@pytest.fixture
+def inactive_entity() -> EntityMasterRow:
+    return EntityMasterRow(
+        entity_id=EntityId("ENT_IBM"),
+        ticker="IBM",
+        name="International Business Machines",
+        exchange="NYSE",
+        is_active=False,
+        sector="technology",
+    )
+
+
+@pytest.fixture
+def market_bar(cycle_id: CycleId, active_entity: EntityMasterRow) -> MarketBar:
+    return MarketBar(
+        cycle_id=cycle_id,
+        entity_id=active_entity.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+        return_1d=0.02,
+    )

--- a/tests/l3_features/test_builder.py
+++ b/tests/l3_features/test_builder.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from datetime import date
+from sys import float_info
+
+import pytest
 
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.types import CycleId, EntityId
 from main_core.l1_l2_basis import EntityMasterRow, MarketBar
 from main_core.l3_features import (
     InMemoryMultiplierStore,
+    InvalidMultiplierError,
     apply_weight_multiplier,
     build_feature_signal_bundle,
 )
@@ -71,6 +75,14 @@ def test_feature_math_omits_missing_return_1d(cycle_id: CycleId) -> None:
         "close_price": 100.0,
         "volume": 1000.0,
     }
+
+
+def test_feature_math_rejects_weighted_feature_overflow() -> None:
+    with pytest.raises(InvalidMultiplierError, match="weighted feature values"):
+        apply_feature_weight_multiplier(
+            {"close_price": float_info.max},
+            {"close_price": 2.0},
+        )
 
 
 def test_build_feature_signal_bundle_uses_latest_market_bar_and_sorts_by_entity(

--- a/tests/l3_features/test_builder.py
+++ b/tests/l3_features/test_builder.py
@@ -1,0 +1,215 @@
+"""Tests for L3 feature bundle assembly."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import EntityMasterRow, MarketBar
+from main_core.l3_features import (
+    InMemoryMultiplierStore,
+    apply_weight_multiplier,
+    build_feature_signal_bundle,
+)
+from main_core.l3_features.feature_math import (
+    apply_feature_weight_multiplier,
+    market_bar_feature_values,
+)
+
+from .conftest import FakeDataPlatformPort
+
+UPDATED_CLOSE_PRICE = 120.0
+UPDATED_CLOSE_MULTIPLIER = 1.2
+
+
+def test_feature_math_derives_market_features_and_applies_known_multipliers(
+    cycle_id: CycleId,
+) -> None:
+    market_bar = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_AAPL"),
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+        return_1d=0.02,
+    )
+
+    base_features = market_bar_feature_values(market_bar)
+    weighted_features, effective_multipliers = apply_feature_weight_multiplier(
+        base_features,
+        {"close_price": 1.2, "unknown_feature": 9.0},
+    )
+
+    assert base_features == {
+        "close_price": 100.0,
+        "volume": 1000.0,
+        "return_1d": 0.02,
+    }
+    assert weighted_features == {
+        "close_price": 120.0,
+        "volume": 1000.0,
+        "return_1d": 0.02,
+    }
+    assert effective_multipliers == {
+        "close_price": 1.2,
+        "volume": 1.0,
+        "return_1d": 1.0,
+    }
+
+
+def test_feature_math_omits_missing_return_1d(cycle_id: CycleId) -> None:
+    market_bar = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_AAPL"),
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+    )
+
+    assert market_bar_feature_values(market_bar) == {
+        "close_price": 100.0,
+        "volume": 1000.0,
+    }
+
+
+def test_build_feature_signal_bundle_uses_latest_market_bar_and_sorts_by_entity(
+    cycle_id: CycleId,
+) -> None:
+    aapl = EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+    )
+    msft = EntityMasterRow(
+        entity_id=EntityId("ENT_MSFT"),
+        ticker="MSFT",
+        name="Microsoft Corp.",
+        exchange="NASDAQ",
+    )
+    inactive = EntityMasterRow(
+        entity_id=EntityId("ENT_IBM"),
+        ticker="IBM",
+        name="International Business Machines",
+        exchange="NYSE",
+        is_active=False,
+    )
+    earlier_aapl = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=aapl.entity_id,
+        as_of_date=date(2026, 4, 16),
+        close_price=90.0,
+        volume=900.0,
+    )
+    latest_aapl = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=aapl.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+        return_1d=0.03,
+    )
+    msft_bar = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=msft.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=200.0,
+        volume=2000.0,
+    )
+    inactive_bar = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=inactive.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=50.0,
+        volume=500.0,
+    )
+    store = InMemoryMultiplierStore()
+    apply_weight_multiplier(cycle_id, {"close_price": 1.2, "volume": 0.5}, store=store)
+    port = FakeDataPlatformPort(
+        market_bars=(msft_bar, inactive_bar, latest_aapl, earlier_aapl),
+        entity_master=(msft, inactive, aapl),
+    )
+
+    bundles = build_feature_signal_bundle(
+        cycle_id,
+        data_port=port,
+        multiplier_store=store,
+        graph_impact={"ENT_AAPL": {"centrality": 0.7}},
+        candidate_signals={"ENT_AAPL": {"direction": "positive"}},
+    )
+
+    assert all(isinstance(bundle, FeatureSignalBundle) for bundle in bundles)
+    assert [bundle.entity_id for bundle in bundles] == ["ENT_AAPL", "ENT_MSFT"]
+    assert bundles[0].feature_values == {
+        "close_price": 120.0,
+        "volume": 500.0,
+        "return_1d": 0.03,
+    }
+    assert bundles[0].feature_weight_multiplier == {
+        "close_price": 1.2,
+        "volume": 0.5,
+        "return_1d": 1.0,
+    }
+    assert bundles[0].signal_values == {"direction": "positive"}
+    assert bundles[0].graph_features == {"centrality": 0.7}
+    assert bundles[1].feature_values == {
+        "close_price": 240.0,
+        "volume": 1000.0,
+    }
+    assert bundles[1].signal_values == {}
+    assert bundles[1].graph_features == {}
+    assert port.entity_master_calls == [cycle_id]
+    assert port.market_bar_calls == [cycle_id]
+
+
+def test_build_feature_signal_bundle_defaults_optional_inputs_to_empty_dicts(
+    cycle_id: CycleId,
+    active_entity: EntityMasterRow,
+    market_bar: MarketBar,
+) -> None:
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(active_entity,),
+    )
+
+    bundles = build_feature_signal_bundle(cycle_id, data_port=port)
+
+    assert len(bundles) == 1
+    assert bundles[0].cycle_id == cycle_id
+    assert bundles[0].entity_id == active_entity.entity_id
+    assert bundles[0].signal_values == {}
+    assert bundles[0].graph_features == {}
+    assert bundles[0].feature_weight_multiplier == {
+        "close_price": 1.0,
+        "volume": 1.0,
+        "return_1d": 1.0,
+    }
+
+
+def test_default_multiplier_store_update_is_visible_to_same_cycle_build() -> None:
+    cycle_id = CycleId("cycle-default-online-update")
+    entity = EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+    )
+    market_bar = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=entity.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+    )
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(entity,),
+    )
+
+    apply_weight_multiplier(cycle_id, {"close_price": UPDATED_CLOSE_MULTIPLIER})
+
+    bundles = build_feature_signal_bundle(cycle_id, data_port=port)
+
+    assert bundles[0].feature_values["close_price"] == UPDATED_CLOSE_PRICE
+    assert bundles[0].feature_weight_multiplier["close_price"] == UPDATED_CLOSE_MULTIPLIER

--- a/tests/l3_features/test_multiplier_store.py
+++ b/tests/l3_features/test_multiplier_store.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
 import pytest
 
 from main_core.common.types import CycleId
@@ -35,6 +38,34 @@ def test_in_memory_multiplier_store_defensively_copies_updates() -> None:
     updates["close_price"] = 9.9
 
     assert store.get_multipliers("cycle-001") == {"close_price": 1.2}
+
+
+def test_in_memory_multiplier_store_merges_concurrent_same_cycle_updates_atomically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryMultiplierStore()
+    original_get_multipliers = store.get_multipliers
+    read_barrier = Barrier(2)
+
+    def synchronized_get_multipliers(cycle_id: CycleId | str) -> dict[str, float]:
+        multipliers = original_get_multipliers(cycle_id)
+        read_barrier.wait(timeout=5)
+        return multipliers
+
+    monkeypatch.setattr(store, "get_multipliers", synchronized_get_multipliers)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(store.put_multipliers, "cycle-001", {"close_price": 1.2}),
+            executor.submit(store.put_multipliers, "cycle-001", {"volume": 0.5}),
+        ]
+        for future in futures:
+            future.result(timeout=5)
+    monkeypatch.undo()
+
+    assert store.get_multipliers("cycle-001") == {
+        "close_price": 1.2,
+        "volume": 0.5,
+    }
 
 
 @pytest.mark.parametrize("invalid_multiplier", [0.0, -0.1, float("nan"), float("inf")])

--- a/tests/l3_features/test_multiplier_store.py
+++ b/tests/l3_features/test_multiplier_store.py
@@ -1,0 +1,49 @@
+"""Tests for L3 multiplier storage."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.types import CycleId
+from main_core.l3_features import InMemoryMultiplierStore, InvalidMultiplierError
+
+
+def test_in_memory_multiplier_store_is_cycle_scoped() -> None:
+    store = InMemoryMultiplierStore()
+
+    store.put_multipliers(CycleId("cycle-001"), {"close_price": 1.2})
+
+    assert store.get_multipliers("cycle-001") == {"close_price": 1.2}
+    assert store.get_multipliers("cycle-002") == {}
+
+
+def test_in_memory_multiplier_store_returns_defensive_copy() -> None:
+    store = InMemoryMultiplierStore()
+    store.put_multipliers("cycle-001", {"close_price": 1.2})
+
+    returned_multipliers = store.get_multipliers("cycle-001")
+    returned_multipliers["close_price"] = 9.9
+
+    assert store.get_multipliers("cycle-001") == {"close_price": 1.2}
+
+
+def test_in_memory_multiplier_store_defensively_copies_updates() -> None:
+    store = InMemoryMultiplierStore()
+    updates = {"close_price": 1.2}
+
+    store.put_multipliers("cycle-001", updates)
+    updates["close_price"] = 9.9
+
+    assert store.get_multipliers("cycle-001") == {"close_price": 1.2}
+
+
+@pytest.mark.parametrize("invalid_multiplier", [0.0, -0.1, float("nan"), float("inf")])
+def test_in_memory_multiplier_store_rejects_invalid_values(
+    invalid_multiplier: float,
+) -> None:
+    store = InMemoryMultiplierStore()
+
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        store.put_multipliers("cycle-001", {"close_price": invalid_multiplier})
+
+    assert store.get_multipliers("cycle-001") == {}

--- a/tests/l3_features/test_weight_api.py
+++ b/tests/l3_features/test_weight_api.py
@@ -1,0 +1,31 @@
+"""Tests for the public L3 multiplier API."""
+
+from __future__ import annotations
+
+from main_core.l3_features import (
+    InMemoryMultiplierStore,
+    apply_weight_multiplier,
+    get_feature_weight_multiplier,
+)
+
+
+def test_weight_api_applies_updates_to_injected_store() -> None:
+    store = InMemoryMultiplierStore()
+
+    apply_weight_multiplier("cycle-001", {"close_price": 1.2}, store=store)
+    apply_weight_multiplier("cycle-001", {"volume": 0.8}, store=store)
+
+    assert get_feature_weight_multiplier("cycle-001", store=store) == {
+        "close_price": 1.2,
+        "volume": 0.8,
+    }
+
+
+def test_weight_api_returns_defensive_copy() -> None:
+    store = InMemoryMultiplierStore()
+    apply_weight_multiplier("cycle-001", {"close_price": 1.2}, store=store)
+
+    returned_multipliers = get_feature_weight_multiplier("cycle-001", store=store)
+    returned_multipliers["close_price"] = 9.9
+
+    assert get_feature_weight_multiplier("cycle-001", store=store) == {"close_price": 1.2}


### PR DESCRIPTION
Closes #6

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
## 1. 背景与目标
项目文档 §11.1 与 §21 阶段 0 要求 L3 能在无图谱、无子系统输入时，从 L1/L2 基础数据产出可消费的 `FeatureSignalBundle`。现有 schema 已在 `main_core.common.schemas.feature_bundle.FeatureSignalBundle` 中固定字段 `cycle_id`, `entity_id`, `feature_values`, `signal_values`, `graph_features`, `feature_weight_multiplier`, `generated_at`，并要求 multiplier 为正且有限。本 issue 在 #5 的 L1 reader/DTO 基础上实现 L3 特征/信号主干和 `feature_weight_multiplier` 在线写入，使同一 cycle 的后续 build 立即看到最新 multiplier。

## 2. 所属模块
- primary writable paths:
  - `src/main_core/l3_features/__init__.py`
  - `src/main_core/l3_features/multiplier_store.py`
  - `src/main_core/l3_features/weight_api.py`
  - `src/main_core/l3_features/feature_math.py`
  - `src/main_core/l3_features/builder.py`
  - `src/main_core/l3_features/errors.py`
  - `tests/l3_features/__init__.py`
  - `tests/l3_features/conftest.py`
  - `tests/l3_features/test_multiplier_store.py`
  - `tests/l3_features/test_weight_api.py`
  - `tests/l3_features/test_builder.py`
  - `tests/integration/test_l1_l3_feature_flow.py`
- adjacent read-only / integration paths:
  - `src/main_core/l1_l2_basis/models.py`, `ports.py`, `readers.py` from #5
  - `src/main_core/common/types.py` (`CycleId`, `EntityId`)
  - `src/main_core/common/schemas/feature_bundle.py` (`FeatureSignalBundle`)
  - package/schema boundary tests from #2 and #21
- off-limits paths:
  - `src/main_core/l4_world_state/**` and higher L layers
  - `src/main_core/l1_l2_basis/**` implementation files except read-only imports
  - external `audit-eval`, `data-platform`, `graph-engine`, `reasoner-runtime` repositories.

## 3. 实现范围
- Create `src/main_core/l3_features/errors.py` with `L3FeatureError(MainCoreError)` and `InvalidMultiplierError(L3FeatureError)`.
- Create `src/main_core/l3_features/multiplier_store.py` with `@runtime_checkable class MultiplierStore(Protocol)` exposing `get_multipliers(cycle_id: CycleId | str) -> Mapping[str, float]` and `put_multipliers(cycle_id: CycleId | str, updates: Mapping[str, float]) -> None`.
- Implement `InMemo