### PR TITLE
feat(#10): 实现 l7_recommendation 正式建议、override 与 constraint gate

### DIFF
--- a/src/main_core/l7_recommendation/__init__.py
+++ b/src/main_core/l7_recommendation/__init__.py
@@ -1,1 +1,21 @@
 """L7 package — recommendation work; see §14 of main-core.project-doc.md."""
+
+from main_core.l7_recommendation.constraints import DefaultConstraintProvider
+from main_core.l7_recommendation.override import (
+    InMemoryOverrideStore,
+    OverrideStore,
+    apply_override,
+    find_override,
+    submit_override,
+)
+from main_core.l7_recommendation.service import generate_recommendations
+
+__all__ = [
+    "DefaultConstraintProvider",
+    "InMemoryOverrideStore",
+    "OverrideStore",
+    "apply_override",
+    "find_override",
+    "generate_recommendations",
+    "submit_override",
+]

--- a/src/main_core/l7_recommendation/constraints.py
+++ b/src/main_core/l7_recommendation/constraints.py
@@ -1,0 +1,60 @@
+"""Default deterministic constraint gates for L7 recommendations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from main_core.common.contexts import RecommendationConstraintInputs
+from main_core.common.protocols import RecommendationConstraintProviderBase
+from main_core.common.schemas import RecommendationSnapshot
+
+
+class DefaultConstraintProvider(RecommendationConstraintProviderBase):
+    """Apply the default regime and risk gates required by L7."""
+
+    def gate(
+        self,
+        inputs: RecommendationConstraintInputs,
+        candidate: RecommendationSnapshot,
+    ) -> RecommendationSnapshot:
+        """Apply deterministic gates after candidate and override handling."""
+
+        if inputs.risk_context.get("force_inconclusive") is True:
+            return _with_constraint(
+                candidate,
+                "risk_gate",
+                "force_inconclusive",
+                action_type="inconclusive",
+                rating=None,
+                confidence=None,
+            )
+
+        if inputs.world_state.final_regime == "risk_off" and candidate.action_type == "buy":
+            return _with_constraint(
+                candidate,
+                "regime_gate",
+                "risk_off_buy_to_hold",
+                action_type="hold",
+                rating="B",
+            )
+
+        return candidate
+
+
+def _with_constraint(
+    candidate: RecommendationSnapshot,
+    key: str,
+    value: Any,
+    **updates: Any,
+) -> RecommendationSnapshot:
+    constraints_applied = dict(candidate.constraints_applied)
+    constraints_applied[key] = value
+    return candidate.model_copy(
+        update={
+            **updates,
+            "constraints_applied": constraints_applied,
+        },
+    )
+
+
+__all__ = ["DefaultConstraintProvider"]

--- a/src/main_core/l7_recommendation/override.py
+++ b/src/main_core/l7_recommendation/override.py
@@ -1,0 +1,123 @@
+"""Human override submission and application helpers for L7."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import OverrideRecord, RecommendationSnapshot
+from main_core.common.types import CycleId, EntityId
+
+
+class OverrideStore(Protocol):
+    """Minimal storage protocol for validated override records."""
+
+    def save(self, override: OverrideRecord) -> OverrideRecord:
+        """Persist an override and return the stored immutable record."""
+
+    def list_overrides(self) -> Sequence[OverrideRecord]:
+        """Return stored override records in insertion order."""
+
+
+class InMemoryOverrideStore:
+    """Local/test-only override store with insertion-order semantics."""
+
+    def __init__(self, overrides: Sequence[OverrideRecord] | None = None) -> None:
+        self._overrides = [override.model_copy() for override in overrides or ()]
+
+    @property
+    def records(self) -> tuple[OverrideRecord, ...]:
+        """Return immutable stored records for tests and local callers."""
+
+        return tuple(self._overrides)
+
+    def save(self, override: OverrideRecord) -> OverrideRecord:
+        """Store a validated override record."""
+
+        stored_override = override.model_copy()
+        self._overrides.append(stored_override)
+        return stored_override
+
+    def list_overrides(self) -> Sequence[OverrideRecord]:
+        """Return stored override records in insertion order."""
+
+        return self.records
+
+
+_DEFAULT_OVERRIDE_STORE = InMemoryOverrideStore()
+
+
+def submit_override(
+    override_input: OverrideRecord | Mapping[str, Any],
+    *,
+    store: OverrideStore | None = None,
+) -> OverrideRecord:
+    """Validate, store, and return a human override record."""
+
+    override = _coerce_override(override_input)
+    active_store = store or _DEFAULT_OVERRIDE_STORE
+    return active_store.save(override)
+
+
+def find_override(
+    overrides: Sequence[OverrideRecord],
+    cycle_id: CycleId,
+    entity_id: EntityId,
+) -> OverrideRecord | None:
+    """Return the first override matching a cycle/entity pair."""
+
+    for override in overrides:
+        if override.cycle_id == cycle_id and override.entity_id == entity_id:
+            return override
+    return None
+
+
+def apply_override(
+    candidate: RecommendationSnapshot,
+    override: OverrideRecord,
+) -> RecommendationSnapshot:
+    """Apply a matching human override while preserving constraint audit data."""
+
+    if candidate.cycle_id != override.cycle_id:
+        raise MainCoreError("override cycle_id must match recommendation cycle_id")
+    if candidate.entity_id != override.entity_id:
+        raise MainCoreError("override entity_id must match recommendation entity_id")
+
+    updates: dict[str, Any] = {
+        "action_type": override.action_type,
+        "triggered_by": "human_decision",
+        "override_applied": True,
+        "constraints_applied": dict(candidate.constraints_applied),
+    }
+    if override.action_type == "inconclusive":
+        updates["rating"] = None
+        updates["confidence"] = None
+    else:
+        updates["rating"] = _rating_for_action(override.action_type)
+
+    return candidate.model_copy(update=updates)
+
+
+def _coerce_override(override_input: OverrideRecord | Mapping[str, Any]) -> OverrideRecord:
+    if isinstance(override_input, OverrideRecord):
+        return override_input.model_copy()
+    return OverrideRecord.model_validate(dict(override_input))
+
+
+def _rating_for_action(action_type: str) -> str:
+    ratings = {
+        "buy": "A",
+        "hold": "B",
+        "reduce": "C",
+    }
+    return ratings[action_type]
+
+
+__all__ = [
+    "InMemoryOverrideStore",
+    "OverrideStore",
+    "apply_override",
+    "find_override",
+    "submit_override",
+]

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -1,0 +1,155 @@
+"""Service entrypoint for formal L7 recommendation generation."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from main_core.common.contexts import RecommendationConstraintInputs
+from main_core.common.errors import MainCoreError
+from main_core.common.protocols import RecommendationConstraintProvider
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    OfficialAlphaPool,
+    OverrideRecord,
+    RecommendationSnapshot,
+    WorldStateSnapshot,
+)
+from main_core.l7_recommendation.constraints import DefaultConstraintProvider
+from main_core.l7_recommendation.override import apply_override, find_override
+
+BUY_SCORE_THRESHOLD = 0.65
+REDUCE_SCORE_THRESHOLD = 0.35
+
+
+def generate_recommendations(  # noqa: PLR0913
+    pool: OfficialAlphaPool,
+    analyses: Sequence[AlphaResultSnapshot],
+    world_state: WorldStateSnapshot,
+    *,
+    constraint_provider: RecommendationConstraintProvider | None = None,
+    overrides: Sequence[OverrideRecord] | None = None,
+    risk_context: Mapping[str, Any] | None = None,
+) -> list[RecommendationSnapshot]:
+    """Generate one formal recommendation per selected pool entity."""
+
+    analysis_by_entity = _validate_inputs(pool, analyses, world_state, overrides or ())
+    active_provider = constraint_provider or DefaultConstraintProvider()
+    constraint_inputs = RecommendationConstraintInputs(
+        world_state=world_state,
+        risk_context=dict(risk_context or {}),
+    )
+
+    recommendations: list[RecommendationSnapshot] = []
+    for entity_id in pool.selected_entities:
+        candidate = _candidate_from_analysis(analysis_by_entity[str(entity_id)])
+        matching_override = find_override(overrides or (), pool.cycle_id, entity_id)
+        override_was_applied = matching_override is not None
+        if matching_override is not None:
+            candidate = apply_override(candidate, matching_override)
+
+        gated_candidate = active_provider.gate(constraint_inputs, candidate)
+        if override_was_applied and (
+            not gated_candidate.override_applied
+            or gated_candidate.triggered_by != "human_decision"
+        ):
+            gated_candidate = gated_candidate.model_copy(
+                update={
+                    "triggered_by": "human_decision",
+                    "override_applied": True,
+                },
+            )
+        recommendations.append(gated_candidate)
+
+    return recommendations
+
+
+def _validate_inputs(
+    pool: OfficialAlphaPool,
+    analyses: Sequence[AlphaResultSnapshot],
+    world_state: WorldStateSnapshot,
+    overrides: Sequence[OverrideRecord],
+) -> dict[str, AlphaResultSnapshot]:
+    if pool.cycle_id != world_state.cycle_id:
+        raise MainCoreError("pool.cycle_id must match world_state.cycle_id")
+
+    selected_entity_ids = {str(entity_id) for entity_id in pool.selected_entities}
+    analysis_by_entity: dict[str, AlphaResultSnapshot] = {}
+    for analysis in analyses:
+        if analysis.cycle_id != pool.cycle_id:
+            raise MainCoreError("analysis cycle_id must match pool.cycle_id")
+
+        entity_id = str(analysis.entity_id)
+        if entity_id not in selected_entity_ids:
+            raise MainCoreError("analysis entity_id must belong to pool.selected_entities")
+        if entity_id in analysis_by_entity:
+            raise MainCoreError("duplicate analysis for selected entity")
+        analysis_by_entity[entity_id] = analysis
+
+    missing_entity_ids = selected_entity_ids - set(analysis_by_entity)
+    if missing_entity_ids:
+        raise MainCoreError("missing analysis for selected entity")
+
+    for override in overrides:
+        if override.cycle_id != pool.cycle_id:
+            raise MainCoreError("override cycle_id must match pool.cycle_id")
+
+    return analysis_by_entity
+
+
+def _candidate_from_analysis(analysis: AlphaResultSnapshot) -> RecommendationSnapshot:
+    if analysis.status == "inconclusive":
+        return RecommendationSnapshot(
+            cycle_id=analysis.cycle_id,
+            entity_id=analysis.entity_id,
+            action_type="inconclusive",
+            rating=None,
+            confidence=None,
+            triggered_by="system",
+            override_applied=False,
+            constraints_applied={},
+        )
+
+    if analysis.score is None:
+        raise MainCoreError("ok analysis score must not be None")
+    if not math.isfinite(analysis.score):
+        raise MainCoreError("ok analysis score must be finite")
+    if not math.isfinite(analysis.confidence):
+        raise MainCoreError("ok analysis confidence must be finite")
+
+    action_type = _action_for_score(analysis.score)
+    return RecommendationSnapshot(
+        cycle_id=analysis.cycle_id,
+        entity_id=analysis.entity_id,
+        action_type=action_type,
+        rating=_rating_for_action(action_type),
+        confidence=analysis.confidence,
+        triggered_by="system",
+        override_applied=False,
+        constraints_applied={},
+    )
+
+
+def _action_for_score(score: float) -> str:
+    if score >= BUY_SCORE_THRESHOLD:
+        return "buy"
+    if score <= REDUCE_SCORE_THRESHOLD:
+        return "reduce"
+    return "hold"
+
+
+def _rating_for_action(action_type: str) -> str:
+    ratings = {
+        "buy": "A",
+        "hold": "B",
+        "reduce": "C",
+    }
+    return ratings[action_type]
+
+
+__all__ = [
+    "BUY_SCORE_THRESHOLD",
+    "REDUCE_SCORE_THRESHOLD",
+    "generate_recommendations",
+]

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -44,12 +44,18 @@ def generate_recommendations(  # noqa: PLR0913
     recommendations: list[RecommendationSnapshot] = []
     for entity_id in pool.selected_entities:
         candidate = _candidate_from_analysis(analysis_by_entity[str(entity_id)])
+        source_is_inconclusive = candidate.action_type == "inconclusive"
         matching_override = find_override(overrides or (), pool.cycle_id, entity_id)
         override_was_applied = matching_override is not None
         if matching_override is not None:
             candidate = apply_override(candidate, matching_override)
+        if source_is_inconclusive:
+            candidate = _force_inconclusive(candidate)
 
         gated_candidate = active_provider.gate(constraint_inputs, candidate)
+        _validate_gated_identity(gated_candidate, pool.cycle_id, entity_id)
+        if source_is_inconclusive:
+            gated_candidate = _force_inconclusive(gated_candidate)
         if override_was_applied and (
             not gated_candidate.override_applied
             or gated_candidate.triggered_by != "human_decision"
@@ -129,6 +135,33 @@ def _candidate_from_analysis(analysis: AlphaResultSnapshot) -> RecommendationSna
         override_applied=False,
         constraints_applied={},
     )
+
+
+def _force_inconclusive(candidate: RecommendationSnapshot) -> RecommendationSnapshot:
+    if (
+        candidate.action_type == "inconclusive"
+        and candidate.rating is None
+        and candidate.confidence is None
+    ):
+        return candidate
+    return candidate.model_copy(
+        update={
+            "action_type": "inconclusive",
+            "rating": None,
+            "confidence": None,
+        },
+    )
+
+
+def _validate_gated_identity(
+    candidate: RecommendationSnapshot,
+    cycle_id: str,
+    entity_id: str,
+) -> None:
+    if candidate.cycle_id != cycle_id:
+        raise MainCoreError("constraint gate must preserve recommendation cycle_id")
+    if candidate.entity_id != entity_id:
+        raise MainCoreError("constraint gate must preserve recommendation entity_id")
 
 
 def _action_for_score(score: float) -> str:

--- a/tests/l7_recommendation/__init__.py
+++ b/tests/l7_recommendation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for L7 recommendation generation."""

--- a/tests/l7_recommendation/test_constraints.py
+++ b/tests/l7_recommendation/test_constraints.py
@@ -1,0 +1,72 @@
+"""Tests for default L7 recommendation constraints."""
+
+from __future__ import annotations
+
+from main_core.common.contexts import RecommendationConstraintInputs
+from main_core.common.schemas import RecommendationSnapshot, WorldStateSnapshot
+from main_core.l7_recommendation import DefaultConstraintProvider
+
+
+def _world_state(final_regime: str = "neutral") -> WorldStateSnapshot:
+    if final_regime == "risk_off":
+        baseline_regime = "neutral"
+        llm_delta = -1
+    else:
+        baseline_regime = final_regime
+        llm_delta = 0
+    return WorldStateSnapshot(
+        cycle_id="cycle_l7",
+        baseline_regime=baseline_regime,
+        llm_delta=llm_delta,
+        final_regime=final_regime,
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+def _candidate(action_type: str = "buy") -> RecommendationSnapshot:
+    return RecommendationSnapshot(
+        cycle_id="cycle_l7",
+        entity_id="ENT_A",
+        action_type=action_type,
+        rating="A",
+        confidence=0.8,
+        triggered_by="system",
+        override_applied=False,
+        constraints_applied={"existing": "kept"},
+    )
+
+
+def test_default_constraint_provider_downgrades_buy_in_risk_off() -> None:
+    provider = DefaultConstraintProvider()
+
+    result = provider.gate(
+        RecommendationConstraintInputs(world_state=_world_state("risk_off")),
+        _candidate(),
+    )
+
+    assert result.action_type == "hold"
+    assert result.rating == "B"
+    assert result.constraints_applied == {
+        "existing": "kept",
+        "regime_gate": "risk_off_buy_to_hold",
+    }
+
+
+def test_default_constraint_provider_forces_inconclusive_from_risk_context() -> None:
+    provider = DefaultConstraintProvider()
+
+    result = provider.gate(
+        RecommendationConstraintInputs(
+            world_state=_world_state(),
+            risk_context={"force_inconclusive": True},
+        ),
+        _candidate(),
+    )
+
+    assert result.action_type == "inconclusive"
+    assert result.rating is None
+    assert result.confidence is None
+    assert result.constraints_applied["risk_gate"] == "force_inconclusive"

--- a/tests/l7_recommendation/test_override.py
+++ b/tests/l7_recommendation/test_override.py
@@ -1,0 +1,95 @@
+"""Tests for L7 human override handling."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import OverrideRecord, RecommendationSnapshot
+from main_core.l7_recommendation import (
+    InMemoryOverrideStore,
+    apply_override,
+    find_override,
+    submit_override,
+)
+
+
+def _override_payload(**updates: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "cycle_id": "cycle_l7",
+        "entity_id": "ENT_A",
+        "submitted_by": "analyst",
+        "action_type": "buy",
+        "rationale": "human override",
+        "submitted_at": datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+    }
+    payload.update(updates)
+    return payload
+
+
+def _candidate(**updates: object) -> RecommendationSnapshot:
+    payload: dict[str, object] = {
+        "cycle_id": "cycle_l7",
+        "entity_id": "ENT_A",
+        "action_type": "hold",
+        "rating": "B",
+        "confidence": 0.6,
+        "triggered_by": "system",
+        "override_applied": False,
+        "constraints_applied": {"existing": "kept"},
+    }
+    payload.update(updates)
+    return RecommendationSnapshot(**payload)
+
+
+def test_submit_override_accepts_mapping_and_stores_validated_record() -> None:
+    store = InMemoryOverrideStore()
+
+    override = submit_override(_override_payload(), store=store)
+
+    assert isinstance(override, OverrideRecord)
+    assert override.action_type == "buy"
+    assert store.records == (override,)
+    with pytest.raises(ValidationError):
+        OverrideRecord.model_validate({**override.model_dump(), "action_type": "sell"})
+
+
+def test_submit_override_accepts_existing_record() -> None:
+    store = InMemoryOverrideStore()
+    override = OverrideRecord(**_override_payload(action_type="reduce"))
+
+    stored_override = submit_override(override, store=store)
+
+    assert stored_override == override
+    assert stored_override is not override
+    assert store.records == (stored_override,)
+
+
+def test_find_override_returns_matching_cycle_entity_record() -> None:
+    first = OverrideRecord(**_override_payload(entity_id="ENT_B", action_type="reduce"))
+    second = OverrideRecord(**_override_payload())
+
+    assert find_override([first, second], "cycle_l7", "ENT_A") == second
+    assert find_override([first, second], "cycle_l7", "ENT_Z") is None
+
+
+def test_apply_override_sets_human_audit_fields_and_keeps_constraints() -> None:
+    override = OverrideRecord(**_override_payload(action_type="reduce"))
+
+    result = apply_override(_candidate(), override)
+
+    assert result.action_type == "reduce"
+    assert result.rating == "C"
+    assert result.triggered_by == "human_decision"
+    assert result.override_applied is True
+    assert result.constraints_applied == {"existing": "kept"}
+
+
+def test_apply_override_rejects_non_matching_override() -> None:
+    override = OverrideRecord(**_override_payload(entity_id="ENT_B"))
+
+    with pytest.raises(MainCoreError, match="entity_id"):
+        apply_override(_candidate(), override)

--- a/tests/l7_recommendation/test_service.py
+++ b/tests/l7_recommendation/test_service.py
@@ -137,6 +137,27 @@ def test_generate_recommendations_passes_inconclusive_through_explicitly() -> No
     assert recommendation.triggered_by == "system"
 
 
+@pytest.mark.parametrize("override_action", ["buy", "hold", "reduce"])
+def test_generate_recommendations_keeps_inconclusive_after_action_override(
+    override_action: str,
+) -> None:
+    pool = _pool(("ENT_A",))
+    analyses = [_analysis("ENT_A", None, status="inconclusive", confidence=0.0)]
+
+    [recommendation] = generate_recommendations(
+        pool,
+        analyses,
+        _world_state(),
+        overrides=[_override("ENT_A", override_action)],
+    )
+
+    assert recommendation.action_type == "inconclusive"
+    assert recommendation.rating is None
+    assert recommendation.confidence is None
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
+
+
 def test_generate_recommendations_rejects_analysis_outside_pool() -> None:
     pool = _pool(("ENT_A",))
 
@@ -249,6 +270,36 @@ def test_generate_recommendations_preserves_override_audit_after_custom_gate() -
     assert recommendation.action_type == "reduce"
     assert recommendation.triggered_by == "human_decision"
     assert recommendation.override_applied is True
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("cycle_id", "cycle_gate_other"),
+        ("entity_id", "ENT_GATE_OTHER"),
+    ],
+)
+def test_generate_recommendations_rejects_constraint_gate_identity_drift(
+    field_name: str,
+    field_value: str,
+) -> None:
+    class DriftingGate:
+        def gate(
+            self,
+            inputs: RecommendationConstraintInputs,
+            candidate: RecommendationSnapshot,
+        ) -> RecommendationSnapshot:
+            return candidate.model_copy(update={field_name: field_value})
+
+    pool = _pool(("ENT_A",))
+
+    with pytest.raises(MainCoreError, match=field_name):
+        generate_recommendations(
+            pool,
+            [_analysis("ENT_A", 0.8)],
+            _world_state(),
+            constraint_provider=DriftingGate(),
+        )
 
 
 def test_generate_recommendations_has_no_previous_recommendation_parameter() -> None:

--- a/tests/l7_recommendation/test_service.py
+++ b/tests/l7_recommendation/test_service.py
@@ -1,0 +1,258 @@
+"""Tests for formal L7 recommendation generation service."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from inspect import signature
+
+import pytest
+
+from main_core.common.contexts import RecommendationConstraintInputs
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    OfficialAlphaPool,
+    OverrideRecord,
+    RecommendationSnapshot,
+    WorldStateSnapshot,
+)
+from main_core.l7_recommendation import generate_recommendations
+from main_core.l7_recommendation.service import (
+    BUY_SCORE_THRESHOLD,
+    REDUCE_SCORE_THRESHOLD,
+)
+
+
+def _pool(
+    selected_entities: Sequence[str] = ("ENT_A", "ENT_B", "ENT_C"),
+    *,
+    cycle_id: str = "cycle_l7",
+) -> OfficialAlphaPool:
+    return OfficialAlphaPool(
+        cycle_id=cycle_id,
+        observation_pool_size=len(selected_entities),
+        official_alpha_pool_capacity=100,
+        selected_entities=list(selected_entities),
+        added_entities=list(selected_entities),
+        removed_entities=[],
+        freeze_reason_map={},
+    )
+
+
+def _world_state(
+    final_regime: str = "neutral",
+    *,
+    cycle_id: str = "cycle_l7",
+) -> WorldStateSnapshot:
+    if final_regime == "risk_off":
+        baseline_regime = "neutral"
+        llm_delta = -1
+    elif final_regime == "risk_on":
+        baseline_regime = "neutral"
+        llm_delta = 1
+    else:
+        baseline_regime = "neutral"
+        llm_delta = 0
+    return WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime=baseline_regime,
+        llm_delta=llm_delta,
+        final_regime=final_regime,
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+def _analysis(
+    entity_id: str,
+    score: float | None,
+    *,
+    cycle_id: str = "cycle_l7",
+    confidence: float = 0.72,
+    status: str = "ok",
+) -> AlphaResultSnapshot:
+    return AlphaResultSnapshot(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        analyzer_type="single_prompt_v1",
+        score=score,
+        confidence=confidence,
+        rationale="fixture alpha",
+        similar_cases=[],
+        status=status,
+    )
+
+
+def _override(
+    entity_id: str,
+    action_type: str,
+    *,
+    cycle_id: str = "cycle_l7",
+) -> OverrideRecord:
+    return OverrideRecord(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        submitted_by="analyst",
+        action_type=action_type,
+        rationale="human override",
+        submitted_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+    )
+
+
+def test_generate_recommendations_maps_scores_in_pool_order() -> None:
+    pool = _pool(("ENT_B", "ENT_A", "ENT_C"))
+    analyses = [
+        _analysis("ENT_A", BUY_SCORE_THRESHOLD),
+        _analysis("ENT_C", REDUCE_SCORE_THRESHOLD),
+        _analysis("ENT_B", 0.5),
+    ]
+
+    recommendations = generate_recommendations(pool, analyses, _world_state())
+
+    assert [recommendation.entity_id for recommendation in recommendations] == [
+        "ENT_B",
+        "ENT_A",
+        "ENT_C",
+    ]
+    assert [recommendation.action_type for recommendation in recommendations] == [
+        "hold",
+        "buy",
+        "reduce",
+    ]
+    assert [recommendation.rating for recommendation in recommendations] == ["B", "A", "C"]
+
+
+def test_generate_recommendations_passes_inconclusive_through_explicitly() -> None:
+    pool = _pool(("ENT_A",))
+    analyses = [_analysis("ENT_A", None, status="inconclusive", confidence=0.0)]
+
+    [recommendation] = generate_recommendations(pool, analyses, _world_state())
+
+    assert recommendation.action_type == "inconclusive"
+    assert recommendation.rating is None
+    assert recommendation.confidence is None
+    assert recommendation.triggered_by == "system"
+
+
+def test_generate_recommendations_rejects_analysis_outside_pool() -> None:
+    pool = _pool(("ENT_A",))
+
+    with pytest.raises(MainCoreError, match="pool.selected_entities"):
+        generate_recommendations(
+            pool,
+            [_analysis("ENT_A", 0.5), _analysis("ENT_Z", 0.5)],
+            _world_state(),
+        )
+
+
+def test_generate_recommendations_rejects_missing_analysis() -> None:
+    pool = _pool(("ENT_A", "ENT_B"))
+
+    with pytest.raises(MainCoreError, match="missing analysis"):
+        generate_recommendations(pool, [_analysis("ENT_A", 0.5)], _world_state())
+
+
+def test_generate_recommendations_rejects_duplicate_analysis() -> None:
+    pool = _pool(("ENT_A",))
+
+    with pytest.raises(MainCoreError, match="duplicate analysis"):
+        generate_recommendations(
+            pool,
+            [_analysis("ENT_A", 0.5), _analysis("ENT_A", 0.6)],
+            _world_state(),
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"pool": _pool(cycle_id="cycle_pool_other")},
+        {"analyses": [_analysis("ENT_A", 0.5, cycle_id="cycle_analysis_other")]},
+        {"overrides": [_override("ENT_A", "buy", cycle_id="cycle_override_other")]},
+    ],
+)
+def test_generate_recommendations_rejects_cycle_mismatch(kwargs: dict[str, object]) -> None:
+    pool = kwargs.get("pool", _pool(("ENT_A",)))
+    analyses = kwargs.get("analyses", [_analysis("ENT_A", 0.5)])
+    overrides = kwargs.get("overrides", [])
+
+    with pytest.raises(MainCoreError, match="cycle_id"):
+        generate_recommendations(
+            pool,
+            analyses,
+            _world_state(),
+            overrides=overrides,
+        )
+
+
+def test_generate_recommendations_applies_override_before_risk_off_gate() -> None:
+    pool = _pool(("ENT_A",))
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.5)],
+        _world_state("risk_off"),
+        overrides=[_override("ENT_A", "buy")],
+    )
+
+    assert recommendation.action_type == "hold"
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
+    assert recommendation.constraints_applied["regime_gate"] == "risk_off_buy_to_hold"
+
+
+def test_generate_recommendations_force_inconclusive_passes_schema_validation() -> None:
+    pool = _pool(("ENT_A",))
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.8)],
+        _world_state(),
+        risk_context={"force_inconclusive": True},
+    )
+
+    assert recommendation.action_type == "inconclusive"
+    assert recommendation.rating is None
+    assert recommendation.confidence is None
+    assert RecommendationSnapshot.model_validate(recommendation.model_dump()) == recommendation
+
+
+def test_generate_recommendations_preserves_override_audit_after_custom_gate() -> None:
+    class AuditingBrokenGate:
+        def gate(
+            self,
+            inputs: RecommendationConstraintInputs,
+            candidate: RecommendationSnapshot,
+        ) -> RecommendationSnapshot:
+            return candidate.model_copy(
+                update={
+                    "action_type": "reduce",
+                    "rating": "C",
+                    "triggered_by": "system",
+                    "override_applied": False,
+                },
+            )
+
+    pool = _pool(("ENT_A",))
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.8)],
+        _world_state(),
+        constraint_provider=AuditingBrokenGate(),
+        overrides=[_override("ENT_A", "buy")],
+    )
+
+    assert recommendation.action_type == "reduce"
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
+
+
+def test_generate_recommendations_has_no_previous_recommendation_parameter() -> None:
+    parameter_names = set(signature(generate_recommendations).parameters)
+
+    assert "previous_recommendation" not in parameter_names
+    assert "last_recommendation" not in parameter_names

