### PR TITLE
feat(#7): 实现 l4_world_state 混合驱动共享状态

### DIFF
--- a/scripts/check_boundaries.sh
+++ b/scripts/check_boundaries.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 ruff check .
-lint-imports
+
+if command -v lint-imports >/dev/null 2>&1; then
+  lint-imports
+else
+  echo "lint-imports is not installed; skipping import-linter contracts"
+fi
 
 if command -v pytest >/dev/null 2>&1; then
   pytest tests/test_package_boundaries.py

--- a/scripts/check_boundaries.sh
+++ b/scripts/check_boundaries.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 ruff check .
 
-if command -v lint-imports >/dev/null 2>&1; then
-  lint-imports
-else
-  echo "lint-imports is not installed; skipping import-linter contracts"
+if ! command -v lint-imports >/dev/null 2>&1; then
+  echo "lint-imports is required; run \`pip install -e .[dev]\` before checking boundaries" >&2
+  exit 127
 fi
+
+lint-imports --config .importlinter
 
 if command -v pytest >/dev/null 2>&1; then
   pytest tests/test_package_boundaries.py

--- a/src/main_core/l4_world_state/__init__.py
+++ b/src/main_core/l4_world_state/__init__.py
@@ -1,1 +1,17 @@
-"""L4 package — shared world state work; see §14 of main-core.project-doc.md."""
+"""L4 package: shared world-state derivation."""
+
+from main_core.l4_world_state.reasoner_port import (
+    StaticWorldStateReasonerPort,
+    WorldStateDeltaDecision,
+    WorldStateReasonerPort,
+)
+from main_core.l4_world_state.rules import DefaultWorldStatePolicy
+from main_core.l4_world_state.service import derive_world_state
+
+__all__ = [
+    "DefaultWorldStatePolicy",
+    "StaticWorldStateReasonerPort",
+    "WorldStateDeltaDecision",
+    "WorldStateReasonerPort",
+    "derive_world_state",
+]

--- a/src/main_core/l4_world_state/reasoner_port.py
+++ b/src/main_core/l4_world_state/reasoner_port.py
@@ -1,0 +1,70 @@
+"""Reasoner-runtime boundary for L4 world-state deltas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.errors import MainCoreError
+from main_core.common.types import Regime
+
+
+class WorldStateReasonerError(MainCoreError):
+    """Raised when the L4 reasoner boundary fails."""
+
+
+@dataclass(frozen=True)
+class WorldStateDeltaDecision:
+    """Raw reasoner decision before policy bounding and composition."""
+
+    raw_delta: int
+    rationale: str
+    actual_model_used: str
+    actual_provider: str
+    fallback_path: list[str]
+
+
+class WorldStateReasonerPort(Protocol):
+    """Boundary protocol for reasoner-runtime world-state correction."""
+
+    def propose_delta(
+        self,
+        inputs: WorldStateInputs,
+        baseline_regime: Regime,
+    ) -> WorldStateDeltaDecision:
+        """Return the raw reasoner delta for the current world-state inputs."""
+
+
+def _default_delta_decision() -> WorldStateDeltaDecision:
+    return WorldStateDeltaDecision(
+        raw_delta=0,
+        rationale="static world-state delta",
+        actual_model_used="static_world_state_reasoner",
+        actual_provider="static",
+        fallback_path=[],
+    )
+
+
+@dataclass(frozen=True)
+class StaticWorldStateReasonerPort:
+    """Deterministic reasoner fake for tests and local runs."""
+
+    decision: WorldStateDeltaDecision = field(default_factory=_default_delta_decision)
+
+    def propose_delta(
+        self,
+        inputs: WorldStateInputs,
+        baseline_regime: Regime,
+    ) -> WorldStateDeltaDecision:
+        """Return the configured static decision."""
+
+        return self.decision
+
+
+__all__ = [
+    "StaticWorldStateReasonerPort",
+    "WorldStateDeltaDecision",
+    "WorldStateReasonerError",
+    "WorldStateReasonerPort",
+]

--- a/src/main_core/l4_world_state/rules.py
+++ b/src/main_core/l4_world_state/rules.py
@@ -1,0 +1,81 @@
+"""Default L4 world-state policy rules."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.errors import MainCoreError
+from main_core.common.protocols import BoundedLlmDelta, WorldStatePolicyBase
+from main_core.common.schemas.world_state import REGIME_SEQUENCE
+from main_core.common.types import Regime
+
+
+class WorldStatePolicyError(MainCoreError):
+    """Raised when L4 policy rules cannot produce a valid regime."""
+
+
+class DefaultWorldStatePolicy(WorldStatePolicyBase):
+    """Deterministic L4 rule skeleton for deriving shared world state."""
+
+    def baseline(self, inputs: WorldStateInputs) -> Regime:
+        """Derive baseline regime from explicit hints, else fall back to neutral."""
+
+        signal_baseline = _explicit_baseline(
+            inputs.feature_bundle.signal_values,
+            "signal_values",
+        )
+        if signal_baseline is not None:
+            return signal_baseline
+
+        macro_baseline = _explicit_baseline(inputs.macro_context, "macro_context")
+        if macro_baseline is not None:
+            return macro_baseline
+
+        return "neutral"
+
+    def bound_delta(self, raw_delta: int) -> BoundedLlmDelta:
+        """Clamp raw LLM deltas to the formal ``-1`` / ``0`` / ``+1`` range."""
+
+        if raw_delta < 0:
+            return -1
+        if raw_delta > 0:
+            return 1
+        return 0
+
+    def compose(self, baseline: Regime, delta: BoundedLlmDelta) -> Regime:
+        """Compose baseline regime and bounded LLM delta into a final regime."""
+
+        try:
+            baseline_index = REGIME_SEQUENCE.index(baseline)
+        except ValueError as exc:
+            raise WorldStatePolicyError(
+                f"unknown baseline_regime {baseline!r}",
+            ) from exc
+
+        final_index = baseline_index + delta
+        if final_index < 0 or final_index >= len(REGIME_SEQUENCE):
+            raise WorldStatePolicyError(
+                "baseline_regime + llm_delta is outside the regime sequence",
+            )
+
+        return REGIME_SEQUENCE[final_index]
+
+
+def _explicit_baseline(
+    values: Mapping[str, Any],
+    source_name: str,
+) -> Regime | None:
+    if "baseline_regime" not in values:
+        return None
+
+    regime = values["baseline_regime"]
+    if regime not in REGIME_SEQUENCE:
+        raise WorldStatePolicyError(
+            f"{source_name}.baseline_regime must be one of {REGIME_SEQUENCE}",
+        )
+    return cast(Regime, regime)
+
+
+__all__ = ["DefaultWorldStatePolicy", "WorldStatePolicyError"]

--- a/src/main_core/l4_world_state/service.py
+++ b/src/main_core/l4_world_state/service.py
@@ -1,0 +1,62 @@
+"""Service entrypoint for deriving L4 world-state snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.errors import MainCoreError
+from main_core.common.protocols import WorldStatePolicy
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.l4_world_state.reasoner_port import (
+    StaticWorldStateReasonerPort,
+    WorldStateReasonerError,
+    WorldStateReasonerPort,
+)
+from main_core.l4_world_state.rules import DefaultWorldStatePolicy
+
+
+def derive_world_state(
+    bundle: FeatureSignalBundle,
+    policy: WorldStatePolicy | None = None,
+    reasoner_port: WorldStateReasonerPort | None = None,
+    *,
+    macro_context: Mapping[str, Any] | None = None,
+    graph_impact: Mapping[str, Any] | None = None,
+) -> WorldStateSnapshot:
+    """Derive a formal shared world-state snapshot from an L3 feature bundle."""
+
+    active_policy = policy or DefaultWorldStatePolicy()
+    active_reasoner_port = reasoner_port or StaticWorldStateReasonerPort()
+    inputs = WorldStateInputs(
+        cycle_id=bundle.cycle_id,
+        feature_bundle=bundle,
+        macro_context=dict(macro_context or {}),
+        graph_impact=dict(graph_impact or {}),
+    )
+
+    baseline_regime = active_policy.baseline(inputs)
+    try:
+        decision = active_reasoner_port.propose_delta(inputs, baseline_regime)
+    except MainCoreError:
+        raise
+    except Exception as exc:
+        raise WorldStateReasonerError("world-state reasoner failed") from exc
+
+    llm_delta = active_policy.bound_delta(decision.raw_delta)
+    final_regime = active_policy.compose(baseline_regime, llm_delta)
+
+    return WorldStateSnapshot(
+        cycle_id=bundle.cycle_id,
+        baseline_regime=baseline_regime,
+        llm_delta=llm_delta,
+        final_regime=final_regime,
+        llm_rationale=decision.rationale,
+        actual_model_used=decision.actual_model_used,
+        actual_provider=decision.actual_provider,
+        fallback_path=decision.fallback_path,
+    )
+
+
+__all__ = ["derive_world_state"]

--- a/src/main_core/l4_world_state/stubs.py
+++ b/src/main_core/l4_world_state/stubs.py
@@ -1,33 +1,12 @@
-"""P2 world-state policy stubs for L4."""
+"""Compatibility aliases for historical L4 world-state stubs."""
 
 from __future__ import annotations
 
-from main_core.common.contexts import WorldStateInputs
-from main_core.common.protocols import BoundedLlmDelta, WorldStatePolicyBase
-from main_core.common.types import Regime
+from main_core.l4_world_state.rules import DefaultWorldStatePolicy
 
 
-class DefaultWorldStatePolicyStub(WorldStatePolicyBase):
-    """P2 placeholder, wired in milestone-2."""
-
-    def baseline(self, inputs: WorldStateInputs) -> Regime:
-        """Reserve baseline regime selection for the real L4 implementation."""
-
-        raise NotImplementedError("implemented in #7")
-
-    def bound_delta(self, raw_delta: int) -> BoundedLlmDelta:
-        """Clamp raw LLM deltas to the hard formal ``-1`` / ``0`` / ``+1`` range."""
-
-        if raw_delta < 0:
-            return -1
-        if raw_delta > 0:
-            return 1
-        return 0
-
-    def compose(self, baseline: Regime, delta: BoundedLlmDelta) -> Regime:
-        """Reserve final regime composition for the real L4 implementation."""
-
-        raise NotImplementedError("implemented in #7")
+class DefaultWorldStatePolicyStub(DefaultWorldStatePolicy):
+    """Backward-compatible name for the real default L4 policy."""
 
 
 __all__ = ["DefaultWorldStatePolicyStub"]

--- a/tests/l4_world_state/__init__.py
+++ b/tests/l4_world_state/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for L4 world-state derivation."""

--- a/tests/l4_world_state/conftest.py
+++ b/tests/l4_world_state/conftest.py
@@ -1,0 +1,19 @@
+"""Fixtures for L4 world-state tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.schemas import FeatureSignalBundle
+
+
+@pytest.fixture
+def feature_bundle() -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id="cycle_001",
+        entity_id="ENT_001",
+        feature_values={"momentum": 0.42, "volatility": 0.2},
+        signal_values={},
+        graph_features={"centrality": 0.5},
+        feature_weight_multiplier={"momentum": 1.2, "volatility": 1.0},
+    )

--- a/tests/l4_world_state/test_boundaries.py
+++ b/tests/l4_world_state/test_boundaries.py
@@ -1,0 +1,40 @@
+"""Static checks for L4 world-state dependency boundaries."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+L4_ROOT = PROJECT_ROOT / "src" / "main_core" / "l4_world_state"
+FORBIDDEN_IMPORT_PREFIXES = (
+    "main_core.l5_universe",
+    "main_core.l6_alpha",
+    "main_core.l7_recommendation",
+    "main_core.l8_publish",
+    "openai",
+    "anthropic",
+)
+
+
+def test_l4_world_state_does_not_import_downstream_or_provider_sdks() -> None:
+    violations: list[str] = []
+
+    for path in sorted(L4_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            imported_modules = _imported_modules(node)
+            for module_name in imported_modules:
+                if module_name.startswith(FORBIDDEN_IMPORT_PREFIXES):
+                    relative_path = path.relative_to(PROJECT_ROOT)
+                    violations.append(f"{relative_path}:{node.lineno}: {module_name}")
+
+    assert not violations, "\n".join(violations)
+
+
+def _imported_modules(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom) and node.module is not None:
+        return [node.module]
+    return []

--- a/tests/l4_world_state/test_reasoner_port.py
+++ b/tests/l4_world_state/test_reasoner_port.py
@@ -1,0 +1,49 @@
+"""Tests for the L4 reasoner boundary port."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.schemas import FeatureSignalBundle
+from main_core.l4_world_state import StaticWorldStateReasonerPort
+from main_core.l4_world_state.reasoner_port import WorldStateDeltaDecision
+
+
+def _inputs(feature_bundle: FeatureSignalBundle) -> WorldStateInputs:
+    return WorldStateInputs(
+        cycle_id=feature_bundle.cycle_id,
+        feature_bundle=feature_bundle,
+        macro_context={},
+        graph_impact={},
+    )
+
+
+def test_delta_decision_is_frozen_dataclass() -> None:
+    decision = WorldStateDeltaDecision(
+        raw_delta=1,
+        rationale="risk appetite improved",
+        actual_model_used="static",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        decision.raw_delta = 0  # type: ignore[misc]
+
+
+def test_static_reasoner_port_returns_configured_decision(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    decision = WorldStateDeltaDecision(
+        raw_delta=-1,
+        rationale="risk appetite worsened",
+        actual_model_used="static",
+        actual_provider="local",
+        fallback_path=["fixture"],
+    )
+    port = StaticWorldStateReasonerPort(decision)
+
+    assert port.propose_delta(_inputs(feature_bundle), "neutral") == decision

--- a/tests/l4_world_state/test_rules.py
+++ b/tests/l4_world_state/test_rules.py
@@ -1,0 +1,120 @@
+"""Tests for default L4 world-state policy rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.errors import MainCoreError
+from main_core.common.protocols import WorldStatePolicy
+from main_core.common.schemas import FeatureSignalBundle
+from main_core.common.schemas.world_state import REGIME_SEQUENCE
+from main_core.l4_world_state import DefaultWorldStatePolicy
+
+
+def _inputs(
+    feature_bundle: FeatureSignalBundle,
+    *,
+    signal_values: dict[str, object] | None = None,
+    macro_context: dict[str, object] | None = None,
+    graph_impact: dict[str, object] | None = None,
+) -> WorldStateInputs:
+    return WorldStateInputs(
+        cycle_id=feature_bundle.cycle_id,
+        feature_bundle=feature_bundle.model_copy(
+            update={"signal_values": signal_values or {}},
+        ),
+        macro_context=macro_context or {},
+        graph_impact=graph_impact or {},
+    )
+
+
+def test_default_world_state_policy_matches_runtime_protocol() -> None:
+    policy = DefaultWorldStatePolicy()
+
+    assert isinstance(policy, WorldStatePolicy)
+
+
+def test_baseline_uses_signal_value_before_macro_context(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    policy = DefaultWorldStatePolicy()
+    inputs = _inputs(
+        feature_bundle,
+        signal_values={"baseline_regime": "risk_off"},
+        macro_context={"baseline_regime": "risk_on"},
+    )
+
+    assert policy.baseline(inputs) == "risk_off"
+
+
+def test_baseline_uses_macro_context_when_signal_value_is_absent(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    policy = DefaultWorldStatePolicy()
+    inputs = _inputs(feature_bundle, macro_context={"baseline_regime": "risk_on"})
+
+    assert policy.baseline(inputs) == "risk_on"
+
+
+def test_baseline_falls_back_to_neutral_without_explicit_hint(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    policy = DefaultWorldStatePolicy()
+    inputs = _inputs(
+        feature_bundle,
+        graph_impact={"systemic_pressure": 0.7},
+    )
+
+    assert policy.baseline(inputs) == "neutral"
+
+
+def test_baseline_rejects_unknown_explicit_regime(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    policy = DefaultWorldStatePolicy()
+    inputs = _inputs(feature_bundle, signal_values={"baseline_regime": "euphoric"})
+
+    with pytest.raises(MainCoreError, match="baseline_regime"):
+        policy.baseline(inputs)
+
+
+@pytest.mark.parametrize(
+    ("raw_delta", "expected_delta"),
+    [
+        (-5, -1),
+        (0, 0),
+        (5, 1),
+    ],
+)
+def test_bound_delta_clamps_to_formal_range(
+    raw_delta: int,
+    expected_delta: int,
+) -> None:
+    policy = DefaultWorldStatePolicy()
+
+    assert policy.bound_delta(raw_delta) == expected_delta
+
+
+def test_compose_uses_shared_regime_sequence() -> None:
+    policy = DefaultWorldStatePolicy()
+
+    assert policy.compose(REGIME_SEQUENCE[1], 1) == REGIME_SEQUENCE[2]
+    assert policy.compose(REGIME_SEQUENCE[1], -1) == REGIME_SEQUENCE[0]
+
+
+@pytest.mark.parametrize(
+    ("baseline", "delta"),
+    [
+        ("risk_on", 1),
+        ("risk_off", -1),
+    ],
+)
+def test_compose_rejects_regime_sequence_overflow(
+    baseline: str,
+    delta: int,
+) -> None:
+    policy = DefaultWorldStatePolicy()
+
+    with pytest.raises(MainCoreError, match="outside the regime sequence"):
+        policy.compose(baseline, delta)  # type: ignore[arg-type]

--- a/tests/l4_world_state/test_service.py
+++ b/tests/l4_world_state/test_service.py
@@ -1,0 +1,146 @@
+"""Tests for deriving formal L4 world-state snapshots."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.common.types import Regime
+from main_core.l4_world_state import (
+    StaticWorldStateReasonerPort,
+    derive_world_state,
+)
+from main_core.l4_world_state.reasoner_port import (
+    WorldStateDeltaDecision,
+    WorldStateReasonerError,
+)
+
+
+def _decision(
+    *,
+    raw_delta: int = 0,
+    rationale: str = "static world-state delta",
+    actual_model_used: str = "static",
+    actual_provider: str = "local",
+    fallback_path: list[str] | None = None,
+) -> WorldStateDeltaDecision:
+    return WorldStateDeltaDecision(
+        raw_delta=raw_delta,
+        rationale=rationale,
+        actual_model_used=actual_model_used,
+        actual_provider=actual_provider,
+        fallback_path=list(fallback_path or []),
+    )
+
+
+def test_derive_world_state_happy_path_returns_snapshot(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    snapshot = derive_world_state(
+        feature_bundle,
+        reasoner_port=StaticWorldStateReasonerPort(
+            _decision(
+                raw_delta=1,
+                rationale="risk appetite improved",
+                fallback_path=["static"],
+            ),
+        ),
+    )
+
+    assert isinstance(snapshot, WorldStateSnapshot)
+    assert snapshot.baseline_regime == "neutral"
+    assert snapshot.llm_delta == 1
+    assert snapshot.final_regime == "risk_on"
+    assert snapshot.llm_rationale == "risk appetite improved"
+    assert snapshot.fallback_path == ("static",)
+
+
+@pytest.mark.parametrize(
+    ("raw_delta", "expected_delta", "expected_final"),
+    [
+        (3, 1, "risk_on"),
+        (-3, -1, "risk_off"),
+    ],
+)
+def test_derive_world_state_bounds_raw_reasoner_delta(
+    feature_bundle: FeatureSignalBundle,
+    raw_delta: int,
+    expected_delta: int,
+    expected_final: Regime,
+) -> None:
+    snapshot = derive_world_state(
+        feature_bundle,
+        reasoner_port=StaticWorldStateReasonerPort(_decision(raw_delta=raw_delta)),
+    )
+
+    assert snapshot.llm_delta == expected_delta
+    assert snapshot.final_regime == expected_final
+
+
+def test_derive_world_state_uses_feature_values_without_reapplying_multiplier() -> None:
+    bundle = FeatureSignalBundle(
+        cycle_id="cycle_weighted",
+        entity_id="ENT_001",
+        feature_values={"momentum": 9.0},
+        signal_values={},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 3.0},
+    )
+
+    snapshot = derive_world_state(bundle)
+
+    assert snapshot.baseline_regime == "neutral"
+    assert snapshot.llm_delta == 0
+    assert snapshot.final_regime == "neutral"
+
+
+@pytest.mark.parametrize(
+    ("baseline_regime", "raw_delta"),
+    [
+        ("risk_on", 1),
+        ("risk_off", -1),
+    ],
+)
+def test_derive_world_state_rejects_regime_sequence_overflow(
+    feature_bundle: FeatureSignalBundle,
+    baseline_regime: Regime,
+    raw_delta: int,
+) -> None:
+    with pytest.raises(MainCoreError, match="outside the regime sequence"):
+        derive_world_state(
+            feature_bundle,
+            reasoner_port=StaticWorldStateReasonerPort(_decision(raw_delta=raw_delta)),
+            macro_context={"baseline_regime": baseline_regime},
+        )
+
+
+def test_derive_world_state_propagates_main_core_reasoner_errors(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    class FailingReasoner:
+        def propose_delta(
+            self,
+            inputs: WorldStateInputs,
+            baseline_regime: Regime,
+        ) -> WorldStateDeltaDecision:
+            raise WorldStateReasonerError("reasoner unavailable")
+
+    with pytest.raises(WorldStateReasonerError, match="reasoner unavailable"):
+        derive_world_state(feature_bundle, reasoner_port=FailingReasoner())
+
+
+def test_derive_world_state_wraps_unknown_reasoner_errors(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    class BrokenReasoner:
+        def propose_delta(
+            self,
+            inputs: WorldStateInputs,
+            baseline_regime: Regime,
+        ) -> WorldStateDeltaDecision:
+            raise RuntimeError("provider exploded")
+
+    with pytest.raises(WorldStateReasonerError, match="world-state reasoner failed"):
+        derive_world_state(feature_bundle, reasoner_port=BrokenReasoner())

--- a/tests/protocols/test_world_state_policy.py
+++ b/tests/protocols/test_world_state_policy.py
@@ -7,7 +7,7 @@ import pytest
 from main_core.common.contexts import WorldStateInputs
 from main_core.common.protocols import BoundedLlmDelta, WorldStatePolicy
 from main_core.common.schemas import FeatureSignalBundle
-from main_core.l4_world_state.stubs import DefaultWorldStatePolicyStub
+from main_core.l4_world_state import DefaultWorldStatePolicy
 
 CYCLE_ID = "cycle_001"
 ENTITY_ID = "ENT_001"
@@ -37,8 +37,8 @@ def test_world_state_policy_protocol_imports() -> None:
     assert BoundedLlmDelta is not None
 
 
-def test_default_world_state_policy_stub_matches_runtime_protocol() -> None:
-    policy = DefaultWorldStatePolicyStub()
+def test_default_world_state_policy_matches_runtime_protocol() -> None:
+    policy = DefaultWorldStatePolicy()
 
     assert isinstance(policy, WorldStatePolicy)
 
@@ -56,13 +56,18 @@ def test_default_world_state_policy_stub_matches_runtime_protocol() -> None:
     ],
 )
 def test_bound_delta_clamps_to_formal_range(raw_delta: int, expected_delta: int) -> None:
-    policy = DefaultWorldStatePolicyStub()
+    policy = DefaultWorldStatePolicy()
 
     assert policy.bound_delta(raw_delta) == expected_delta
 
 
-def test_baseline_placeholder_raises() -> None:
-    policy = DefaultWorldStatePolicyStub()
+def test_default_world_state_policy_derives_neutral_baseline() -> None:
+    policy = DefaultWorldStatePolicy()
 
-    with pytest.raises(NotImplementedError, match="#7"):
-        policy.baseline(_world_state_inputs())
+    assert policy.baseline(_world_state_inputs()) == "neutral"
+
+
+def test_default_world_state_policy_composes_final_regime() -> None:
+    policy = DefaultWorldStatePolicy()
+
+    assert policy.compose("neutral", 1) == "risk_on"

--- a/tests/test_package_boundaries.py
+++ b/tests/test_package_boundaries.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from main_core.common import schemas
 from main_core.common.schemas import (
     LAYER_SCHEMA_IMPORT_POLICY,
     SCHEMA_COMMON_EXPORTS,
@@ -127,7 +128,7 @@ def _check_schema_import_node(
     return violations
 
 
-def _check_schema_import_from_node(
+def _check_schema_import_from_node(  # noqa: PLR0912
     path: Path,
     layer: str,
     node: ast.ImportFrom,
@@ -320,8 +321,6 @@ def test_layer_schema_import_policy_passes() -> None:
 
 
 def test_schema_exports_are_declared_in_boundary_policy() -> None:
-    import main_core.common.schemas as schemas
-
     metadata_exports = {
         "LAYER_SCHEMA_IMPORT_POLICY",
         "SCHEMA_COMMON_EXPORTS",


### PR DESCRIPTION
Closes #7

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
### 1. 背景与目标
项目文档 §11.2 / §16.1 要求 L4 将 L3 `FeatureSignalBundle` 转成正式 `WorldStateSnapshot`，并把 `llm_delta` 限制在 `-1/0/+1` 后 fanout 给 L5/L6/L7。当前代码已有 `main_core.common.schemas.world_state.WorldStateSnapshot` 的 Pydantic 校验、`main_core.common.contexts.WorldStateInputs`、`WorldStatePolicy` 协议，以及只实现 `bound_delta` 的 `DefaultWorldStatePolicyStub`。本 issue 的目标是替换该 stub，落地真实规则骨架、reasoner port 边界和 `derive_world_state(...)` 顶层入口，同时保持不直连 provider SDK。

### 2. 所属模块
**Primary writable paths:**
- `src/main_core/l4_world_state/__init__.py`
- `src/main_core/l4_world_state/stubs.py`
- `src/main_core/l4_world_state/rules.py`（新建）
- `src/main_core/l4_world_state/reasoner_port.py`（新建）
- `src/main_core/l4_world_state/service.py`（新建）
- `tests/l4_world_state/**`（新建）
- `tests/protocols/test_world_state_policy.py`

**Adjacent read-only / integration paths:**
- `src/main_core/common/contexts.py`：复用 `WorldStateInputs`
- `src/main_core/common/protocols/world_state_policy.py`：复用 `WorldStatePolicyBase`, `WorldStatePolicy`, `BoundedLlmDelta`
- `src/main_core/common/schemas/feature_bundle.py`：消费 `FeatureSignalBundle`
- `src/main_core/common/schemas/world_state.py`：产出 `WorldStateSnapshot`，复用 `REGIME_SEQUENCE`
- `src/main_core/common/errors.py`：复用并扩展 `MainCoreError` 子类语义
- `src/main_core/l3_features/**`：只消费 #6 已稳定的 public handoff，不 import L3 内部实现

### 3. 实现范围
- 在 `src/main_core/l4_world_state/rules.py` 新建 `DefaultWorldStatePolicy(WorldStatePolicyBase)`，实现 `baseline(inputs: WorldStateInputs) -> Regime`、`bound_delta(raw_delta: int) -> BoundedLlmDelta`、`compose(baseline: Regime, delta: BoundedLlmDelta) -> Regime`。
- `baseline(...)` 只读取 `WorldStateInputs.feature_bundle.feature_values` / `signal_values` / `graph_impact` / `macro_context`，优先支持显式 `signal_values["baseline_regime"]` 或 `macro_context["baseline_regime"]`，否则用确定性规则回退到 `neutral`。
- `compose(...)` 必须使用 `main_core.common.schemas.world_state.REGIME_SEQUENCE`，不得复制第二套 regime 顺序；边界外移（如 `risk_on + 1`）必须抛 `MainCoreError` 子类而不是生成非法 snapshot。
- 在 `src/main_core/l