### PR TITLE
feat(#26): [milestone-1 review] P0: L3 builder does not match the milestone public contract

### DIFF
--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -1,6 +1,6 @@
 """L3 package: feature and signal bundle assembly."""
 
-from main_core.l3_features.builder import build_feature_signal_bundle
+from main_core.l3_features.builder import build_feature_signal_bundle, build_feature_signal_bundles
 from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
 from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
 from main_core.l3_features.weight_api import (
@@ -15,5 +15,6 @@ __all__ = [
     "MultiplierStore",
     "apply_weight_multiplier",
     "build_feature_signal_bundle",
+    "build_feature_signal_bundles",
     "get_feature_weight_multiplier",
 ]

--- a/src/main_core/l3_features/builder.py
+++ b/src/main_core/l3_features/builder.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from importlib import import_module
+from os import environ
 from typing import Any
 
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
@@ -10,6 +12,7 @@ from main_core.common.types import CycleId, EntityId
 from main_core.l1_l2_basis.models import MarketBar
 from main_core.l1_l2_basis.ports import DataPlatformPort
 from main_core.l1_l2_basis.readers import read_entity_master, read_market_bars
+from main_core.l3_features.errors import L3FeatureError
 from main_core.l3_features.feature_math import (
     apply_feature_weight_multiplier,
     market_bar_feature_values,
@@ -17,19 +20,54 @@ from main_core.l3_features.feature_math import (
 from main_core.l3_features.multiplier_store import MultiplierStore
 from main_core.l3_features.weight_api import get_feature_weight_multiplier
 
+_DATA_PLATFORM_PORT_ENV = "MAIN_CORE_DATA_PLATFORM_PORT"
+
 
 def build_feature_signal_bundle(
     cycle_id: CycleId | str,
     *,
-    data_port: DataPlatformPort,
+    data_port: DataPlatformPort | None = None,
+    multiplier_store: MultiplierStore | None = None,
+    graph_impact: Mapping[str, Mapping[str, Any]] | None = None,
+    candidate_signals: Mapping[str, Mapping[str, Any]] | None = None,
+) -> FeatureSignalBundle:
+    """Build the documented single L3 feature signal bundle for a cycle.
+
+    The default data-platform port is resolved from
+    ``MAIN_CORE_DATA_PLATFORM_PORT=module:attribute``. The attribute may be either a
+    ``DataPlatformPort`` instance or a zero-argument factory returning one.
+    """
+
+    bundles = build_feature_signal_bundles(
+        cycle_id,
+        data_port=data_port,
+        multiplier_store=multiplier_store,
+        graph_impact=graph_impact,
+        candidate_signals=candidate_signals,
+    )
+    if len(bundles) == 1:
+        return bundles[0]
+    if not bundles:
+        raise L3FeatureError("cycle produced no FeatureSignalBundle records")
+    raise L3FeatureError(
+        "cycle produced multiple FeatureSignalBundle records; "
+        "call build_feature_signal_bundles for per-entity output"
+    )
+
+
+def build_feature_signal_bundles(
+    cycle_id: CycleId | str,
+    *,
+    data_port: DataPlatformPort | None = None,
     multiplier_store: MultiplierStore | None = None,
     graph_impact: Mapping[str, Mapping[str, Any]] | None = None,
     candidate_signals: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> list[FeatureSignalBundle]:
     """Build one feature signal bundle per active entity with market data."""
 
-    entity_master = read_entity_master(cycle_id, port=data_port)
-    market_bars = read_market_bars(cycle_id, port=data_port)
+    resolved_data_port = _resolve_data_platform_port(data_port)
+    entity_master = read_entity_master(cycle_id, port=resolved_data_port)
+    market_bars = read_market_bars(cycle_id, port=resolved_data_port)
     active_entity_ids = {
         str(entity.entity_id)
         for entity in entity_master
@@ -63,6 +101,35 @@ def build_feature_signal_bundle(
     return bundles
 
 
+def _resolve_data_platform_port(data_port: DataPlatformPort | None) -> DataPlatformPort:
+    if data_port is not None:
+        return data_port
+
+    port_path = environ.get(_DATA_PLATFORM_PORT_ENV)
+    if not port_path:
+        raise L3FeatureError(
+            "data_port is required unless MAIN_CORE_DATA_PLATFORM_PORT is configured"
+        )
+
+    module_name, separator, attribute_name = port_path.partition(":")
+    if not separator or not module_name or not attribute_name:
+        raise L3FeatureError(
+            "MAIN_CORE_DATA_PLATFORM_PORT must use module:attribute format"
+        )
+
+    try:
+        candidate = getattr(import_module(module_name), attribute_name)
+        resolved_port = candidate() if callable(candidate) else candidate
+    except Exception as exc:
+        raise L3FeatureError("failed to resolve default data-platform port") from exc
+
+    if not isinstance(resolved_port, DataPlatformPort):
+        raise L3FeatureError(
+            "resolved default data-platform port does not implement DataPlatformPort"
+        )
+    return resolved_port
+
+
 def _latest_market_bars_by_entity(market_bars: list[MarketBar]) -> dict[str, MarketBar]:
     latest_bars: dict[str, MarketBar] = {}
     for market_bar in market_bars:
@@ -73,4 +140,4 @@ def _latest_market_bars_by_entity(market_bars: list[MarketBar]) -> dict[str, Mar
     return latest_bars
 
 
-__all__ = ["build_feature_signal_bundle"]
+__all__ = ["build_feature_signal_bundle", "build_feature_signal_bundles"]

--- a/tests/integration/test_l1_l3_feature_flow.py
+++ b/tests/integration/test_l1_l3_feature_flow.py
@@ -8,7 +8,7 @@ from datetime import date
 
 from main_core.common.types import CycleId, EntityId
 from main_core.l1_l2_basis import CalendarDay, EntityMasterRow, MarketBar
-from main_core.l3_features import build_feature_signal_bundle
+from main_core.l3_features import build_feature_signal_bundles
 
 
 @dataclass
@@ -56,7 +56,7 @@ def test_pure_market_l1_to_l3_flow_without_graph_or_candidate_signals() -> None:
         ),
     )
 
-    bundles = build_feature_signal_bundle(cycle_id, data_port=port)
+    bundles = build_feature_signal_bundles(cycle_id, data_port=port)
 
     assert len(bundles) == 1
     assert bundles[0].cycle_id == cycle_id

--- a/tests/l3_features/test_builder.py
+++ b/tests/l3_features/test_builder.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import date
 from sys import float_info
+from types import ModuleType
 
 import pytest
 
@@ -13,8 +15,10 @@ from main_core.l1_l2_basis import EntityMasterRow, MarketBar
 from main_core.l3_features import (
     InMemoryMultiplierStore,
     InvalidMultiplierError,
+    L3FeatureError,
     apply_weight_multiplier,
     build_feature_signal_bundle,
+    build_feature_signal_bundles,
 )
 from main_core.l3_features.feature_math import (
     apply_feature_weight_multiplier,
@@ -143,7 +147,7 @@ def test_build_feature_signal_bundle_uses_latest_market_bar_and_sorts_by_entity(
         entity_master=(msft, inactive, aapl),
     )
 
-    bundles = build_feature_signal_bundle(
+    bundles = build_feature_signal_bundles(
         cycle_id,
         data_port=port,
         multiplier_store=store,
@@ -185,7 +189,7 @@ def test_build_feature_signal_bundle_defaults_optional_inputs_to_empty_dicts(
         entity_master=(active_entity,),
     )
 
-    bundles = build_feature_signal_bundle(cycle_id, data_port=port)
+    bundles = build_feature_signal_bundles(cycle_id, data_port=port)
 
     assert len(bundles) == 1
     assert bundles[0].cycle_id == cycle_id
@@ -221,7 +225,73 @@ def test_default_multiplier_store_update_is_visible_to_same_cycle_build() -> Non
 
     apply_weight_multiplier(cycle_id, {"close_price": UPDATED_CLOSE_MULTIPLIER})
 
-    bundles = build_feature_signal_bundle(cycle_id, data_port=port)
+    bundles = build_feature_signal_bundles(cycle_id, data_port=port)
 
     assert bundles[0].feature_values["close_price"] == UPDATED_CLOSE_PRICE
     assert bundles[0].feature_weight_multiplier["close_price"] == UPDATED_CLOSE_MULTIPLIER
+
+
+def test_build_feature_signal_bundle_resolves_default_port_and_returns_single_bundle(
+    cycle_id: CycleId,
+    active_entity: EntityMasterRow,
+    market_bar: MarketBar,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(active_entity,),
+    )
+    module = ModuleType("fake_l3_data_platform")
+    module.build_port = lambda: port
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setenv("MAIN_CORE_DATA_PLATFORM_PORT", f"{module.__name__}:build_port")
+
+    bundle = build_feature_signal_bundle(cycle_id)
+
+    assert isinstance(bundle, FeatureSignalBundle)
+    assert bundle.cycle_id == cycle_id
+    assert bundle.entity_id == active_entity.entity_id
+    assert port.entity_master_calls == [cycle_id]
+    assert port.market_bar_calls == [cycle_id]
+
+
+def test_build_feature_signal_bundle_rejects_ambiguous_multi_entity_cycle(
+    cycle_id: CycleId,
+) -> None:
+    aapl = EntityMasterRow(
+        entity_id=EntityId("ENT_AAPL"),
+        ticker="AAPL",
+        name="Apple Inc.",
+        exchange="NASDAQ",
+    )
+    msft = EntityMasterRow(
+        entity_id=EntityId("ENT_MSFT"),
+        ticker="MSFT",
+        name="Microsoft Corp.",
+        exchange="NASDAQ",
+    )
+    port = FakeDataPlatformPort(
+        entity_master=(aapl, msft),
+        market_bars=(
+            MarketBar(
+                cycle_id=cycle_id,
+                entity_id=aapl.entity_id,
+                as_of_date=date(2026, 4, 17),
+                close_price=100.0,
+                volume=1000.0,
+            ),
+            MarketBar(
+                cycle_id=cycle_id,
+                entity_id=msft.entity_id,
+                as_of_date=date(2026, 4, 17),
+                close_price=200.0,
+                volume=2000.0,
+            ),
+        ),
+    )
+
+    with pytest.raises(L3FeatureError, match="multiple FeatureSignalBundle"):
+        build_feature_signal_bundle(cycle_id, data_port=port)
+
+    bundles = build_feature_signal_bundles(cycle_id, data_port=port)
+    assert [bundle.entity_id for bundle in bundles] == ["ENT_AAPL", "ENT_MSFT"]


### PR DESCRIPTION
Closes #26

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/builder.py`, `src/main_core/l3_features/feature_math.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
## 背景与目标
Milestone review for milestone-1 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The project contract and ISSUE-005 specify build_feature_signal_bundle(cycle_id) as the L3 entry point and describe the output as FeatureSignalBundle, but the implementation requires a keyword-only data_port and returns list[FeatureSignalBundle]. This leaves downstream milestone-2 components with no stable callable or cardinality contract: L4/L5/L6 cannot know whether they consume one bundle, a per-entity list, or a future aggregate object, and calling the documented API without a port will fail.

## 实现范围
- 修改文件: `src/main_core/l3_features/builder.py`
- Stabilize the public API before milestone-2: either implement a documented default data-platform port resolver so build_feature_signal_bundle(cycle_id) works, or explicitly update the project contract and next milestone specs to require dependency injection. Also settle cardinality by returning the documented FeatureSignalBundle shape or introducing a clearly named aggregate/list API such as build_feature_signal_bundles with downstream tests.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
