### PR TITLE
feat(#32): [milestone-2 review] P0: Legacy L7 stub still bypasses the real constraint gate

### DIFF
--- a/src/main_core/l7_recommendation/stubs.py
+++ b/src/main_core/l7_recommendation/stubs.py
@@ -1,23 +1,12 @@
-"""P2 recommendation constraint stubs for L7."""
+"""Compatibility exports for implemented L7 recommendation constraints."""
 
 from __future__ import annotations
 
-from main_core.common.contexts import RecommendationConstraintInputs
-from main_core.common.protocols import RecommendationConstraintProviderBase
-from main_core.common.schemas import RecommendationSnapshot
+from main_core.l7_recommendation.constraints import DefaultConstraintProvider
 
 
-class NullConstraintProviderStub(RecommendationConstraintProviderBase):
-    """P2 placeholder, wired in milestone-2."""
-
-    def gate(
-        self,
-        inputs: RecommendationConstraintInputs,
-        candidate: RecommendationSnapshot,
-    ) -> RecommendationSnapshot:
-        """Return the candidate unchanged until real regime/risk gates land."""
-
-        return candidate
+class NullConstraintProviderStub(DefaultConstraintProvider):
+    """Backward-compatible name for the real default L7 constraint provider."""
 
 
 __all__ = ["NullConstraintProviderStub"]

--- a/tests/l7_recommendation/test_constraints.py
+++ b/tests/l7_recommendation/test_constraints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from main_core.common.contexts import RecommendationConstraintInputs
 from main_core.common.schemas import RecommendationSnapshot, WorldStateSnapshot
 from main_core.l7_recommendation import DefaultConstraintProvider
+from main_core.l7_recommendation.stubs import NullConstraintProviderStub
 
 
 def _world_state(final_regime: str = "neutral") -> WorldStateSnapshot:
@@ -70,3 +71,16 @@ def test_default_constraint_provider_forces_inconclusive_from_risk_context() -> 
     assert result.rating is None
     assert result.confidence is None
     assert result.constraints_applied["risk_gate"] == "force_inconclusive"
+
+
+def test_legacy_null_constraint_provider_stub_downgrades_buy_in_risk_off() -> None:
+    inputs = RecommendationConstraintInputs(world_state=_world_state("risk_off"))
+    candidate = _candidate()
+
+    legacy_result = NullConstraintProviderStub().gate(inputs, candidate)
+    default_result = DefaultConstraintProvider().gate(inputs, candidate)
+
+    assert legacy_result == default_result
+    assert legacy_result.action_type == "hold"
+    assert legacy_result.rating == "B"
+    assert legacy_result.constraints_applied["regime_gate"] == "risk_off_buy_to_hold"


### PR DESCRIPTION
Closes #32

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
Issue #10 explicitly calls out NullConstraintProviderStub as the pre-milestone problem, but the milestone leaves src/main_core/l7_recommendation/stubs.py returning the candidate unchanged. L4 and L6 converted their historical stubs into aliases for the real implementations; L7 did not. Any caller that still imports this public compatibility path gets a valid RecommendationConstraintProvider that bypasses risk_off and force_inconclusive gates, which defeats the milestone's constraint-priority requirement.

## 实现范围
- 修改文件: `src/main_core/l7_recommendation/stubs.py`
- Replace NullConstraintProviderStub with a compatibility subclass/alias of DefaultConstraintProvider, or remove the stub and fail old imports loudly. Add a regression test proving the legacy import downgrades risk_off buy candidates the same way as DefaultConstraintProvider.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
