### PR TITLE
feat(#9): 实现 l6_alpha SinglePromptAnalyzer 与 inconclusive 降级

### DIFF
--- a/src/main_core/l6_alpha/__init__.py
+++ b/src/main_core/l6_alpha/__init__.py
@@ -1,1 +1,19 @@
-"""L6 package — analyzer work; see §14 of main-core.project-doc.md."""
+"""L6 package: single-stock alpha analysis."""
+
+from main_core.l6_alpha.fallback import build_inconclusive_result
+from main_core.l6_alpha.reasoner_port import (
+    AlphaReasonerPort,
+    AlphaReasonerResponse,
+    StaticAlphaReasonerPort,
+)
+from main_core.l6_alpha.service import analyze_stock
+from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
+
+__all__ = [
+    "AlphaReasonerPort",
+    "AlphaReasonerResponse",
+    "SinglePromptAnalyzer",
+    "StaticAlphaReasonerPort",
+    "analyze_stock",
+    "build_inconclusive_result",
+]

--- a/src/main_core/l6_alpha/fallback.py
+++ b/src/main_core/l6_alpha/fallback.py
@@ -1,0 +1,44 @@
+"""Task-level fallback helpers for L6 alpha analysis."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import InconclusiveError
+from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
+from main_core.common.types import EntityId
+from main_core.l6_alpha.reasoner_port import AlphaReasonerResponse
+
+
+def build_inconclusive_result(
+    entity_id: EntityId,
+    context: AlphaAnalysisContext,
+    reason: str,
+    *,
+    similar_cases: Sequence[Mapping[str, Any]] | None = None,
+) -> AlphaResultSnapshot:
+    """Build a formal inconclusive L6 result for a task-level failure."""
+
+    active_similar_cases = similar_cases if similar_cases is not None else context.similar_cases
+    return single_prompt_result(
+        cycle_id=context.cycle_id,
+        entity_id=entity_id,
+        score=None,
+        confidence=0.0,
+        rationale=f"inconclusive: {reason}",
+        similar_cases=[dict(case) for case in active_similar_cases],
+        status="inconclusive",
+    )
+
+
+def is_task_level_failure(error: BaseException) -> bool:
+    """Return whether an exception should be downgraded to inconclusive."""
+
+    return isinstance(error, InconclusiveError) or (
+        isinstance(error, AlphaReasonerResponse) and error.task_failed
+    )
+
+
+__all__ = ["build_inconclusive_result", "is_task_level_failure"]

--- a/src/main_core/l6_alpha/reasoner_port.py
+++ b/src/main_core/l6_alpha/reasoner_port.py
@@ -1,0 +1,63 @@
+"""Reasoner-runtime boundary for L6 single-stock alpha analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.types import EntityId
+
+
+@dataclass(frozen=True)
+class AlphaReasonerResponse:
+    """Raw L6 reasoner response before formal alpha result assembly."""
+
+    score: float | None
+    confidence: float
+    rationale: str
+    similar_cases: list[dict[str, Any]]
+    task_failed: bool = False
+    failure_reason: str | None = None
+
+
+class AlphaReasonerPort(Protocol):
+    """Boundary protocol for reasoner-runtime alpha analysis."""
+
+    def analyze_alpha(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaReasonerResponse:
+        """Analyze one entity and return the raw reasoner response."""
+
+
+@dataclass(frozen=True)
+class StaticAlphaReasonerPort:
+    """Deterministic reasoner fake for tests and local single-stock runs."""
+
+    response: AlphaReasonerResponse | None = None
+
+    def analyze_alpha(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaReasonerResponse:
+        """Return the configured response, or a static response from context."""
+
+        if self.response is not None:
+            return self.response
+
+        return AlphaReasonerResponse(
+            score=0.0,
+            confidence=0.0,
+            rationale="static alpha analysis",
+            similar_cases=[dict(case) for case in context.similar_cases],
+        )
+
+
+__all__ = [
+    "AlphaReasonerPort",
+    "AlphaReasonerResponse",
+    "StaticAlphaReasonerPort",
+]

--- a/src/main_core/l6_alpha/service.py
+++ b/src/main_core/l6_alpha/service.py
@@ -1,0 +1,25 @@
+"""Service entrypoint for single-stock L6 alpha analysis."""
+
+from __future__ import annotations
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.protocols import AnalyzerInterface
+from main_core.common.schemas import AlphaResultSnapshot
+from main_core.common.types import EntityId
+from main_core.l6_alpha.reasoner_port import StaticAlphaReasonerPort
+from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
+
+
+def analyze_stock(
+    entity_id: EntityId,
+    context: AlphaAnalysisContext,
+    *,
+    analyzer: AnalyzerInterface | None = None,
+) -> AlphaResultSnapshot:
+    """Analyze one stock using the P2 single-prompt analyzer by default."""
+
+    active_analyzer = analyzer or SinglePromptAnalyzer(StaticAlphaReasonerPort())
+    return active_analyzer.analyze(entity_id, context)
+
+
+__all__ = ["analyze_stock"]

--- a/src/main_core/l6_alpha/single_prompt_analyzer.py
+++ b/src/main_core/l6_alpha/single_prompt_analyzer.py
@@ -1,0 +1,71 @@
+"""P2 single-prompt alpha analyzer implementation."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import MainCoreError
+from main_core.common.protocols import AnalyzerBase
+from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
+from main_core.common.types import EntityId
+from main_core.l6_alpha.fallback import (
+    build_inconclusive_result,
+    is_task_level_failure,
+)
+from main_core.l6_alpha.reasoner_port import (
+    AlphaReasonerPort,
+    StaticAlphaReasonerPort,
+)
+
+
+class AlphaAnalyzerError(MainCoreError):
+    """Raised when the L6 analyzer contract is violated before provider work."""
+
+
+class SinglePromptAnalyzer(AnalyzerBase):
+    """P2 single-prompt analyzer for one official alpha pool entity."""
+
+    analyzer_type: ClassVar[str] = "single_prompt_v1"
+
+    def __init__(self, reasoner_port: AlphaReasonerPort | None = None) -> None:
+        self._reasoner_port = reasoner_port or StaticAlphaReasonerPort()
+
+    def analyze(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        """Analyze one entity and downgrade only task-level failures."""
+
+        if entity_id != context.entity_id:
+            raise AlphaAnalyzerError("entity_id must match context.entity_id")
+
+        try:
+            response = self._reasoner_port.analyze_alpha(entity_id, context)
+        except Exception as exc:
+            if is_task_level_failure(exc):
+                return build_inconclusive_result(entity_id, context, str(exc))
+            raise
+
+        if response.task_failed:
+            reason = response.failure_reason or response.rationale or "alpha task failed"
+            return build_inconclusive_result(
+                entity_id,
+                context,
+                reason,
+                similar_cases=response.similar_cases,
+            )
+
+        return single_prompt_result(
+            cycle_id=context.cycle_id,
+            entity_id=entity_id,
+            score=response.score,
+            confidence=response.confidence,
+            rationale=response.rationale,
+            similar_cases=response.similar_cases,
+            status="ok",
+        )
+
+
+__all__ = ["AlphaAnalyzerError", "SinglePromptAnalyzer"]

--- a/src/main_core/l6_alpha/stubs.py
+++ b/src/main_core/l6_alpha/stubs.py
@@ -1,28 +1,12 @@
-"""P2 analyzer stubs for L6 alpha analysis."""
+"""Compatibility exports for the implemented L6 alpha analyzer."""
 
 from __future__ import annotations
 
-from typing import ClassVar
-
-from main_core.common.contexts import AlphaAnalysisContext
-from main_core.common.protocols import AnalyzerBase
-from main_core.common.schemas import AlphaResultSnapshot
-from main_core.common.types import EntityId
+from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
 
 
-class SinglePromptAnalyzerStub(AnalyzerBase):
-    """P2 placeholder, wired in milestone-2."""
-
-    analyzer_type: ClassVar[str] = "single_prompt_v1"
-
-    def analyze(
-        self,
-        entity_id: EntityId,
-        context: AlphaAnalysisContext,
-    ) -> AlphaResultSnapshot:
-        """Reserve the L6 analyzer contract until the real implementation lands."""
-
-        raise NotImplementedError("implemented in #9")
+class SinglePromptAnalyzerStub(SinglePromptAnalyzer):
+    """Backward-compatible name for the issue #9 single-prompt analyzer."""
 
 
 __all__ = ["SinglePromptAnalyzerStub"]

--- a/tests/l6_alpha/__init__.py
+++ b/tests/l6_alpha/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for L6 alpha analysis."""

--- a/tests/l6_alpha/conftest.py
+++ b/tests/l6_alpha/conftest.py
@@ -1,0 +1,48 @@
+"""Fixtures for L6 alpha analysis tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+
+
+@pytest.fixture
+def feature_bundle() -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id="cycle_l6",
+        entity_id="ENT_A",
+        feature_values={"momentum": 4.2, "quality": 1.5},
+        signal_values={"signal": "positive"},
+        graph_features={"centrality": 0.3},
+        feature_weight_multiplier={"momentum": 2.5, "quality": 1.0},
+    )
+
+
+@pytest.fixture
+def world_state() -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id="cycle_l6",
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+@pytest.fixture
+def analysis_context(
+    feature_bundle: FeatureSignalBundle,
+    world_state: WorldStateSnapshot,
+) -> AlphaAnalysisContext:
+    return AlphaAnalysisContext(
+        cycle_id="cycle_l6",
+        entity_id="ENT_A",
+        feature_bundle=feature_bundle,
+        world_state=world_state,
+        similar_cases=[{"entity_id": "ENT_B", "score": 0.4}],
+    )

--- a/tests/l6_alpha/test_fallback.py
+++ b/tests/l6_alpha/test_fallback.py
@@ -1,0 +1,55 @@
+"""Tests for L6 inconclusive fallback helpers."""
+
+from __future__ import annotations
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import InconclusiveError, MainCoreError
+from main_core.l6_alpha import AlphaReasonerResponse, build_inconclusive_result
+from main_core.l6_alpha.fallback import is_task_level_failure
+
+
+def test_build_inconclusive_result_creates_valid_formal_object(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    result = build_inconclusive_result(
+        "ENT_A",
+        analysis_context,
+        "provider returned no usable answer",
+    )
+
+    assert result.cycle_id == "cycle_l6"
+    assert result.entity_id == "ENT_A"
+    assert result.analyzer_type == "single_prompt_v1"
+    assert result.status == "inconclusive"
+    assert result.score is None
+    assert result.confidence == 0.0
+    assert "provider returned no usable answer" in result.rationale
+    assert result.similar_cases == ({"entity_id": "ENT_B", "score": 0.4},)
+
+
+def test_build_inconclusive_result_accepts_explicit_similar_cases(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    result = build_inconclusive_result(
+        "ENT_A",
+        analysis_context,
+        "task timeout",
+        similar_cases=[{"entity_id": "ENT_C"}],
+    )
+
+    assert result.similar_cases == ({"entity_id": "ENT_C"},)
+
+
+def test_is_task_level_failure_only_accepts_inconclusive_errors() -> None:
+    assert is_task_level_failure(InconclusiveError("single stock task failed"))
+    assert is_task_level_failure(
+        AlphaReasonerResponse(
+            score=None,
+            confidence=0.0,
+            rationale="provider task failed",
+            similar_cases=[],
+            task_failed=True,
+        ),
+    )
+    assert not is_task_level_failure(MainCoreError("infrastructure failed"))
+    assert not is_task_level_failure(RuntimeError("unknown failure"))

--- a/tests/l6_alpha/test_reasoner_port.py
+++ b/tests/l6_alpha/test_reasoner_port.py
@@ -1,0 +1,47 @@
+"""Tests for the L6 alpha reasoner boundary port."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.l6_alpha import AlphaReasonerResponse, StaticAlphaReasonerPort
+
+
+def test_alpha_reasoner_response_is_frozen_dataclass() -> None:
+    response = AlphaReasonerResponse(
+        score=0.8,
+        confidence=0.7,
+        rationale="fixture",
+        similar_cases=[],
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        response.score = 0.1  # type: ignore[misc]
+
+
+def test_static_alpha_reasoner_port_returns_configured_response(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    response = AlphaReasonerResponse(
+        score=0.61,
+        confidence=0.77,
+        rationale="configured fake response",
+        similar_cases=[{"entity_id": "ENT_X"}],
+    )
+    port = StaticAlphaReasonerPort(response)
+
+    assert port.analyze_alpha("ENT_A", analysis_context) == response
+
+
+def test_static_alpha_reasoner_port_default_uses_context_similar_cases(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    response = StaticAlphaReasonerPort().analyze_alpha("ENT_A", analysis_context)
+
+    assert response.score == 0.0
+    assert response.confidence == 0.0
+    assert response.rationale == "static alpha analysis"
+    assert response.similar_cases == [{"entity_id": "ENT_B", "score": 0.4}]

--- a/tests/l6_alpha/test_service.py
+++ b/tests/l6_alpha/test_service.py
@@ -1,0 +1,61 @@
+"""Tests for the L6 single-stock service entrypoint."""
+
+from __future__ import annotations
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.schemas import FeatureSignalBundle, OfficialAlphaPool, WorldStateSnapshot
+from main_core.l6_alpha import analyze_stock
+
+
+def test_analyze_stock_uses_default_single_prompt_analyzer(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    result = analyze_stock("ENT_A", analysis_context)
+
+    assert result.entity_id == "ENT_A"
+    assert result.analyzer_type == "single_prompt_v1"
+    assert result.status == "ok"
+
+
+def test_analyze_stock_consumes_upstream_pool_world_state_and_feature_context() -> None:
+    cycle_id = "cycle_l6_integration"
+    feature_bundle = FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id="ENT_CORE",
+        feature_values={"momentum": 6.0},
+        signal_values={"signal": "positive"},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 3.0},
+    )
+    world_state = WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime="neutral",
+        llm_delta=1,
+        final_regime="risk_on",
+        llm_rationale="risk appetite improved",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+    pool = OfficialAlphaPool(
+        cycle_id=cycle_id,
+        observation_pool_size=1,
+        official_alpha_pool_capacity=100,
+        selected_entities=["ENT_CORE"],
+        added_entities=["ENT_CORE"],
+        removed_entities=[],
+        freeze_reason_map={},
+    )
+    context = AlphaAnalysisContext(
+        cycle_id=cycle_id,
+        entity_id=pool.selected_entities[0],
+        feature_bundle=feature_bundle,
+        world_state=world_state,
+        similar_cases=[],
+    )
+
+    result = analyze_stock(pool.selected_entities[0], context)
+
+    assert result.cycle_id == cycle_id
+    assert result.entity_id == "ENT_CORE"
+    assert result.analyzer_type == "single_prompt_v1"

--- a/tests/l6_alpha/test_single_prompt_analyzer.py
+++ b/tests/l6_alpha/test_single_prompt_analyzer.py
@@ -1,0 +1,145 @@
+"""Tests for the concrete P2 single-prompt analyzer."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import InconclusiveError, MainCoreError
+from main_core.common.schemas import AlphaResultSnapshot
+from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer
+from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
+
+EXPECTED_FEATURE_MOMENTUM = 4.2
+EXPECTED_FEATURE_MULTIPLIER = 2.5
+HAPPY_PATH_CONFIDENCE = 0.82
+HAPPY_PATH_SCORE = 0.73
+
+
+class RecordingReasonerPort:
+    def __init__(
+        self,
+        response: AlphaReasonerResponse | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        self.response = response or AlphaReasonerResponse(
+            score=0.5,
+            confidence=0.6,
+            rationale="recorded response",
+            similar_cases=[],
+        )
+        self.error = error
+        self.calls: list[tuple[object, AlphaAnalysisContext]] = []
+
+    def analyze_alpha(
+        self,
+        entity_id: object,
+        context: AlphaAnalysisContext,
+    ) -> AlphaReasonerResponse:
+        self.calls.append((entity_id, context))
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def test_single_prompt_analyzer_happy_path_returns_formal_result(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    port = RecordingReasonerPort(
+            AlphaReasonerResponse(
+                score=HAPPY_PATH_SCORE,
+                confidence=HAPPY_PATH_CONFIDENCE,
+                rationale="positive quality and momentum",
+                similar_cases=[{"entity_id": "ENT_Z", "score": 0.7}],
+            ),
+    )
+    analyzer = SinglePromptAnalyzer(port)
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert isinstance(result, AlphaResultSnapshot)
+    assert result.analyzer_type == "single_prompt_v1"
+    assert result.status == "ok"
+    assert result.score == HAPPY_PATH_SCORE
+    assert result.confidence == HAPPY_PATH_CONFIDENCE
+    assert result.similar_cases == ({"entity_id": "ENT_Z", "score": 0.7},)
+    assert port.calls == [("ENT_A", analysis_context)]
+
+
+def test_single_prompt_analyzer_rejects_entity_mismatch_without_calling_reasoner(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    port = RecordingReasonerPort()
+    analyzer = SinglePromptAnalyzer(port)
+
+    with pytest.raises(AlphaAnalyzerError, match="context.entity_id"):
+        analyzer.analyze("ENT_OTHER", analysis_context)
+
+    assert port.calls == []
+
+
+def test_single_prompt_analyzer_converts_task_failed_response_to_inconclusive(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = SinglePromptAnalyzer(
+        RecordingReasonerPort(
+            AlphaReasonerResponse(
+                score=0.99,
+                confidence=0.9,
+                rationale="raw provider failure",
+                similar_cases=[{"entity_id": "ENT_FAIL"}],
+                task_failed=True,
+                failure_reason="provider task timeout",
+            ),
+        ),
+    )
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert result.status == "inconclusive"
+    assert result.score is None
+    assert result.confidence == 0.0
+    assert "provider task timeout" in result.rationale
+    assert result.similar_cases == ({"entity_id": "ENT_FAIL"},)
+
+
+def test_single_prompt_analyzer_converts_inconclusive_error_to_formal_result(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = SinglePromptAnalyzer(
+        RecordingReasonerPort(error=InconclusiveError("single prompt had no answer")),
+    )
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert result.status == "inconclusive"
+    assert result.score is None
+    assert result.confidence == 0.0
+    assert "single prompt had no answer" in result.rationale
+
+
+def test_single_prompt_analyzer_propagates_main_core_infrastructure_errors(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = SinglePromptAnalyzer(
+        RecordingReasonerPort(error=MainCoreError("reasoner unavailable")),
+    )
+
+    with pytest.raises(MainCoreError, match="reasoner unavailable"):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+def test_single_prompt_analyzer_does_not_reapply_feature_multipliers(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    port = RecordingReasonerPort()
+    analyzer = SinglePromptAnalyzer(port)
+
+    analyzer.analyze("ENT_A", analysis_context)
+
+    _, observed_context = port.calls[0]
+    assert observed_context.feature_bundle.feature_values["momentum"] == EXPECTED_FEATURE_MOMENTUM
+    assert (
+        observed_context.feature_bundle.feature_weight_multiplier["momentum"]
+        == EXPECTED_FEATURE_MULTIPLIER
+    )

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from inspect import signature
 
-import pytest
-
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.protocols import AnalyzerBase, AnalyzerInterface
 from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
-from main_core.l6_alpha.stubs import SinglePromptAnalyzerStub
+from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer, StaticAlphaReasonerPort
 
 CYCLE_ID = "cycle_001"
 ENTITY_ID = "ENT_001"
@@ -55,8 +53,8 @@ def test_analyzer_protocol_imports() -> None:
     assert AnalyzerBase is not None
 
 
-def test_single_prompt_stub_matches_runtime_protocol() -> None:
-    analyzer = SinglePromptAnalyzerStub()
+def test_single_prompt_analyzer_matches_runtime_protocol() -> None:
+    analyzer = SinglePromptAnalyzer()
 
     assert isinstance(analyzer, AnalyzerInterface)
     assert analyzer.analyzer_type == SINGLE_PROMPT_ANALYZER
@@ -67,11 +65,22 @@ def test_analyzer_protocol_requires_explicit_entity_argument() -> None:
 
     assert list(signature(AnalyzerInterface.analyze).parameters) == expected_parameters
     assert list(signature(AnalyzerBase.analyze).parameters) == expected_parameters
-    assert list(signature(SinglePromptAnalyzerStub.analyze).parameters) == expected_parameters
+    assert list(signature(SinglePromptAnalyzer.analyze).parameters) == expected_parameters
 
 
-def test_single_prompt_stub_analyze_placeholder_raises() -> None:
-    analyzer = SinglePromptAnalyzerStub()
+def test_single_prompt_analyzer_returns_single_prompt_result() -> None:
+    analyzer = SinglePromptAnalyzer(
+        StaticAlphaReasonerPort(
+            AlphaReasonerResponse(
+                score=0.64,
+                confidence=0.72,
+                rationale="quality and momentum align",
+                similar_cases=[],
+            ),
+        ),
+    )
 
-    with pytest.raises(NotImplementedError, match="#9"):
-        analyzer.analyze(ENTITY_ID, _analysis_context())
+    result = analyzer.analyze(ENTITY_ID, _analysis_context())
+
+    assert result.analyzer_type == SINGLE_PROMPT_ANALYZER
+    assert result.status == "ok"


### PR DESCRIPTION
Closes #9

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `tests/schemas/test_feature_bundle.py`, `unknown`


---
### 1. 背景与目标
项目文档 §11.3 / §12.3 / §16.3 要求 P2 阶段使用 `single_prompt_v1` 分析核心池实体，并把单股票任务级失败显式转成 `inconclusive`。当前代码已有 `AnalyzerInterface.analyze(self, entity_id, context)` 的签名、`AlphaAnalysisContext`、`AlphaResultSnapshot` 与 `single_prompt_result(...)` 工厂，但 `SinglePromptAnalyzerStub` 仍只抛 `NotImplementedError`。本 issue 替换该 stub，落地 `SinglePromptAnalyzer`、L6 自有 reasoner port 边界、任务级失败降级和 `analyze_stock(...)` 顶层入口。

### 2. 所属模块
**Primary writable paths:**
- `src/main_core/l6_alpha/__init__.py`
- `src/main_core/l6_alpha/stubs.py`
- `src/main_core/l6_alpha/reasoner_port.py`（新建）
- `src/main_core/l6_alpha/fallback.py`（新建）
- `src/main_core/l6_alpha/single_prompt_analyzer.py`（新建）
- `src/main_core/l6_alpha/service.py`（新建）
- `tests/l6_alpha/**`（新建）
- `tests/protocols/test_analyzer_interface.py`

**Adjacent read-only / integration paths:**
- `src/main_core/common/protocols/analyzer.py`：复用 `AnalyzerBase`, `AnalyzerInterface`
- `src/main_core/common/contexts.py`：消费 `AlphaAnalysisContext`
- `src/main_core/common/schemas/alpha.py`：产出 `AlphaResultSnapshot`，复用 `single_prompt_result`
- `src/main_core/common/errors.py`：复用 `MainCoreError`, `InconclusiveError`
- `src/main_core/common/types.py`：复用 `EntityId`
- #8 产出的 `OfficialAlphaPool` 与 #7 产出的 `WorldStateSnapshot` 只用于测试/调用方组装 context，不 import L5/L4 内部实现

### 3. 实现范围
- 在 `src/main_core/l6_alpha/reasoner_port.py` 定义 frozen dataclass `AlphaReasonerResponse(score: float | None, confidence: float, rationale: str, similar_cases: list[dict[str, Any]], task_failed: bool = False, failure_reason: str | None = None)`。
- 在同文件定义 `AlphaReasonerPort` `Protocol`：`analyze_alpha(entity_id: EntityId, context: AlphaAnalysisContext) -> AlphaReasonerResponse`，以及 deterministic `StaticAlphaReasonerPort` fake。
- 在 `src/main_core/l6_alpha/fallback.py` 实现 `build_inconclusive_result(entity_id: EntityId, context: AlphaAnalysisContext, reason: str, *, similar_cases: Sequence[Mapping[str, Any]] | None = None) -> AlphaResultSnapshot`。
- 在 `fallback.py` 实现 `is_task_level_failu