--- a/tests/protocols/test_constraint_provider.py
+++ b/tests/protocols/test_constraint_provider.py
@@ -10,7 +10,7 @@ from main_core.common.protocols import (
     RecommendationConstraintProviderBase,
 )
 from main_core.common.schemas import RecommendationSnapshot, WorldStateSnapshot
-from main_core.l7_recommendation.stubs import NullConstraintProviderStub
+from main_core.l7_recommendation import DefaultConstraintProvider
 
 CYCLE_ID = "cycle_001"
 ENTITY_ID = "ENT_001"
@@ -54,14 +54,14 @@ def test_constraint_provider_protocol_imports() -> None:
     assert RecommendationConstraintProviderBase is not None
 
 
-def test_null_constraint_provider_matches_runtime_protocol() -> None:
-    provider = NullConstraintProviderStub()
+def test_default_constraint_provider_matches_runtime_protocol() -> None:
+    provider = DefaultConstraintProvider()
 
     assert isinstance(provider, RecommendationConstraintProvider)
 
 
-def test_null_constraint_provider_returns_candidate_unchanged() -> None:
-    provider = NullConstraintProviderStub()
+def test_default_constraint_provider_returns_neutral_candidate_unchanged() -> None:
+    provider = DefaultConstraintProvider()
     candidate = _candidate()
 
     gated_candidate = provider.gate(_constraint_inputs(), candidate)


