### PR TITLE
feat(#8): 实现 l5_universe 正式池选择与冻结

### DIFF
--- a/src/main_core/l5_universe/__init__.py
+++ b/src/main_core/l5_universe/__init__.py
@@ -1,1 +1,12 @@
 """L5 package — observation and core pool work; see §14 of main-core.project-doc.md."""
+
+from main_core.l5_universe.rules import rank_candidates, score_candidate
+from main_core.l5_universe.service import select_official_alpha_pool
+from main_core.l5_universe.types import PoolSelectionConfig
+
+__all__ = [
+    "PoolSelectionConfig",
+    "rank_candidates",
+    "score_candidate",
+    "select_official_alpha_pool",
+]

--- a/src/main_core/l5_universe/freezer.py
+++ b/src/main_core/l5_universe/freezer.py
@@ -1,0 +1,51 @@
+"""Frozen entity handling for L5 official alpha pool selection."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas.pool import OfficialAlphaPool
+from main_core.common.types import EntityId
+
+
+def merge_frozen_entities(
+    previous_pool: OfficialAlphaPool | None,
+    frozen_entities: Mapping[EntityId, str] | None,
+) -> dict[EntityId, str]:
+    """Merge previous and explicit freeze reasons without rewriting prior reasons."""
+
+    merged: dict[EntityId, str] = {}
+
+    if previous_pool is not None:
+        previous_freeze_reason_map = dict(previous_pool.freeze_reason_map)
+        for entity_id in previous_pool.selected_entities:
+            if entity_id in previous_freeze_reason_map:
+                merged[EntityId(str(entity_id))] = previous_freeze_reason_map[entity_id]
+
+        for entity_id, reason in sorted(
+            previous_freeze_reason_map.items(),
+            key=lambda item: str(item[0]),
+        ):
+            merged.setdefault(EntityId(str(entity_id)), reason)
+
+    for entity_id, reason in sorted(
+        dict(frozen_entities or {}).items(),
+        key=lambda item: str(item[0]),
+    ):
+        merged.setdefault(EntityId(str(entity_id)), reason)
+
+    return merged
+
+
+def ensure_frozen_entities_fit_capacity(
+    freeze_reason_map: Mapping[EntityId, str],
+    capacity: int,
+) -> None:
+    """Reject pools where frozen entities alone would exceed capacity."""
+
+    if len(freeze_reason_map) > capacity:
+        raise MainCoreError("frozen entity count exceeds official_alpha_pool_capacity")
+
+
+__all__ = ["ensure_frozen_entities_fit_capacity", "merge_frozen_entities"]

--- a/src/main_core/l5_universe/rules.py
+++ b/src/main_core/l5_universe/rules.py
@@ -1,0 +1,59 @@
+"""Deterministic L5 scoring and ranking rules."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.schemas.world_state import WorldStateSnapshot
+from main_core.l5_universe.types import PoolSelectionConfig
+
+
+def score_candidate(
+    bundle: FeatureSignalBundle,
+    world_state: WorldStateSnapshot,
+) -> float:
+    """Score one candidate using already-finalized L3 feature semantics."""
+
+    del world_state
+
+    if "candidate_score" in bundle.signal_values:
+        return float(bundle.signal_values["candidate_score"])
+    if "alpha_score" in bundle.feature_values:
+        return float(bundle.feature_values["alpha_score"])
+    if "momentum" in bundle.feature_values:
+        return float(bundle.feature_values["momentum"])
+    return 0.0
+
+
+def rank_candidates(
+    world_state: WorldStateSnapshot,
+    bundles: Sequence[FeatureSignalBundle],
+    config: PoolSelectionConfig,
+) -> list[FeatureSignalBundle]:
+    """Rank observation candidates by score descending and entity_id ascending."""
+
+    scored_candidates = [
+        (score_candidate(bundle, world_state), bundle)
+        for bundle in bundles
+    ]
+    if config.min_candidate_score is not None:
+        scored_candidates = [
+            (score, bundle)
+            for score, bundle in scored_candidates
+            if score >= config.min_candidate_score
+        ]
+
+    ranked_candidates = [
+        bundle
+        for _score, bundle in sorted(
+            scored_candidates,
+            key=lambda scored: (-scored[0], str(scored[1].entity_id)),
+        )
+    ]
+    if config.observation_limit is None:
+        return ranked_candidates
+    return ranked_candidates[: config.observation_limit]
+
+
+__all__ = ["rank_candidates", "score_candidate"]

--- a/src/main_core/l5_universe/service.py
+++ b/src/main_core/l5_universe/service.py
@@ -1,0 +1,141 @@
+"""Service entrypoint for selecting the formal L5 official alpha pool."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.schemas.pool import OfficialAlphaPool
+from main_core.common.schemas.world_state import WorldStateSnapshot
+from main_core.common.types import EntityId
+from main_core.l5_universe.freezer import (
+    ensure_frozen_entities_fit_capacity,
+    merge_frozen_entities,
+)
+from main_core.l5_universe.rules import rank_candidates
+from main_core.l5_universe.types import PoolSelectionConfig
+
+
+def select_official_alpha_pool(  # noqa: PLR0913
+    world_state: WorldStateSnapshot,
+    bundles: Sequence[FeatureSignalBundle],
+    *,
+    previous_pool: OfficialAlphaPool | None = None,
+    capacity: int = 100,
+    frozen_entities: Mapping[EntityId, str] | None = None,
+    config: PoolSelectionConfig | None = None,
+) -> OfficialAlphaPool:
+    """Select the formal official alpha pool for one cycle."""
+
+    active_config = config or PoolSelectionConfig(capacity=capacity)
+    bundle_list = list(bundles)
+    _validate_inputs(world_state, bundle_list)
+
+    freeze_reason_map = merge_frozen_entities(previous_pool, frozen_entities)
+    ensure_frozen_entities_fit_capacity(freeze_reason_map, active_config.capacity)
+
+    observation_candidates = rank_candidates(world_state, bundle_list, active_config)
+    selected_entities = _select_entities(
+        observation_candidates,
+        freeze_reason_map,
+        active_config.capacity,
+    )
+    added_entities, removed_entities = _diff_selected_entities(
+        previous_pool,
+        selected_entities,
+    )
+
+    return OfficialAlphaPool(
+        cycle_id=world_state.cycle_id,
+        observation_pool_size=len(observation_candidates),
+        official_alpha_pool_capacity=active_config.capacity,
+        selected_entities=selected_entities,
+        added_entities=added_entities,
+        removed_entities=removed_entities,
+        freeze_reason_map=freeze_reason_map,
+    )
+
+
+def _validate_inputs(
+    world_state: WorldStateSnapshot,
+    bundles: Sequence[FeatureSignalBundle],
+) -> None:
+    if not bundles:
+        raise MainCoreError("bundles must not be empty")
+
+    seen_entity_ids: set[str] = set()
+    for bundle in bundles:
+        if bundle.cycle_id != world_state.cycle_id:
+            raise MainCoreError("bundle cycle_id must match world_state.cycle_id")
+
+        entity_id = str(bundle.entity_id)
+        if entity_id in seen_entity_ids:
+            raise MainCoreError("duplicate entity_id in FeatureSignalBundle input")
+        seen_entity_ids.add(entity_id)
+
+
+def _select_entities(
+    observation_candidates: Sequence[FeatureSignalBundle],
+    freeze_reason_map: Mapping[EntityId, str],
+    capacity: int,
+) -> list[EntityId]:
+    selected_entities: list[EntityId] = []
+    selected_entity_ids: set[str] = set()
+
+    for entity_id in freeze_reason_map:
+        _append_if_room(
+            selected_entities,
+            selected_entity_ids,
+            EntityId(str(entity_id)),
+            capacity,
+        )
+
+    for bundle in observation_candidates:
+        _append_if_room(
+            selected_entities,
+            selected_entity_ids,
+            EntityId(str(bundle.entity_id)),
+            capacity,
+        )
+
+    return selected_entities
+
+
+def _append_if_room(
+    selected_entities: list[EntityId],
+    selected_entity_ids: set[str],
+    entity_id: EntityId,
+    capacity: int,
+) -> None:
+    entity_id_value = str(entity_id)
+    if entity_id_value in selected_entity_ids or len(selected_entities) >= capacity:
+        return
+
+    selected_entities.append(entity_id)
+    selected_entity_ids.add(entity_id_value)
+
+
+def _diff_selected_entities(
+    previous_pool: OfficialAlphaPool | None,
+    selected_entities: Sequence[EntityId],
+) -> tuple[list[EntityId], list[EntityId]]:
+    if previous_pool is None:
+        return list(selected_entities), []
+
+    previous_entity_ids = {str(entity_id) for entity_id in previous_pool.selected_entities}
+    selected_entity_ids = {str(entity_id) for entity_id in selected_entities}
+    added_entities = [
+        entity_id
+        for entity_id in selected_entities
+        if str(entity_id) not in previous_entity_ids
+    ]
+    removed_entities = [
+        EntityId(str(entity_id))
+        for entity_id in previous_pool.selected_entities
+        if str(entity_id) not in selected_entity_ids
+    ]
+    return added_entities, removed_entities
+
+
+__all__ = ["select_official_alpha_pool"]

--- a/src/main_core/l5_universe/types.py
+++ b/src/main_core/l5_universe/types.py
@@ -1,0 +1,40 @@
+"""Configuration types for L5 universe selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from main_core.common.errors import MainCoreError
+
+MAX_OFFICIAL_ALPHA_POOL_CAPACITY = 100
+
+
+@dataclass(frozen=True)
+class PoolSelectionConfig:
+    """Runtime configuration for observation and official alpha pool selection."""
+
+    capacity: int = MAX_OFFICIAL_ALPHA_POOL_CAPACITY
+    observation_limit: int | None = None
+    min_candidate_score: float | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the formal capacity hard bound before a pool is built."""
+
+        if not isinstance(self.capacity, int) or isinstance(self.capacity, bool):
+            raise MainCoreError("official_alpha_pool_capacity must be an integer")
+        if not 1 <= self.capacity <= MAX_OFFICIAL_ALPHA_POOL_CAPACITY:
+            raise MainCoreError(
+                "official_alpha_pool_capacity must be between 1 and 100",
+            )
+        if (
+            self.observation_limit is not None
+            and (
+                not isinstance(self.observation_limit, int)
+                or isinstance(self.observation_limit, bool)
+                or self.observation_limit < 0
+            )
+        ):
+            raise MainCoreError("observation_limit must be a non-negative integer")
+
+
+__all__ = ["MAX_OFFICIAL_ALPHA_POOL_CAPACITY", "PoolSelectionConfig"]

--- a/tests/l5_universe/__init__.py
+++ b/tests/l5_universe/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for L5 universe selection."""

--- a/tests/l5_universe/test_freezer.py
+++ b/tests/l5_universe/test_freezer.py
@@ -1,0 +1,58 @@
+"""Tests for L5 frozen entity merge helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import OfficialAlphaPool
+from main_core.l5_universe.freezer import (
+    ensure_frozen_entities_fit_capacity,
+    merge_frozen_entities,
+)
+
+
+def _previous_pool() -> OfficialAlphaPool:
+    return OfficialAlphaPool(
+        cycle_id="cycle_l5",
+        observation_pool_size=3,
+        official_alpha_pool_capacity=3,
+        selected_entities=["ENT_B", "ENT_A", "ENT_D"],
+        added_entities=[],
+        removed_entities=[],
+        freeze_reason_map={
+            "ENT_A": "prior freeze A",
+            "ENT_B": "prior freeze B",
+        },
+    )
+
+
+def test_merge_frozen_entities_preserves_previous_reasons_and_adds_explicit() -> None:
+    frozen = merge_frozen_entities(
+        _previous_pool(),
+        {
+            "ENT_A": "explicit reason should not replace prior reason",
+            "ENT_C": "manual freeze C",
+        },
+    )
+
+    assert list(frozen) == ["ENT_B", "ENT_A", "ENT_C"]
+    assert frozen == {
+        "ENT_B": "prior freeze B",
+        "ENT_A": "prior freeze A",
+        "ENT_C": "manual freeze C",
+    }
+
+
+def test_merge_frozen_entities_accepts_explicit_without_previous_pool() -> None:
+    frozen = merge_frozen_entities(None, {"ENT_Z": "manual freeze"})
+
+    assert frozen == {"ENT_Z": "manual freeze"}
+
+
+def test_ensure_frozen_entities_fit_capacity_rejects_overflow() -> None:
+    with pytest.raises(MainCoreError, match="frozen entity count"):
+        ensure_frozen_entities_fit_capacity(
+            {"ENT_A": "freeze", "ENT_B": "freeze"},
+            capacity=1,
+        )

--- a/tests/l5_universe/test_rules.py
+++ b/tests/l5_universe/test_rules.py
@@ -1,0 +1,102 @@
+"""Tests for deterministic L5 candidate ranking rules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.l5_universe import PoolSelectionConfig, rank_candidates, score_candidate
+
+SIGNAL_SCORE = 1.5
+ALPHA_SCORE = 2.5
+MOMENTUM_SCORE = 3.5
+
+
+def _world_state(cycle_id: str = "cycle_l5") -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+def _bundle(
+    entity_id: str,
+    *,
+    cycle_id: str = "cycle_l5",
+    feature_values: dict[str, float] | None = None,
+    signal_values: dict[str, Any] | None = None,
+    feature_weight_multiplier: dict[str, float] | None = None,
+) -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_values=feature_values or {},
+        signal_values=signal_values or {},
+        graph_features={},
+        feature_weight_multiplier=feature_weight_multiplier or {},
+    )
+
+
+def test_score_candidate_uses_documented_precedence() -> None:
+    world_state = _world_state()
+
+    assert score_candidate(
+        _bundle(
+            "ENT_SIGNAL",
+            feature_values={"alpha_score": 9.0, "momentum": 8.0},
+            signal_values={"candidate_score": SIGNAL_SCORE},
+        ),
+        world_state,
+    ) == SIGNAL_SCORE
+    assert score_candidate(
+        _bundle("ENT_ALPHA", feature_values={"alpha_score": ALPHA_SCORE, "momentum": 8.0}),
+        world_state,
+    ) == ALPHA_SCORE
+    assert score_candidate(
+        _bundle(
+            "ENT_MOMENTUM",
+            feature_values={"momentum": MOMENTUM_SCORE},
+            feature_weight_multiplier={"momentum": 10.0},
+        ),
+        world_state,
+    ) == MOMENTUM_SCORE
+    assert score_candidate(_bundle("ENT_MISSING"), world_state) == 0.0
+
+
+def test_rank_candidates_is_stable_with_entity_id_tie_break() -> None:
+    world_state = _world_state()
+    bundles = [
+        _bundle("ENT_B", signal_values={"candidate_score": 2.0}),
+        _bundle("ENT_A", signal_values={"candidate_score": 2.0}),
+        _bundle("ENT_C", signal_values={"candidate_score": 3.0}),
+    ]
+
+    ranked_once = rank_candidates(world_state, bundles, PoolSelectionConfig(capacity=3))
+    ranked_twice = rank_candidates(world_state, bundles, PoolSelectionConfig(capacity=3))
+
+    assert [bundle.entity_id for bundle in ranked_once] == ["ENT_C", "ENT_A", "ENT_B"]
+    assert ranked_once == ranked_twice
+
+
+def test_rank_candidates_applies_score_threshold_before_observation_limit() -> None:
+    world_state = _world_state()
+    bundles = [
+        _bundle("ENT_LOW", signal_values={"candidate_score": 0.5}),
+        _bundle("ENT_MID", signal_values={"candidate_score": 1.5}),
+        _bundle("ENT_HIGH", signal_values={"candidate_score": 2.5}),
+    ]
+    config = PoolSelectionConfig(
+        capacity=3,
+        observation_limit=1,
+        min_candidate_score=1.0,
+    )
+
+    ranked = rank_candidates(world_state, bundles, config)
+
+    assert [bundle.entity_id for bundle in ranked] == ["ENT_HIGH"]

