### PR TITLE
feat(#33): [milestone-2 review] P0: Submitted overrides are not connected to recommendation generation

### DIFF
--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -79,14 +79,27 @@ def _resolve_overrides(
     override_store: OverrideStore | None,
 ) -> tuple[OverrideRecord, ...]:
     if overrides is not None:
-        return tuple(overrides)
+        return _latest_overrides_by_cycle_entity(overrides)
 
-    active_store = override_store or _default_override_store()
-    return tuple(
-        override
-        for override in active_store.list_overrides()
-        if override.cycle_id == pool.cycle_id
+    active_store = (
+        override_store if override_store is not None else _default_override_store()
     )
+    return _latest_overrides_by_cycle_entity(
+        tuple(
+            override
+            for override in active_store.list_overrides()
+            if override.cycle_id == pool.cycle_id
+        ),
+    )
+
+
+def _latest_overrides_by_cycle_entity(
+    overrides: Sequence[OverrideRecord],
+) -> tuple[OverrideRecord, ...]:
+    latest_by_key: dict[tuple[str, str], OverrideRecord] = {}
+    for override in overrides:
+        latest_by_key[(str(override.cycle_id), str(override.entity_id))] = override
+    return tuple(latest_by_key.values())
 
 
 def _default_override_store() -> OverrideStore:

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -17,7 +17,7 @@ from main_core.common.schemas import (
     WorldStateSnapshot,
 )
 from main_core.l7_recommendation.constraints import DefaultConstraintProvider
-from main_core.l7_recommendation.override import apply_override, find_override
+from main_core.l7_recommendation.override import OverrideStore, apply_override, find_override
 
 BUY_SCORE_THRESHOLD = 0.65
 REDUCE_SCORE_THRESHOLD = 0.35
@@ -30,11 +30,13 @@ def generate_recommendations(  # noqa: PLR0913
     *,
     constraint_provider: RecommendationConstraintProvider | None = None,
     overrides: Sequence[OverrideRecord] | None = None,
+    override_store: OverrideStore | None = None,
     risk_context: Mapping[str, Any] | None = None,
 ) -> list[RecommendationSnapshot]:
     """Generate one formal recommendation per selected pool entity."""
 
-    analysis_by_entity = _validate_inputs(pool, analyses, world_state, overrides or ())
+    active_overrides = _resolve_overrides(pool, overrides, override_store)
+    analysis_by_entity = _validate_inputs(pool, analyses, world_state, active_overrides)
     active_provider = constraint_provider or DefaultConstraintProvider()
     constraint_inputs = RecommendationConstraintInputs(
         world_state=world_state,
@@ -45,7 +47,7 @@ def generate_recommendations(  # noqa: PLR0913
     for entity_id in pool.selected_entities:
         candidate = _candidate_from_analysis(analysis_by_entity[str(entity_id)])
         source_is_inconclusive = candidate.action_type == "inconclusive"
-        matching_override = find_override(overrides or (), pool.cycle_id, entity_id)
+        matching_override = find_override(active_overrides, pool.cycle_id, entity_id)
         override_was_applied = matching_override is not None
         if matching_override is not None:
             candidate = apply_override(candidate, matching_override)
@@ -69,6 +71,28 @@ def generate_recommendations(  # noqa: PLR0913
         recommendations.append(gated_candidate)
 
     return recommendations
+
+
+def _resolve_overrides(
+    pool: OfficialAlphaPool,
+    overrides: Sequence[OverrideRecord] | None,
+    override_store: OverrideStore | None,
+) -> tuple[OverrideRecord, ...]:
+    if overrides is not None:
+        return tuple(overrides)
+
+    active_store = override_store or _default_override_store()
+    return tuple(
+        override
+        for override in active_store.list_overrides()
+        if override.cycle_id == pool.cycle_id
+    )
+
+
+def _default_override_store() -> OverrideStore:
+    from main_core.l7_recommendation.override import _DEFAULT_OVERRIDE_STORE
+
+    return _DEFAULT_OVERRIDE_STORE
 
 
 def _validate_inputs(

--- a/tests/l7_recommendation/test_service.py
+++ b/tests/l7_recommendation/test_service.py
@@ -95,6 +95,7 @@ def _override(
     action_type: str,
     *,
     cycle_id: str = "cycle_l7",
+    submitted_at: datetime | None = None,
 ) -> OverrideRecord:
     return OverrideRecord(
         cycle_id=cycle_id,
@@ -102,7 +103,7 @@ def _override(
         submitted_by="analyst",
         action_type=action_type,
         rationale="human override",
-        submitted_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+        submitted_at=submitted_at or datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
     )
 
 
@@ -252,6 +253,69 @@ def test_submit_override_default_store_feeds_recommendation_generation(
     assert recommendation.triggered_by == "human_decision"
     assert recommendation.override_applied is True
     assert recommendation.constraints_applied["regime_gate"] == "risk_off_buy_to_hold"
+
+
+def test_submit_override_default_store_latest_matching_submission_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_store = InMemoryOverrideStore()
+    monkeypatch.setattr(
+        "main_core.l7_recommendation.override._DEFAULT_OVERRIDE_STORE",
+        default_store,
+    )
+    pool = _pool(("ENT_A",))
+
+    submit_override(
+        _override(
+            "ENT_A",
+            "buy",
+            submitted_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+        ),
+    )
+    submit_override(
+        _override(
+            "ENT_A",
+            "reduce",
+            submitted_at=datetime(2026, 1, 2, 3, 4, 6, tzinfo=UTC),
+        ),
+    )
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.5)],
+        _world_state("risk_off"),
+    )
+
+    assert recommendation.action_type == "reduce"
+    assert recommendation.rating == "C"
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
+    assert "regime_gate" not in recommendation.constraints_applied
+
+
+def test_generate_recommendations_honors_explicit_falsey_override_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FalseyOverrideStore(InMemoryOverrideStore):
+        def __len__(self) -> int:
+            return 0
+
+    default_store = InMemoryOverrideStore([_override("ENT_A", "buy")])
+    monkeypatch.setattr(
+        "main_core.l7_recommendation.override._DEFAULT_OVERRIDE_STORE",
+        default_store,
+    )
+    pool = _pool(("ENT_A",))
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.5)],
+        _world_state(),
+        override_store=FalseyOverrideStore(),
+    )
+
+    assert recommendation.action_type == "hold"
+    assert recommendation.triggered_by == "system"
+    assert recommendation.override_applied is False
 
 
 def test_generate_recommendations_force_inconclusive_passes_schema_validation() -> None:

--- a/tests/l7_recommendation/test_service.py
+++ b/tests/l7_recommendation/test_service.py
@@ -17,7 +17,11 @@ from main_core.common.schemas import (
     RecommendationSnapshot,
     WorldStateSnapshot,
 )
-from main_core.l7_recommendation import generate_recommendations
+from main_core.l7_recommendation import (
+    InMemoryOverrideStore,
+    generate_recommendations,
+    submit_override,
+)
 from main_core.l7_recommendation.service import (
     BUY_SCORE_THRESHOLD,
     REDUCE_SCORE_THRESHOLD,
@@ -217,6 +221,31 @@ def test_generate_recommendations_applies_override_before_risk_off_gate() -> Non
         [_analysis("ENT_A", 0.5)],
         _world_state("risk_off"),
         overrides=[_override("ENT_A", "buy")],
+    )
+
+    assert recommendation.action_type == "hold"
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
+    assert recommendation.constraints_applied["regime_gate"] == "risk_off_buy_to_hold"
+
+
+def test_submit_override_default_store_feeds_recommendation_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_store = InMemoryOverrideStore(
+        [_override("ENT_Z", "reduce", cycle_id="cycle_other")],
+    )
+    monkeypatch.setattr(
+        "main_core.l7_recommendation.override._DEFAULT_OVERRIDE_STORE",
+        default_store,
+    )
+    pool = _pool(("ENT_A",))
+
+    submit_override(_override("ENT_A", "buy"))
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.5)],
+        _world_state("risk_off"),
     )
 
     assert recommendation.action_type == "hold"


### PR DESCRIPTION
Closes #33

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
submit_override() persists to an override store, including a module-level default store, but generate_recommendations() only looks at the explicit overrides sequence passed to that call. A caller using the documented public flow submit_override(override_input) followed by generate_recommendations(...) will not see the override take effect unless it manually extracts and passes records. This breaks the milestone goal that override submission becomes effective and makes the new store abstraction disconnected from the service path.

## 实现范围
- 修改文件: `src/main_core/l7_recommendation/service.py`
- Introduce a single L7 service boundary that owns the OverrideStore, or add an override_store parameter to generate_recommendations and default it consistently with submit_override. Add an integration test that calls submit_override(), then generate_recommendations(), and verifies the matching override is applied before the constraint gate.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
