### PR TITLE
feat(#34): [milestone-2 review] P0: Frozen L5 entities can be selected without current-cycle feature inputs

### DIFF
--- a/src/main_core/l5_universe/service.py
+++ b/src/main_core/l5_universe/service.py
@@ -30,9 +30,13 @@ def select_official_alpha_pool(  # noqa: PLR0913
 
     active_config = config or PoolSelectionConfig(capacity=capacity)
     bundle_list = list(bundles)
-    _validate_inputs(world_state, bundle_list)
+    current_entity_ids = _validate_inputs(world_state, bundle_list)
 
     freeze_reason_map = merge_frozen_entities(previous_pool, frozen_entities)
+    _ensure_frozen_entities_have_current_bundles(
+        freeze_reason_map,
+        current_entity_ids,
+    )
     ensure_frozen_entities_fit_capacity(freeze_reason_map, active_config.capacity)
 
     observation_candidates = rank_candidates(world_state, bundle_list, active_config)
@@ -60,7 +64,7 @@ def select_official_alpha_pool(  # noqa: PLR0913
 def _validate_inputs(
     world_state: WorldStateSnapshot,
     bundles: Sequence[FeatureSignalBundle],
-) -> None:
+) -> set[str]:
     if not bundles:
         raise MainCoreError("bundles must not be empty")
 
@@ -73,6 +77,25 @@ def _validate_inputs(
         if entity_id in seen_entity_ids:
             raise MainCoreError("duplicate entity_id in FeatureSignalBundle input")
         seen_entity_ids.add(entity_id)
+    return seen_entity_ids
+
+
+def _ensure_frozen_entities_have_current_bundles(
+    freeze_reason_map: Mapping[EntityId, str],
+    current_entity_ids: set[str],
+) -> None:
+    """Require each frozen entity to have current L3 feature inputs."""
+
+    missing_entity_ids = sorted(
+        str(entity_id)
+        for entity_id in freeze_reason_map
+        if str(entity_id) not in current_entity_ids
+    )
+    if missing_entity_ids:
+        raise MainCoreError(
+            "frozen entities must be present in current FeatureSignalBundle input: "
+            f"{', '.join(missing_entity_ids)}",
+        )
 
 
 def _select_entities(

--- a/tests/l5_universe/test_service.py
+++ b/tests/l5_universe/test_service.py
@@ -179,6 +179,31 @@ def test_select_official_alpha_pool_rejects_too_many_frozen_entities() -> None:
         )
 
 
+def test_select_official_alpha_pool_rejects_stale_previous_pool_freeze() -> None:
+    previous_pool = _pool(
+        selected_entities=["ENT_STALE"],
+        freeze_reason_map={"ENT_STALE": "stale core freeze"},
+    )
+
+    with pytest.raises(MainCoreError, match="frozen entities must be present"):
+        select_official_alpha_pool(
+            _world_state(),
+            [_bundle("ENT_A", 2.0)],
+            previous_pool=previous_pool,
+            capacity=2,
+        )
+
+
+def test_select_official_alpha_pool_rejects_explicit_frozen_entity_without_bundle() -> None:
+    with pytest.raises(MainCoreError, match="frozen entities must be present"):
+        select_official_alpha_pool(
+            _world_state(),
+            [_bundle("ENT_A", 2.0)],
+            frozen_entities={"ENT_STALE": "manual freeze"},
+            capacity=2,
+        )
+
+
 @pytest.mark.parametrize("capacity", [0, 101])
 def test_select_official_alpha_pool_rejects_capacity_outside_bounds(capacity: int) -> None:
     with pytest.raises(MainCoreError, match="official_alpha_pool_capacity"):


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
select_official_alpha_pool() merges previous and explicit frozen entities, then appends all frozen IDs before selecting ranked current observation candidates. There is no check that those frozen IDs exist in the current FeatureSignalBundle input set. That can emit selected_entities for which L6 cannot construct an AlphaAnalysisContext, causing the L5-L6-L7 closed loop to fail or forcing downstream code to invent missing feature data.

## 实现范围
- 修改文件: `src/main_core/l5_universe/service.py`
- Define the freeze invariant explicitly: either frozen entities must be present in the current L3 bundle set, or L5 must emit a formal removal/fallback path for missing data. For P2, reject frozen IDs absent from current bundles and add tests for stale previous_pool freezes and explicit frozen_entities outside the observation set.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