--- a/tests/l5_universe/test_service.py
+++ b/tests/l5_universe/test_service.py
@@ -1,0 +1,213 @@
+"""Tests for L5 official alpha pool selection service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import FeatureSignalBundle, OfficialAlphaPool, WorldStateSnapshot
+from main_core.l5_universe import PoolSelectionConfig, select_official_alpha_pool
+from main_core.l5_universe.types import MAX_OFFICIAL_ALPHA_POOL_CAPACITY
+
+DEFAULT_OBSERVATION_SIZE = 3
+THRESHOLDED_OBSERVATION_SIZE = 2
+TWO_ENTITY_CAPACITY = 2
+
+
+def _world_state(cycle_id: str = "cycle_l5") -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+def _bundle(
+    entity_id: str,
+    score: float,
+    *,
+    cycle_id: str = "cycle_l5",
+    signal_values: dict[str, Any] | None = None,
+) -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_values={"momentum": score},
+        signal_values=signal_values or {},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+
+
+def _pool(
+    *,
+    selected_entities: list[str],
+    freeze_reason_map: dict[str, str] | None = None,
+) -> OfficialAlphaPool:
+    return OfficialAlphaPool(
+        cycle_id="cycle_l5",
+        observation_pool_size=len(selected_entities),
+        official_alpha_pool_capacity=100,
+        selected_entities=selected_entities,
+        added_entities=[],
+        removed_entities=[],
+        freeze_reason_map=freeze_reason_map or {},
+    )
+
+
+def test_select_official_alpha_pool_selects_ranked_candidates_with_capacity() -> None:
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 2.0),
+            _bundle("ENT_B", 3.0),
+            _bundle("ENT_C", 1.0),
+        ],
+        capacity=2,
+    )
+
+    assert pool.cycle_id == "cycle_l5"
+    assert pool.observation_pool_size == DEFAULT_OBSERVATION_SIZE
+    assert pool.official_alpha_pool_capacity == TWO_ENTITY_CAPACITY
+    assert pool.selected_entities == ("ENT_B", "ENT_A")
+    assert pool.added_entities == ("ENT_B", "ENT_A")
+    assert pool.removed_entities == ()
+    assert (
+        len(pool.selected_entities)
+        <= pool.official_alpha_pool_capacity
+        <= MAX_OFFICIAL_ALPHA_POOL_CAPACITY
+    )
+
+
+def test_select_official_alpha_pool_records_thresholded_observation_pool_size() -> None:
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 3.0),
+            _bundle("ENT_B", 2.0),
+            _bundle("ENT_C", 0.5),
+        ],
+        config=PoolSelectionConfig(capacity=1, min_candidate_score=1.0),
+    )
+
+    assert pool.observation_pool_size == THRESHOLDED_OBSERVATION_SIZE
+    assert pool.selected_entities == ("ENT_A",)
+
+
+def test_select_official_alpha_pool_prioritizes_frozen_entities() -> None:
+    previous_pool = _pool(
+        selected_entities=["ENT_A", "ENT_C"],
+        freeze_reason_map={"ENT_C": "existing core freeze"},
+    )
+
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 10.0),
+            _bundle("ENT_B", 9.0),
+            _bundle("ENT_C", 0.0),
+        ],
+        previous_pool=previous_pool,
+        capacity=2,
+    )
+
+    assert pool.selected_entities == ("ENT_C", "ENT_A")
+    assert pool.added_entities == ()
+    assert pool.removed_entities == ()
+    assert pool.freeze_reason_map == {"ENT_C": "existing core freeze"}
+
+
+def test_select_official_alpha_pool_merges_explicit_frozen_entities() -> None:
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 10.0),
+            _bundle("ENT_B", 9.0),
+        ],
+        capacity=2,
+        frozen_entities={"ENT_B": "manual freeze"},
+    )
+
+    assert pool.selected_entities == ("ENT_B", "ENT_A")
+    assert pool.freeze_reason_map == {"ENT_B": "manual freeze"}
+
+
+def test_select_official_alpha_pool_computes_added_and_removed_entities() -> None:
+    previous_pool = _pool(selected_entities=["ENT_A", "ENT_C"])
+
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 2.0),
+            _bundle("ENT_B", 3.0),
+            _bundle("ENT_C", 1.0),
+        ],
+        previous_pool=previous_pool,
+        capacity=2,
+    )
+
+    assert pool.selected_entities == ("ENT_B", "ENT_A")
+    assert pool.added_entities == ("ENT_B",)
+    assert pool.removed_entities == ("ENT_C",)
+
+
+def test_select_official_alpha_pool_rejects_too_many_frozen_entities() -> None:
+    previous_pool = _pool(
+        selected_entities=["ENT_A", "ENT_B"],
+        freeze_reason_map={
+            "ENT_A": "freeze A",
+            "ENT_B": "freeze B",
+        },
+    )
+
+    with pytest.raises(MainCoreError, match="frozen entity count"):
+        select_official_alpha_pool(
+            _world_state(),
+            [
+                _bundle("ENT_A", 2.0),
+                _bundle("ENT_B", 3.0),
+            ],
+            previous_pool=previous_pool,
+            capacity=1,
+        )
+
+
+@pytest.mark.parametrize("capacity", [0, 101])
+def test_select_official_alpha_pool_rejects_capacity_outside_bounds(capacity: int) -> None:
+    with pytest.raises(MainCoreError, match="official_alpha_pool_capacity"):
+        select_official_alpha_pool(
+            _world_state(),
+            [_bundle("ENT_A", 1.0)],
+            capacity=capacity,
+        )
+
+
+def test_select_official_alpha_pool_rejects_empty_bundles() -> None:
+    with pytest.raises(MainCoreError, match="bundles"):
+        select_official_alpha_pool(_world_state(), [])
+
+
+def test_select_official_alpha_pool_rejects_cycle_mismatch() -> None:
+    with pytest.raises(MainCoreError, match="cycle_id"):
+        select_official_alpha_pool(
+            _world_state("cycle_l5"),
+            [_bundle("ENT_A", 1.0, cycle_id="other_cycle")],
+        )
+
+
+def test_select_official_alpha_pool_rejects_duplicate_entity_id() -> None:
+    with pytest.raises(MainCoreError, match="duplicate entity_id"):
+        select_official_alpha_pool(
+            _world_state(),
+            [
+                _bundle("ENT_A", 1.0),
+                _bundle("ENT_A", 2.0),
+            ],
+        )


### PR DESCRIPTION
Closes #8

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
### 1. 背景与目标
项目文档 §11.3 / §9 要求 L5 基于共享 `WorldStateSnapshot` 与 L3 特征输入生成正式 `OfficialAlphaPool`，并保证 `official_alpha_pool_capacity` 不越界。当前代码只有 `main_core.common.schemas.pool.OfficialAlphaPool` 的 frozen Pydantic schema 和容量 validator，`src/main_core/l5_universe/__init__.py` 仍为空。目标是在 L5 包内落地确定性的 observation/core pool 选择、冻结保留、add/remove 差分和 `select_official_alpha_pool(...)` 顶层入口。

### 2. 所属模块
**Primary writable paths:**
- `src/main_core/l5_universe/__init__.py`
- `src/main_core/l5_universe/types.py`（新建）
- `src/main_core/l5_universe/rules.py`（新建）
- `src/main_core/l5_universe/freezer.py`（新建）
- `src/main_core/l5_universe/service.py`（新建）
- `tests/l5_universe/**`（新建）

**Adjacent read-only / integration paths:**
- `src/main_core/common/schemas/pool.py`：产出 `OfficialAlphaPool`
- `src/main_core/common/schemas/world_state.py`：消费 `WorldStateSnapshot`
- `src/main_core/common/schemas/feature_bundle.py`：消费 `FeatureSignalBundle`
- `src/main_core/common/types.py`：复用 `EntityId`
- `src/main_core/common/errors.py`：复用 `MainCoreError`
- `src/main_core/l4_world_state/service.py`：只通过 #7 产出的 `WorldStateSnapshot` 间接集成，不 import L4 内部规则
- `src/main_core/l3_features/**`：只通过 #6 的 public bundle handoff 或测试 fixture 集成，不 import L3 内部 reader/store

### 3. 实现范围
- 在 `src/main_core/l5_universe/types.py` 新建 frozen dataclass `PoolSelectionConfig(capacity: int = 100, observation_limit: int | None = None, min_candidate_score: float | None = None)`，并集中校验 `1 <= capacity <= 100`。
- 在 `src/main_core/l5_universe/rules.py` 实现 `score_candidate(bundle: FeatureSignalBundle, world_state: WorldStateSnapshot) -> float`，优先读取 `signal_values["candidate_score"]` / `feature_values["alpha_score"]` / `feature_values["momentum"]`，缺失时返回 `0.0`。
- 在 `rules.py` 实现 `rank_candidates(world_state: WorldStateSnapshot, bundles: Sequence[FeatureSignalBundle], config: PoolSelectionConfig) -> list[FeatureSignalBundle]`，排序必须确定性：分数降序、`entity_id` 升序 tie-break。
- 在 `src/main_core/l5_universe/freezer.py` 实现冻结合并逻辑：冻结实体来自 `previous_pool.freeze_reason_