### PR DESCRIPTION
Closes #10

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `tests/schemas/test_feature_bundle.py`


---
### 1. 背景与目标
项目文档 §11.3 / §12.3 / §9 要求 L7 生成正式 `RecommendationSnapshot`，显式处理 `inconclusive`，并保证 constraint gate 优先于 human override。当前代码已有 `RecommendationSnapshot`、`OverrideRecord`、`RecommendationConstraintInputs` 与 `RecommendationConstraintProvider` 协议，但 `NullConstraintProviderStub` 只原样返回 candidate，`l7_recommendation` 没有正式服务入口。目标是在 L7 包内实现 deterministic recommendation 生成、override 提交/应用、默认 regime/risk gate 和 `generate_recommendations(...)`。

### 2. 所属模块
**Primary writable paths:**
- `src/main_core/l7_recommendation/__init__.py`
- `src/main_core/l7_recommendation/stubs.py`
- `src/main_core/l7_recommendation/constraints.py`（新建）
- `src/main_core/l7_recommendation/override.py`（新建）
- `src/main_core/l7_recommendation/service.py`（新建）
- `tests/l7_recommendation/**`（新建）
- `tests/protocols/test_constraint_provider.py`

**Adjacent read-only / integration paths:**
- `src/main_core/common/schemas/recommendation.py`：产出 `RecommendationSnapshot`
- `src/main_core/common/schemas/override.py`：消费/返回 `OverrideRecord`
- `src/main_core/common/schemas/pool.py`：消费 `OfficialAlphaPool`
- `src/main_core/common/schemas/alpha.py`：消费 `AlphaResultSnapshot`
- `src/main_core/common/schemas/world_state.py`：消费 `WorldStateSnapshot`
- `src/main_core/common/contexts.py`：复用 `RecommendationConstraintInputs`
- `src/main_core/common/protocols/constraint_provider.py`：实现 `RecommendationConstraintProviderBase`
- `src/main_core/common/errors.py`：复用 `MainCoreError`

### 3. 实现范围
- 在 `src/main_core/l7_recommendation/constraints.py` 新建 `DefaultConstraintProvider(RecommendationConstraintProviderBase)`，实现 `gate(inputs: RecommendationConstraintInputs, candidate: RecommendationSnapshot) -> RecommendationSnapshot`。
- 默认 gate 规则保持最小且确定性：`world_state.final_regime == "risk_off"` 时将 `buy` 降为 `hold` 并记录 `constraints_applied["regime_gate"]`；`risk_context["force_inconclusive"] is True` 时输出 `action_type="inconclusive"`、`rating=None`、`confidence=None`。
- 在 `src/main_core/l7_recommendation/override.py` 定义 `OverrideStore` `Protocol