### PR TITLE
feat(#11): 实现 l8_publish 发布装配与 manifest 发起

### DIFF
--- a/src/main_core/l8_publish/__init__.py
+++ b/src/main_core/l8_publish/__init__.py
@@ -1,1 +1,22 @@
-"""L8 package — publish bundle work; see §14 of main-core.project-doc.md."""
+"""L8 package — publish bundle assembly and manifest publication."""
+
+from main_core.l8_publish.assembler import prepare_publish_bundle
+from main_core.l8_publish.publish_port import (
+    CommittedFormalObject,
+    DataPlatformPublishPort,
+    DerivedFormalObjectBuilder,
+    FormalObjectSource,
+    ManifestWriteResult,
+)
+from main_core.l8_publish.refs import formal_object_ref, formal_object_refs
+
+__all__ = [
+    "CommittedFormalObject",
+    "DataPlatformPublishPort",
+    "DerivedFormalObjectBuilder",
+    "FormalObjectSource",
+    "ManifestWriteResult",
+    "formal_object_ref",
+    "formal_object_refs",
+    "prepare_publish_bundle",
+]

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -206,17 +206,30 @@ def _validate_publish_consistency(
             f"missing alpha result for selected pool entities: {missing}",
         )
 
-    for recommendation in recommendations:
-        recommendation_entity_id = str(recommendation.entity_id)
-        if recommendation_entity_id not in selected_entity_ids:
-            raise ManifestPublishError(
-                "recommendation entity_id must belong to pool.selected_entities",
-            )
+    recommendation_entity_ids = _unique_entity_ids(
+        RECOMMENDATION_SNAPSHOT_KEY,
+        recommendations,
+    )
+    extra_recommendation_entity_ids = recommendation_entity_ids - selected_entity_ids
+    if extra_recommendation_entity_ids:
+        extra = ", ".join(sorted(extra_recommendation_entity_ids))
+        raise ManifestPublishError(
+            "recommendation entity_id must belong to pool.selected_entities: "
+            f"{extra}",
+        )
+
+    missing_recommendation_entity_ids = selected_entity_ids - recommendation_entity_ids
+    if missing_recommendation_entity_ids:
+        missing = ", ".join(sorted(missing_recommendation_entity_ids))
+        raise ManifestPublishError(
+            "missing recommendation for selected pool entities: "
+            f"{missing}",
+        )
 
 
 def _unique_entity_ids(
     object_key: str,
-    formal_objects: Sequence[AlphaResultSnapshot],
+    formal_objects: Sequence[AlphaResultSnapshot | RecommendationSnapshot],
 ) -> set[str]:
     entity_ids: set[str] = set()
     for formal_object in formal_objects:

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -1,0 +1,294 @@
+"""L8 publish bundle assembly boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    FormalObjectBase,
+    OfficialAlphaPool,
+    PublishBundle,
+    RecommendationSnapshot,
+)
+from main_core.common.types import CycleId
+from main_core.l8_publish.audit_payload import (
+    build_audit_payload,
+    build_retrospective_seed,
+)
+from main_core.l8_publish.manifest import (
+    build_manifest_candidate,
+    commit_formal_objects,
+    write_manifest_after_commits,
+)
+from main_core.l8_publish.publish_port import (
+    CommittedFormalObject,
+    DataPlatformPublishPort,
+    DerivedFormalObjectBuilder,
+    FormalObjectSource,
+    FormalObjectValue,
+)
+from main_core.l8_publish.refs import (
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    CANONICAL_FORMAL_OBJECT_KEYS,
+    OFFICIAL_ALPHA_POOL_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+    WORLD_STATE_SNAPSHOT_KEY,
+)
+
+
+def collect_formal_objects(
+    cycle_id: CycleId,
+    source: FormalObjectSource,
+) -> dict[str, FormalObjectValue]:
+    """Load and validate formal objects already produced by L4-L7."""
+
+    requested_cycle_id = CycleId(str(cycle_id))
+    try:
+        world_state = source.load_world_state(requested_cycle_id)
+        pool = source.load_official_alpha_pool(requested_cycle_id)
+        alpha_results = tuple(source.load_alpha_results(requested_cycle_id))
+        recommendations = tuple(source.load_recommendations(requested_cycle_id))
+    except ManifestPublishError:
+        raise
+    except Exception as exc:
+        raise ManifestPublishError("failed to load formal objects for publish") from exc
+
+    formal_objects: dict[str, FormalObjectValue] = {
+        WORLD_STATE_SNAPSHOT_KEY: world_state,
+        OFFICIAL_ALPHA_POOL_KEY: pool,
+        ALPHA_RESULT_SNAPSHOT_KEY: alpha_results,
+        RECOMMENDATION_SNAPSHOT_KEY: recommendations,
+    }
+    _validate_formal_object_cycles(requested_cycle_id, formal_objects)
+    _validate_publish_consistency(
+        pool=pool,
+        alpha_results=alpha_results,
+        recommendations=recommendations,
+    )
+    return formal_objects
+
+
+def prepare_publish_bundle(
+    cycle_id: CycleId,
+    *,
+    source: FormalObjectSource,
+    publish_port: DataPlatformPublishPort,
+    derived_builders: Sequence[DerivedFormalObjectBuilder] = (),
+) -> PublishBundle:
+    """Prepare, commit, manifest, and return the formal L8 publish bundle."""
+
+    requested_cycle_id = CycleId(str(cycle_id))
+    formal_objects = collect_formal_objects(requested_cycle_id, source)
+    formal_objects = _apply_derived_builders(
+        requested_cycle_id,
+        formal_objects,
+        derived_builders,
+    )
+
+    committed_objects = commit_formal_objects(
+        requested_cycle_id,
+        formal_objects,
+        publish_port,
+    )
+    manifest = write_manifest_after_commits(
+        requested_cycle_id,
+        committed_objects,
+        publish_port,
+    )
+    bundle_formal_objects = _build_bundle_formal_objects(
+        formal_objects,
+        committed_objects,
+    )
+
+    return PublishBundle(
+        cycle_id=requested_cycle_id,
+        formal_objects=bundle_formal_objects,
+        manifest_candidate=build_manifest_candidate(
+            requested_cycle_id,
+            committed_objects,
+            manifest,
+        ),
+        audit_payload=build_audit_payload(
+            requested_cycle_id,
+            bundle_formal_objects,
+            committed_objects,
+            manifest,
+        ),
+        retrospective_seed=build_retrospective_seed(
+            requested_cycle_id,
+            bundle_formal_objects,
+            committed_objects,
+        ),
+    )
+
+
+def _apply_derived_builders(
+    cycle_id: CycleId,
+    formal_objects: Mapping[str, FormalObjectValue],
+    derived_builders: Sequence[DerivedFormalObjectBuilder],
+) -> dict[str, FormalObjectValue]:
+    if not derived_builders:
+        return dict(formal_objects)
+
+    active_formal_objects = dict(formal_objects)
+    for builder in derived_builders:
+        draft_bundle = PublishBundle(
+            cycle_id=cycle_id,
+            formal_objects=_build_uncommitted_bundle_formal_objects(active_formal_objects),
+            manifest_candidate={},
+            audit_payload={},
+            retrospective_seed={},
+        )
+        try:
+            derived_objects = builder(cycle_id, draft_bundle)
+        except ManifestPublishError:
+            raise
+        except Exception as exc:
+            raise ManifestPublishError("failed to build derived formal objects") from exc
+
+        for object_key, formal_object in derived_objects.items():
+            if object_key in active_formal_objects:
+                raise ManifestPublishError(
+                    f"derived formal object duplicates key {object_key}",
+                )
+            if not isinstance(formal_object, FormalObjectBase):
+                raise ManifestPublishError(
+                    f"derived formal object {object_key} must be FormalObjectBase",
+                )
+            _ensure_cycle_id(object_key, formal_object, cycle_id)
+            active_formal_objects[object_key] = formal_object
+
+    return active_formal_objects
+
+
+def _validate_formal_object_cycles(
+    cycle_id: CycleId,
+    formal_objects: Mapping[str, FormalObjectValue],
+) -> None:
+    for object_key, value in formal_objects.items():
+        if isinstance(value, FormalObjectBase):
+            _ensure_cycle_id(object_key, value, cycle_id)
+            continue
+        for item in value:
+            _ensure_cycle_id(object_key, item, cycle_id)
+
+
+def _ensure_cycle_id(
+    object_key: str,
+    formal_object: FormalObjectBase,
+    cycle_id: CycleId,
+) -> None:
+    object_cycle_id = getattr(formal_object, "cycle_id", None)
+    if object_cycle_id != cycle_id:
+        raise ManifestPublishError(
+            f"{object_key}.cycle_id must match requested cycle_id",
+        )
+
+
+def _validate_publish_consistency(
+    *,
+    pool: OfficialAlphaPool,
+    alpha_results: Sequence[AlphaResultSnapshot],
+    recommendations: Sequence[RecommendationSnapshot],
+) -> None:
+    selected_entity_ids = {str(entity_id) for entity_id in pool.selected_entities}
+    alpha_entity_ids = _unique_entity_ids(
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        alpha_results,
+    )
+    missing_alpha_entity_ids = selected_entity_ids - alpha_entity_ids
+    if missing_alpha_entity_ids:
+        missing = ", ".join(sorted(missing_alpha_entity_ids))
+        raise ManifestPublishError(
+            f"missing alpha result for selected pool entities: {missing}",
+        )
+
+    for recommendation in recommendations:
+        recommendation_entity_id = str(recommendation.entity_id)
+        if recommendation_entity_id not in selected_entity_ids:
+            raise ManifestPublishError(
+                "recommendation entity_id must belong to pool.selected_entities",
+            )
+
+
+def _unique_entity_ids(
+    object_key: str,
+    formal_objects: Sequence[AlphaResultSnapshot],
+) -> set[str]:
+    entity_ids: set[str] = set()
+    for formal_object in formal_objects:
+        entity_id = str(formal_object.entity_id)
+        if entity_id in entity_ids:
+            raise ManifestPublishError(f"duplicate {object_key} entity_id")
+        entity_ids.add(entity_id)
+    return entity_ids
+
+
+def _build_bundle_formal_objects(
+    formal_objects: Mapping[str, FormalObjectValue],
+    committed_objects: Sequence[CommittedFormalObject],
+) -> dict[str, dict[str, Any]]:
+    committed_by_key = {
+        committed.object_key: committed
+        for committed in committed_objects
+    }
+    bundle_formal_objects: dict[str, dict[str, Any]] = {}
+    for object_key in _ordered_object_keys(formal_objects):
+        committed_object = committed_by_key.get(object_key)
+        if committed_object is None:
+            raise ManifestPublishError(f"missing commit result for {object_key}")
+        bundle_formal_objects[object_key] = _bundle_formal_object_entry(
+            formal_objects[object_key],
+            committed_object.ref,
+        )
+    return bundle_formal_objects
+
+
+def _build_uncommitted_bundle_formal_objects(
+    formal_objects: Mapping[str, FormalObjectValue],
+) -> dict[str, dict[str, Any]]:
+    return {
+        object_key: _bundle_formal_object_entry(value, "")
+        for object_key, value in formal_objects.items()
+    }
+
+
+def _bundle_formal_object_entry(
+    value: FormalObjectValue,
+    ref: str,
+) -> dict[str, Any]:
+    payload = _bundle_payload(value)
+    return {
+        "ref": ref,
+        "payload": payload,
+        "count": len(payload) if isinstance(payload, list) else 1,
+    }
+
+
+def _bundle_payload(value: FormalObjectValue) -> dict[str, Any] | list[dict[str, Any]]:
+    if isinstance(value, FormalObjectBase):
+        return value.model_dump(mode="json")
+    return [
+        item.model_dump(mode="json")
+        for item in value
+    ]
+
+
+def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
+    canonical_keys = [
+        object_key
+        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
+        if object_key in formal_objects
+    ]
+    derived_keys = [
+        object_key
+        for object_key in formal_objects
+        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
+    ]
+    return (*canonical_keys, *derived_keys)
+
+
+__all__ = ["collect_formal_objects", "prepare_publish_bundle"]

--- a/src/main_core/l8_publish/audit_payload.py
+++ b/src/main_core/l8_publish/audit_payload.py
@@ -1,0 +1,134 @@
+"""Audit and retrospective payload builders for L8 publication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from main_core.common.types import CycleId
+from main_core.l8_publish.publish_port import (
+    CommittedFormalObject,
+    ManifestWriteResult,
+)
+from main_core.l8_publish.refs import (
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    OFFICIAL_ALPHA_POOL_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+    WORLD_STATE_SNAPSHOT_KEY,
+)
+
+
+def build_audit_payload(
+    cycle_id: CycleId,
+    formal_objects: Mapping[str, Any],
+    committed_objects: Sequence[CommittedFormalObject],
+    manifest: ManifestWriteResult,
+) -> dict[str, Any]:
+    """Build the publication audit payload from committed formal objects."""
+
+    alpha_results = _payload_list(formal_objects, ALPHA_RESULT_SNAPSHOT_KEY)
+    recommendations = _payload_list(formal_objects, RECOMMENDATION_SNAPSHOT_KEY)
+
+    return {
+        "cycle_id": str(cycle_id),
+        "object_counts": _object_counts(formal_objects),
+        "commit_refs": _commit_refs(committed_objects),
+        "manifest_ref": manifest.manifest_ref,
+        "manifest_version": manifest.manifest_version,
+        "inconclusive_count": sum(
+            1
+            for alpha_result in alpha_results
+            if alpha_result.get("status") == "inconclusive"
+        ),
+        "override_applied_count": sum(
+            1
+            for recommendation in recommendations
+            if recommendation.get("override_applied") is True
+        ),
+        "selected_entity_ids": _selected_entity_ids(formal_objects),
+        "recommendation_entity_ids": _recommendation_entity_ids(formal_objects),
+    }
+
+
+def build_retrospective_seed(
+    cycle_id: CycleId,
+    formal_objects: Mapping[str, Any],
+    committed_objects: Sequence[CommittedFormalObject],
+) -> dict[str, Any]:
+    """Build the retrospective seed carried by the publish bundle."""
+
+    commit_refs = _commit_refs(committed_objects)
+    return {
+        "cycle_id": str(cycle_id),
+        "world_state_ref": commit_refs.get(WORLD_STATE_SNAPSHOT_KEY),
+        "pool_ref": commit_refs.get(OFFICIAL_ALPHA_POOL_KEY),
+        "recommendation_ref": commit_refs.get(RECOMMENDATION_SNAPSHOT_KEY),
+        "selected_entity_ids": _selected_entity_ids(formal_objects),
+        "recommendation_entity_ids": _recommendation_entity_ids(formal_objects),
+    }
+
+
+def _object_counts(formal_objects: Mapping[str, Any]) -> dict[str, int]:
+    return {
+        object_key: _entry_count(entry)
+        for object_key, entry in formal_objects.items()
+    }
+
+
+def _commit_refs(committed_objects: Sequence[CommittedFormalObject]) -> dict[str, str]:
+    return {
+        committed.object_key: committed.ref
+        for committed in committed_objects
+    }
+
+
+def _selected_entity_ids(formal_objects: Mapping[str, Any]) -> list[str]:
+    payload = _payload_mapping(formal_objects, OFFICIAL_ALPHA_POOL_KEY)
+    selected_entities = payload.get("selected_entities", [])
+    if not isinstance(selected_entities, Sequence) or isinstance(
+        selected_entities,
+        (str, bytes),
+    ):
+        return []
+    return [str(entity_id) for entity_id in selected_entities]
+
+
+def _recommendation_entity_ids(formal_objects: Mapping[str, Any]) -> list[str]:
+    return [
+        str(recommendation["entity_id"])
+        for recommendation in _payload_list(formal_objects, RECOMMENDATION_SNAPSHOT_KEY)
+        if "entity_id" in recommendation
+    ]
+
+
+def _payload_mapping(formal_objects: Mapping[str, Any], object_key: str) -> Mapping[str, Any]:
+    entry = formal_objects.get(object_key, {})
+    if not isinstance(entry, Mapping):
+        return {}
+    payload = entry.get("payload", {})
+    if isinstance(payload, Mapping):
+        return payload
+    return {}
+
+
+def _payload_list(formal_objects: Mapping[str, Any], object_key: str) -> list[Mapping[str, Any]]:
+    entry = formal_objects.get(object_key, {})
+    if not isinstance(entry, Mapping):
+        return []
+    payload = entry.get("payload", [])
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
+        return []
+    return [
+        item
+        for item in payload
+        if isinstance(item, Mapping)
+    ]
+
+
+def _entry_count(entry: Any) -> int:
+    if isinstance(entry, Mapping) and isinstance(entry.get("count"), int):
+        return entry["count"]
+    return 0
+
+
+__all__ = ["build_audit_payload", "build_retrospective_seed"]

--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -1,0 +1,134 @@
+"""Manifest-backed formal object commit helpers for L8 publication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import FormalObjectBase
+from main_core.common.types import CycleId
+from main_core.l8_publish.publish_port import (
+    CommittedFormalObject,
+    DataPlatformPublishPort,
+    FormalObjectValue,
+    ManifestWriteResult,
+)
+from main_core.l8_publish.refs import CANONICAL_FORMAL_OBJECT_KEYS
+
+
+def commit_formal_objects(
+    cycle_id: CycleId,
+    formal_objects: Mapping[str, FormalObjectValue],
+    publish_port: DataPlatformPublishPort,
+) -> tuple[CommittedFormalObject, ...]:
+    """Commit formal object classes in stable order before manifest publication."""
+
+    committed_objects: list[CommittedFormalObject] = []
+    for object_key in _ordered_object_keys(formal_objects):
+        payload = _commit_payload(formal_objects[object_key])
+        try:
+            committed_object = publish_port.commit_formal_object(
+                cycle_id=cycle_id,
+                object_key=object_key,
+                payload=payload,
+            )
+        except ManifestPublishError:
+            raise
+        except Exception as exc:
+            raise ManifestPublishError(
+                f"failed to commit formal object {object_key}",
+            ) from exc
+
+        if committed_object.object_key != object_key:
+            raise ManifestPublishError(
+                f"commit result object_key mismatch for {object_key}",
+            )
+        committed_objects.append(committed_object)
+
+    return tuple(committed_objects)
+
+
+def write_manifest_after_commits(
+    cycle_id: CycleId,
+    committed_objects: Sequence[CommittedFormalObject],
+    publish_port: DataPlatformPublishPort,
+) -> ManifestWriteResult:
+    """Write the cycle manifest only after all formal object commits succeed."""
+
+    try:
+        return publish_port.write_cycle_manifest(
+            cycle_id=cycle_id,
+            committed_objects=tuple(committed_objects),
+        )
+    except ManifestPublishError:
+        raise
+    except Exception as exc:
+        raise ManifestPublishError("failed to write cycle publish manifest") from exc
+
+
+def build_manifest_candidate(
+    cycle_id: CycleId,
+    committed_objects: Sequence[CommittedFormalObject],
+    manifest: ManifestWriteResult | None = None,
+) -> dict[str, Any]:
+    """Build the manifest candidate embedded in the returned publish bundle."""
+
+    candidate: dict[str, Any] = {
+        "cycle_id": str(cycle_id),
+        "object_refs": {
+            committed.object_key: committed.ref
+            for committed in committed_objects
+        },
+        "committed_objects": [
+            {
+                "object_key": committed.object_key,
+                "ref": committed.ref,
+                "snapshot_id": committed.snapshot_id,
+                "payload_hash": committed.payload_hash,
+                "row_count": committed.row_count,
+            }
+            for committed in committed_objects
+        ],
+    }
+    if manifest is not None:
+        candidate.update(
+            {
+                "manifest_ref": manifest.manifest_ref,
+                "manifest_version": manifest.manifest_version,
+                "table_snapshots": dict(manifest.table_snapshots),
+            }
+        )
+    return candidate
+
+
+def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
+    canonical_keys = [
+        object_key
+        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
+        if object_key in formal_objects
+    ]
+    derived_keys = [
+        object_key
+        for object_key in formal_objects
+        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
+    ]
+    return (*canonical_keys, *derived_keys)
+
+
+def _commit_payload(value: FormalObjectValue) -> Mapping[str, Any]:
+    if isinstance(value, FormalObjectBase):
+        return value.model_dump(mode="json")
+
+    payload_items = [
+        item.model_dump(mode="json")
+        for item in value
+    ]
+    return {"items": payload_items, "count": len(payload_items)}
+
+
+__all__ = [
+    "build_manifest_candidate",
+    "commit_formal_objects",
+    "write_manifest_after_commits",
+]

--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -26,7 +26,9 @@ def commit_formal_objects(
 
     committed_objects: list[CommittedFormalObject] = []
     for object_key in _ordered_object_keys(formal_objects):
-        payload = _commit_payload(formal_objects[object_key])
+        formal_object = formal_objects[object_key]
+        payload = _commit_payload(formal_object)
+        expected_row_count = _expected_row_count(formal_object)
         try:
             committed_object = publish_port.commit_formal_object(
                 cycle_id=cycle_id,
@@ -40,10 +42,11 @@ def commit_formal_objects(
                 f"failed to commit formal object {object_key}",
             ) from exc
 
-        if committed_object.object_key != object_key:
-            raise ManifestPublishError(
-                f"commit result object_key mismatch for {object_key}",
-            )
+        _validate_committed_formal_object(
+            committed_object,
+            object_key,
+            expected_row_count,
+        )
         committed_objects.append(committed_object)
 
     return tuple(committed_objects)
@@ -56,15 +59,18 @@ def write_manifest_after_commits(
 ) -> ManifestWriteResult:
     """Write the cycle manifest only after all formal object commits succeed."""
 
+    committed_tuple = tuple(committed_objects)
     try:
-        return publish_port.write_cycle_manifest(
+        manifest = publish_port.write_cycle_manifest(
             cycle_id=cycle_id,
-            committed_objects=tuple(committed_objects),
+            committed_objects=committed_tuple,
         )
     except ManifestPublishError:
         raise
     except Exception as exc:
         raise ManifestPublishError("failed to write cycle publish manifest") from exc
+    _validate_manifest_write_result(manifest, committed_tuple)
+    return manifest
 
 
 def build_manifest_candidate(
@@ -125,6 +131,80 @@ def _commit_payload(value: FormalObjectValue) -> Mapping[str, Any]:
         for item in value
     ]
     return {"items": payload_items, "count": len(payload_items)}
+
+
+def _expected_row_count(value: FormalObjectValue) -> int:
+    if isinstance(value, FormalObjectBase):
+        return 1
+    return len(value)
+
+
+def _validate_committed_formal_object(
+    committed_object: CommittedFormalObject,
+    object_key: str,
+    expected_row_count: int,
+) -> None:
+    if not isinstance(committed_object, CommittedFormalObject):
+        raise ManifestPublishError(
+            f"commit result for {object_key} must be CommittedFormalObject",
+        )
+    if committed_object.object_key != object_key:
+        raise ManifestPublishError(
+            f"commit result object_key mismatch for {object_key}",
+        )
+    for field_name in ("ref", "snapshot_id", "payload_hash"):
+        field_value = getattr(committed_object, field_name)
+        if not _non_empty_string(field_value):
+            raise ManifestPublishError(
+                f"commit result {field_name} must be non-empty for {object_key}",
+            )
+    if (
+        not isinstance(committed_object.row_count, int)
+        or isinstance(committed_object.row_count, bool)
+        or committed_object.row_count < 0
+    ):
+        raise ManifestPublishError(
+            f"commit result row_count must be non-negative for {object_key}",
+        )
+    if committed_object.row_count != expected_row_count:
+        raise ManifestPublishError(
+            f"commit result row_count mismatch for {object_key}",
+        )
+
+
+def _validate_manifest_write_result(
+    manifest: ManifestWriteResult,
+    committed_objects: Sequence[CommittedFormalObject],
+) -> None:
+    if not isinstance(manifest, ManifestWriteResult):
+        raise ManifestPublishError("manifest result must be ManifestWriteResult")
+    if not _non_empty_string(manifest.manifest_ref):
+        raise ManifestPublishError("manifest_ref must be non-empty")
+    if not _non_empty_string(manifest.manifest_version):
+        raise ManifestPublishError("manifest_version must be non-empty")
+    if not isinstance(manifest.table_snapshots, Mapping):
+        raise ManifestPublishError("manifest table_snapshots must be a mapping")
+
+    committed_object_keys = {committed.object_key for committed in committed_objects}
+    table_snapshot_keys = set(manifest.table_snapshots)
+    missing_object_keys = committed_object_keys - table_snapshot_keys
+    if missing_object_keys:
+        missing = ", ".join(sorted(missing_object_keys))
+        raise ManifestPublishError(
+            f"manifest table_snapshots missing committed object keys: {missing}",
+        )
+    for object_key in committed_object_keys:
+        table_snapshot = manifest.table_snapshots[object_key]
+        if table_snapshot is None or (
+            isinstance(table_snapshot, str) and not table_snapshot.strip()
+        ):
+            raise ManifestPublishError(
+                f"manifest table_snapshots entry must be non-empty for {object_key}",
+            )
+
+
+def _non_empty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
 
 __all__ = [

--- a/src/main_core/l8_publish/publish_port.py
+++ b/src/main_core/l8_publish/publish_port.py
@@ -1,0 +1,97 @@
+"""L8 publish source and data-platform boundary protocols."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    FormalObjectBase,
+    OfficialAlphaPool,
+    PublishBundle,
+    RecommendationSnapshot,
+    WorldStateSnapshot,
+)
+from main_core.common.types import CycleId
+
+FormalObjectValue = FormalObjectBase | Sequence[FormalObjectBase]
+
+
+@dataclass(frozen=True)
+class CommittedFormalObject:
+    """Reference returned after one formal object class is committed."""
+
+    object_key: str
+    ref: str
+    snapshot_id: str
+    payload_hash: str
+    row_count: int
+
+
+@dataclass(frozen=True)
+class ManifestWriteResult:
+    """Reference returned after the cycle manifest becomes visible."""
+
+    manifest_ref: str
+    manifest_version: str
+    table_snapshots: Mapping[str, Any]
+
+
+class FormalObjectSource(Protocol):
+    """Read already-built formal objects from upstream L4-L7 boundaries."""
+
+    def load_world_state(self, cycle_id: CycleId) -> WorldStateSnapshot:
+        """Load the formal L4 world-state snapshot for a cycle."""
+
+    def load_official_alpha_pool(self, cycle_id: CycleId) -> OfficialAlphaPool:
+        """Load the formal L5 official alpha pool for a cycle."""
+
+    def load_alpha_results(self, cycle_id: CycleId) -> Sequence[AlphaResultSnapshot]:
+        """Load formal L6 alpha result snapshots for a cycle."""
+
+    def load_recommendations(self, cycle_id: CycleId) -> Sequence[RecommendationSnapshot]:
+        """Load formal L7 recommendation snapshots for a cycle."""
+
+
+class DataPlatformPublishPort(Protocol):
+    """Manifest-backed formal object publication boundary."""
+
+    def commit_formal_object(
+        self,
+        *,
+        cycle_id: CycleId,
+        object_key: str,
+        payload: Mapping[str, Any],
+    ) -> CommittedFormalObject:
+        """Commit one formal object class before the manifest is written."""
+
+    def write_cycle_manifest(
+        self,
+        *,
+        cycle_id: CycleId,
+        committed_objects: Sequence[CommittedFormalObject],
+    ) -> ManifestWriteResult:
+        """Write the cycle manifest after all formal object commits succeed."""
+
+
+class DerivedFormalObjectBuilder(Protocol):
+    """Future hook for derived L8 formal objects such as reports."""
+
+    def __call__(
+        self,
+        cycle_id: CycleId,
+        bundle: PublishBundle,
+    ) -> Mapping[str, FormalObjectBase]:
+        """Build derived formal objects from a pre-publish bundle draft."""
+
+
+__all__ = [
+    "CommittedFormalObject",
+    "DataPlatformPublishPort",
+    "DerivedFormalObjectBuilder",
+    "FormalObjectSource",
+    "FormalObjectValue",
+    "ManifestWriteResult",
+]

--- a/src/main_core/l8_publish/refs.py
+++ b/src/main_core/l8_publish/refs.py
@@ -1,0 +1,75 @@
+"""Canonical formal object keys and ref readers for L8 publish bundles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import PublishBundle
+
+WORLD_STATE_SNAPSHOT_KEY = "world_state_snapshot"
+OFFICIAL_ALPHA_POOL_KEY = "official_alpha_pool"
+ALPHA_RESULT_SNAPSHOT_KEY = "alpha_result_snapshot"
+RECOMMENDATION_SNAPSHOT_KEY = "recommendation_snapshot"
+
+CANONICAL_FORMAL_OBJECT_KEYS: tuple[str, ...] = (
+    WORLD_STATE_SNAPSHOT_KEY,
+    OFFICIAL_ALPHA_POOL_KEY,
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+)
+
+
+def formal_object_ref(bundle: PublishBundle, object_key: str) -> str:
+    """Return the single canonical ref for a formal object entry."""
+
+    refs = formal_object_refs(bundle, object_key)
+    if len(refs) != 1:
+        raise ManifestPublishError(f"{object_key} must expose exactly one formal ref")
+    return refs[0]
+
+
+def formal_object_refs(bundle: PublishBundle, object_key: str) -> tuple[str, ...]:
+    """Return formal refs from a bundle entry using the canonical ref shape."""
+
+    entry = _formal_object_entry(bundle, object_key)
+    if "refs" in entry:
+        refs = entry["refs"]
+        if (
+            isinstance(refs, Sequence)
+            and not isinstance(refs, (str, bytes))
+            and all(isinstance(ref, str) for ref in refs)
+        ):
+            return tuple(refs)
+        raise ManifestPublishError(f"{object_key}.refs must be a sequence of strings")
+
+    ref = entry.get("ref")
+    if not isinstance(ref, str) or not ref:
+        raise ManifestPublishError(f"{object_key}.ref must be a non-empty string")
+    return (ref,)
+
+
+def _formal_object_entry(
+    bundle: PublishBundle,
+    object_key: str,
+) -> Mapping[str, Any]:
+    try:
+        entry = bundle.formal_objects[object_key]
+    except KeyError as exc:
+        raise ManifestPublishError(f"missing formal object entry {object_key}") from exc
+
+    if not isinstance(entry, Mapping):
+        raise ManifestPublishError(f"{object_key} formal object entry must be a mapping")
+    return entry
+
+
+__all__ = [
+    "ALPHA_RESULT_SNAPSHOT_KEY",
+    "CANONICAL_FORMAL_OBJECT_KEYS",
+    "OFFICIAL_ALPHA_POOL_KEY",
+    "RECOMMENDATION_SNAPSHOT_KEY",
+    "WORLD_STATE_SNAPSHOT_KEY",
+    "formal_object_ref",
+    "formal_object_refs",
+]

--- a/tests/l8_publish/__init__.py
+++ b/tests/l8_publish/__init__.py
@@ -1,0 +1,188 @@
+"""Local fakes and factories for L8 publish tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    OfficialAlphaPool,
+    RecommendationSnapshot,
+    WorldStateSnapshot,
+)
+from main_core.common.types import CycleId
+from main_core.l8_publish import CommittedFormalObject, ManifestWriteResult
+
+
+def world_state(cycle_id: str = "cycle_l8") -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+def pool(
+    selected_entities: Sequence[str] = ("ENT_A", "ENT_B"),
+    *,
+    cycle_id: str = "cycle_l8",
+) -> OfficialAlphaPool:
+    return OfficialAlphaPool(
+        cycle_id=cycle_id,
+        observation_pool_size=len(selected_entities),
+        official_alpha_pool_capacity=100,
+        selected_entities=list(selected_entities),
+        added_entities=list(selected_entities),
+        removed_entities=[],
+        freeze_reason_map={},
+    )
+
+
+def alpha_result(
+    entity_id: str,
+    *,
+    cycle_id: str = "cycle_l8",
+    score: float | None = 0.7,
+    status: str = "ok",
+) -> AlphaResultSnapshot:
+    return AlphaResultSnapshot(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        analyzer_type="single_prompt_v1",
+        score=score,
+        confidence=0.8 if status == "ok" else 0.0,
+        rationale="fixture alpha",
+        similar_cases=[],
+        status=status,
+    )
+
+
+def recommendation(
+    entity_id: str,
+    *,
+    cycle_id: str = "cycle_l8",
+    action_type: str = "buy",
+    override_applied: bool = False,
+) -> RecommendationSnapshot:
+    return RecommendationSnapshot(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        action_type=action_type,
+        rating="A" if action_type == "buy" else "B",
+        confidence=0.8,
+        triggered_by="human_decision" if override_applied else "system",
+        override_applied=override_applied,
+        constraints_applied={},
+    )
+
+
+class FakeFormalObjectSource:
+    def __init__(
+        self,
+        *,
+        loaded_world_state: WorldStateSnapshot | None = None,
+        loaded_pool: OfficialAlphaPool | None = None,
+        loaded_alpha_results: Sequence[AlphaResultSnapshot] | None = None,
+        loaded_recommendations: Sequence[RecommendationSnapshot] | None = None,
+    ) -> None:
+        self.world_state = loaded_world_state or world_state()
+        self.pool = loaded_pool or pool()
+        self.alpha_results = tuple(
+            loaded_alpha_results
+            or (
+                alpha_result("ENT_A"),
+                alpha_result("ENT_B", score=None, status="inconclusive"),
+            )
+        )
+        self.recommendations = tuple(
+            loaded_recommendations
+            or (
+                recommendation("ENT_A", override_applied=True),
+                RecommendationSnapshot(
+                    cycle_id="cycle_l8",
+                    entity_id="ENT_B",
+                    action_type="inconclusive",
+                    rating=None,
+                    confidence=None,
+                    triggered_by="system",
+                    override_applied=False,
+                    constraints_applied={},
+                ),
+            )
+        )
+        self.calls: list[tuple[str, CycleId]] = []
+
+    def load_world_state(self, cycle_id: CycleId) -> WorldStateSnapshot:
+        self.calls.append(("world_state", cycle_id))
+        return self.world_state
+
+    def load_official_alpha_pool(self, cycle_id: CycleId) -> OfficialAlphaPool:
+        self.calls.append(("pool", cycle_id))
+        return self.pool
+
+    def load_alpha_results(self, cycle_id: CycleId) -> Sequence[AlphaResultSnapshot]:
+        self.calls.append(("alpha", cycle_id))
+        return self.alpha_results
+
+    def load_recommendations(self, cycle_id: CycleId) -> Sequence[RecommendationSnapshot]:
+        self.calls.append(("recommendation", cycle_id))
+        return self.recommendations
+
+
+class RecordingPublishPort:
+    def __init__(
+        self,
+        *,
+        fail_on_object_key: str | None = None,
+        fail_manifest: bool = False,
+    ) -> None:
+        self.fail_on_object_key = fail_on_object_key
+        self.fail_manifest = fail_manifest
+        self.commit_calls: list[tuple[CycleId, str, Mapping[str, Any]]] = []
+        self.manifest_calls: list[
+            tuple[CycleId, tuple[CommittedFormalObject, ...]]
+        ] = []
+
+    def commit_formal_object(
+        self,
+        *,
+        cycle_id: CycleId,
+        object_key: str,
+        payload: Mapping[str, Any],
+    ) -> CommittedFormalObject:
+        self.commit_calls.append((cycle_id, object_key, payload))
+        if object_key == self.fail_on_object_key:
+            raise RuntimeError(f"commit failed for {object_key}")
+        row_count = int(payload.get("count", 1))
+        return CommittedFormalObject(
+            object_key=object_key,
+            ref=f"{object_key}/{cycle_id}/ref",
+            snapshot_id=f"{object_key}-snapshot",
+            payload_hash=f"{object_key}-hash",
+            row_count=row_count,
+        )
+
+    def write_cycle_manifest(
+        self,
+        *,
+        cycle_id: CycleId,
+        committed_objects: Sequence[CommittedFormalObject],
+    ) -> ManifestWriteResult:
+        committed_tuple = tuple(committed_objects)
+        self.manifest_calls.append((cycle_id, committed_tuple))
+        if self.fail_manifest:
+            raise RuntimeError("manifest write failed")
+        return ManifestWriteResult(
+            manifest_ref=f"manifest/{cycle_id}",
+            manifest_version="v1",
+            table_snapshots={
+                committed.object_key: committed.snapshot_id
+                for committed in committed_tuple
+            },
+        )

--- a/tests/l8_publish/test_assembler.py
+++ b/tests/l8_publish/test_assembler.py
@@ -1,0 +1,172 @@
+"""Tests for L8 publish bundle assembly."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.errors import ManifestPublishError
+from main_core.l8_publish import formal_object_ref, formal_object_refs, prepare_publish_bundle
+from main_core.l8_publish.assembler import collect_formal_objects
+from main_core.l8_publish.refs import (
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    CANONICAL_FORMAL_OBJECT_KEYS,
+    OFFICIAL_ALPHA_POOL_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+    WORLD_STATE_SNAPSHOT_KEY,
+)
+from tests.l8_publish import (
+    FakeFormalObjectSource,
+    RecordingPublishPort,
+    alpha_result,
+    pool,
+    recommendation,
+    world_state,
+)
+
+SINGLE_OBJECT_COUNT = 1
+ALPHA_RESULT_COUNT = 2
+
+
+def test_collect_formal_objects_loads_source_in_layer_order() -> None:
+    source = FakeFormalObjectSource()
+
+    formal_objects = collect_formal_objects("cycle_l8", source)
+
+    assert tuple(formal_objects) == CANONICAL_FORMAL_OBJECT_KEYS
+    assert source.calls == [
+        ("world_state", "cycle_l8"),
+        ("pool", "cycle_l8"),
+        ("alpha", "cycle_l8"),
+        ("recommendation", "cycle_l8"),
+    ]
+
+
+def test_prepare_publish_bundle_returns_canonical_formal_object_entries() -> None:
+    source = FakeFormalObjectSource()
+    publish_port = RecordingPublishPort()
+
+    bundle = prepare_publish_bundle(
+        "cycle_l8",
+        source=source,
+        publish_port=publish_port,
+    )
+
+    bundle_payload = bundle.model_dump(mode="json")
+    formal_objects = bundle_payload["formal_objects"]
+    assert bundle.cycle_id == "cycle_l8"
+    assert tuple(formal_objects) == CANONICAL_FORMAL_OBJECT_KEYS
+    assert set(formal_objects[WORLD_STATE_SNAPSHOT_KEY]) == {
+        "count",
+        "payload",
+        "ref",
+    }
+    assert formal_objects[WORLD_STATE_SNAPSHOT_KEY]["payload"] == (
+        source.world_state.model_dump(mode="json")
+    )
+    assert formal_objects[ALPHA_RESULT_SNAPSHOT_KEY]["payload"] == [
+        alpha.model_dump(mode="json")
+        for alpha in source.alpha_results
+    ]
+    assert formal_objects[OFFICIAL_ALPHA_POOL_KEY]["count"] == SINGLE_OBJECT_COUNT
+    assert formal_objects[ALPHA_RESULT_SNAPSHOT_KEY]["count"] == ALPHA_RESULT_COUNT
+    assert formal_object_ref(bundle, WORLD_STATE_SNAPSHOT_KEY) == (
+        "world_state_snapshot/cycle_l8/ref"
+    )
+    assert formal_object_refs(bundle, RECOMMENDATION_SNAPSHOT_KEY) == (
+        "recommendation_snapshot/cycle_l8/ref",
+    )
+    assert bundle_payload["manifest_candidate"]["manifest_ref"] == "manifest/cycle_l8"
+    assert bundle_payload["audit_payload"]["object_counts"] == {
+        WORLD_STATE_SNAPSHOT_KEY: SINGLE_OBJECT_COUNT,
+        OFFICIAL_ALPHA_POOL_KEY: SINGLE_OBJECT_COUNT,
+        ALPHA_RESULT_SNAPSHOT_KEY: ALPHA_RESULT_COUNT,
+        RECOMMENDATION_SNAPSHOT_KEY: ALPHA_RESULT_COUNT,
+    }
+    assert bundle_payload["audit_payload"]["inconclusive_count"] == SINGLE_OBJECT_COUNT
+    assert bundle_payload["audit_payload"]["override_applied_count"] == SINGLE_OBJECT_COUNT
+    assert bundle_payload["retrospective_seed"]["selected_entity_ids"] == [
+        "ENT_A",
+        "ENT_B",
+    ]
+    assert bundle_payload["retrospective_seed"]["recommendation_entity_ids"] == [
+        "ENT_A",
+        "ENT_B",
+    ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        FakeFormalObjectSource(loaded_world_state=world_state("cycle_other")),
+        FakeFormalObjectSource(loaded_pool=pool(cycle_id="cycle_other")),
+        FakeFormalObjectSource(
+            loaded_alpha_results=[alpha_result("ENT_A", cycle_id="cycle_other")],
+        ),
+        FakeFormalObjectSource(
+            loaded_recommendations=[recommendation("ENT_A", cycle_id="cycle_other")],
+        ),
+    ],
+)
+def test_prepare_publish_bundle_rejects_cycle_mismatch_before_commit(
+    source: FakeFormalObjectSource,
+) -> None:
+    publish_port = RecordingPublishPort()
+
+    with pytest.raises(ManifestPublishError, match="cycle_id"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=source,
+            publish_port=publish_port,
+        )
+
+    assert publish_port.commit_calls == []
+    assert publish_port.manifest_calls == []
+
+
+def test_prepare_publish_bundle_rejects_missing_alpha_for_selected_pool_entity() -> None:
+    source = FakeFormalObjectSource(
+        loaded_pool=pool(("ENT_A", "ENT_B")),
+        loaded_alpha_results=[alpha_result("ENT_A")],
+        loaded_recommendations=[recommendation("ENT_A")],
+    )
+    publish_port = RecordingPublishPort()
+
+    with pytest.raises(ManifestPublishError, match="missing alpha result"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=source,
+            publish_port=publish_port,
+        )
+
+    assert publish_port.commit_calls == []
+    assert publish_port.manifest_calls == []
+
+
+def test_prepare_publish_bundle_rejects_recommendation_outside_pool() -> None:
+    source = FakeFormalObjectSource(
+        loaded_pool=pool(("ENT_A",)),
+        loaded_alpha_results=[alpha_result("ENT_A")],
+        loaded_recommendations=[recommendation("ENT_Z")],
+    )
+    publish_port = RecordingPublishPort()
+
+    with pytest.raises(ManifestPublishError, match="pool.selected_entities"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=source,
+            publish_port=publish_port,
+        )
+
+    assert publish_port.commit_calls == []
+    assert publish_port.manifest_calls == []
+
+
+def test_formal_object_ref_rejects_missing_entry() -> None:
+    bundle = prepare_publish_bundle(
+        "cycle_l8",
+        source=FakeFormalObjectSource(),
+        publish_port=RecordingPublishPort(),
+    )
+
+    with pytest.raises(ManifestPublishError, match="missing formal object"):
+        formal_object_ref(bundle, "dashboard_snapshot")

--- a/tests/l8_publish/test_assembler.py
+++ b/tests/l8_publish/test_assembler.py
@@ -161,6 +161,47 @@ def test_prepare_publish_bundle_rejects_recommendation_outside_pool() -> None:
     assert publish_port.manifest_calls == []
 
 
+def test_prepare_publish_bundle_rejects_missing_recommendation_for_pool_entity() -> None:
+    source = FakeFormalObjectSource(
+        loaded_pool=pool(("ENT_A", "ENT_B")),
+        loaded_alpha_results=[alpha_result("ENT_A"), alpha_result("ENT_B")],
+        loaded_recommendations=[recommendation("ENT_A")],
+    )
+    publish_port = RecordingPublishPort()
+
+    with pytest.raises(ManifestPublishError, match="missing recommendation"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=source,
+            publish_port=publish_port,
+        )
+
+    assert publish_port.commit_calls == []
+    assert publish_port.manifest_calls == []
+
+
+def test_prepare_publish_bundle_rejects_duplicate_recommendation_entity() -> None:
+    source = FakeFormalObjectSource(
+        loaded_pool=pool(("ENT_A", "ENT_B")),
+        loaded_alpha_results=[alpha_result("ENT_A"), alpha_result("ENT_B")],
+        loaded_recommendations=[
+            recommendation("ENT_A"),
+            recommendation("ENT_A", action_type="hold"),
+        ],
+    )
+    publish_port = RecordingPublishPort()
+
+    with pytest.raises(ManifestPublishError, match="duplicate recommendation_snapshot"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=source,
+            publish_port=publish_port,
+        )
+
+    assert publish_port.commit_calls == []
+    assert publish_port.manifest_calls == []
+
+
 def test_formal_object_ref_rejects_missing_entry() -> None:
     bundle = prepare_publish_bundle(
         "cycle_l8",

--- a/tests/l8_publish/test_manifest.py
+++ b/tests/l8_publish/test_manifest.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import pytest
 
 from main_core.common.errors import ManifestPublishError
-from main_core.l8_publish import prepare_publish_bundle
+from main_core.common.types import CycleId
+from main_core.l8_publish import (
+    CommittedFormalObject,
+    ManifestWriteResult,
+    prepare_publish_bundle,
+)
 from main_core.l8_publish.manifest import (
     build_manifest_candidate,
     commit_formal_objects,
@@ -57,6 +65,30 @@ def test_commit_formal_objects_uses_stable_publish_order() -> None:
     assert manifest.manifest_ref == "manifest/cycle_l8"
 
 
+@pytest.mark.parametrize(
+    ("override", "match"),
+    [
+        ({"ref": ""}, "ref must be non-empty"),
+        ({"snapshot_id": ""}, "snapshot_id must be non-empty"),
+        ({"payload_hash": ""}, "payload_hash must be non-empty"),
+        ({"row_count": -1}, "row_count must be non-negative"),
+        ({"row_count": 0}, "row_count mismatch"),
+    ],
+)
+def test_commit_formal_objects_rejects_invalid_commit_result(
+    override: Mapping[str, Any],
+    match: str,
+) -> None:
+    publish_port = InvalidCommitResultPublishPort(override=override)
+
+    with pytest.raises(ManifestPublishError, match=match):
+        commit_formal_objects(
+            "cycle_l8",
+            {WORLD_STATE_SNAPSHOT_KEY: world_state()},
+            publish_port,
+        )
+
+
 def test_build_manifest_candidate_includes_commit_and_manifest_refs() -> None:
     publish_port = RecordingPublishPort()
     committed_objects = commit_formal_objects(
@@ -75,6 +107,39 @@ def test_build_manifest_candidate_includes_commit_and_manifest_refs() -> None:
     assert candidate["table_snapshots"] == {
         WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot-snapshot",
     }
+
+
+@pytest.mark.parametrize(
+    ("override", "match"),
+    [
+        ({"manifest_ref": ""}, "manifest_ref must be non-empty"),
+        ({"manifest_version": ""}, "manifest_version must be non-empty"),
+        ({"table_snapshots": []}, "table_snapshots must be a mapping"),
+        ({"table_snapshots": {}}, "missing committed object keys"),
+        (
+            {"table_snapshots": {WORLD_STATE_SNAPSHOT_KEY: ""}},
+            "table_snapshots entry must be non-empty",
+        ),
+    ],
+)
+def test_write_manifest_after_commits_rejects_invalid_manifest_result(
+    override: Mapping[str, Any],
+    match: str,
+) -> None:
+    publish_port = RecordingPublishPort()
+    committed_objects = commit_formal_objects(
+        "cycle_l8",
+        {WORLD_STATE_SNAPSHOT_KEY: world_state()},
+        publish_port,
+    )
+    invalid_manifest_port = InvalidManifestResultPublishPort(override=override)
+
+    with pytest.raises(ManifestPublishError, match=match):
+        write_manifest_after_commits(
+            "cycle_l8",
+            committed_objects,
+            invalid_manifest_port,
+        )
 
 
 def test_prepare_publish_bundle_does_not_write_manifest_after_commit_failure() -> None:
@@ -112,3 +177,53 @@ def test_prepare_publish_bundle_raises_when_manifest_write_fails() -> None:
         RECOMMENDATION_SNAPSHOT_KEY,
     ]
     assert len(publish_port.manifest_calls) == 1
+
+
+class InvalidCommitResultPublishPort(RecordingPublishPort):
+    def __init__(self, *, override: Mapping[str, Any]) -> None:
+        super().__init__()
+        self.override = dict(override)
+
+    def commit_formal_object(
+        self,
+        *,
+        cycle_id: CycleId,
+        object_key: str,
+        payload: Mapping[str, Any],
+    ) -> CommittedFormalObject:
+        committed = super().commit_formal_object(
+            cycle_id=cycle_id,
+            object_key=object_key,
+            payload=payload,
+        )
+        return CommittedFormalObject(
+            object_key=self.override.get("object_key", committed.object_key),
+            ref=self.override.get("ref", committed.ref),
+            snapshot_id=self.override.get("snapshot_id", committed.snapshot_id),
+            payload_hash=self.override.get("payload_hash", committed.payload_hash),
+            row_count=self.override.get("row_count", committed.row_count),
+        )
+
+
+class InvalidManifestResultPublishPort(RecordingPublishPort):
+    def __init__(self, *, override: Mapping[str, Any]) -> None:
+        super().__init__()
+        self.override = dict(override)
+
+    def write_cycle_manifest(
+        self,
+        *,
+        cycle_id: CycleId,
+        committed_objects: Sequence[CommittedFormalObject],
+    ) -> ManifestWriteResult:
+        committed_tuple = tuple(committed_objects)
+        self.manifest_calls.append((cycle_id, committed_tuple))
+        table_snapshots = {
+            committed.object_key: committed.snapshot_id
+            for committed in committed_tuple
+        }
+        return ManifestWriteResult(
+            manifest_ref=self.override.get("manifest_ref", f"manifest/{cycle_id}"),
+            manifest_version=self.override.get("manifest_version", "v1"),
+            table_snapshots=self.override.get("table_snapshots", table_snapshots),
+        )

--- a/tests/l8_publish/test_manifest.py
+++ b/tests/l8_publish/test_manifest.py
@@ -1,0 +1,114 @@
+"""Tests for L8 formal object commits and manifest semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.errors import ManifestPublishError
+from main_core.l8_publish import prepare_publish_bundle
+from main_core.l8_publish.manifest import (
+    build_manifest_candidate,
+    commit_formal_objects,
+    write_manifest_after_commits,
+)
+from main_core.l8_publish.refs import (
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    OFFICIAL_ALPHA_POOL_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+    WORLD_STATE_SNAPSHOT_KEY,
+)
+from tests.l8_publish import (
+    FakeFormalObjectSource,
+    RecordingPublishPort,
+    alpha_result,
+    pool,
+    recommendation,
+    world_state,
+)
+
+
+def test_commit_formal_objects_uses_stable_publish_order() -> None:
+    formal_objects = {
+        RECOMMENDATION_SNAPSHOT_KEY: (recommendation("ENT_A"),),
+        ALPHA_RESULT_SNAPSHOT_KEY: (alpha_result("ENT_A"),),
+        WORLD_STATE_SNAPSHOT_KEY: world_state(),
+        OFFICIAL_ALPHA_POOL_KEY: pool(("ENT_A",)),
+    }
+    publish_port = RecordingPublishPort()
+
+    committed_objects = commit_formal_objects(
+        "cycle_l8",
+        formal_objects,
+        publish_port,
+    )
+    manifest = write_manifest_after_commits(
+        "cycle_l8",
+        committed_objects,
+        publish_port,
+    )
+
+    assert [call[1] for call in publish_port.commit_calls] == [
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        RECOMMENDATION_SNAPSHOT_KEY,
+    ]
+    assert publish_port.manifest_calls == [("cycle_l8", committed_objects)]
+    assert manifest.manifest_ref == "manifest/cycle_l8"
+
+
+def test_build_manifest_candidate_includes_commit_and_manifest_refs() -> None:
+    publish_port = RecordingPublishPort()
+    committed_objects = commit_formal_objects(
+        "cycle_l8",
+        {WORLD_STATE_SNAPSHOT_KEY: world_state()},
+        publish_port,
+    )
+    manifest = write_manifest_after_commits("cycle_l8", committed_objects, publish_port)
+
+    candidate = build_manifest_candidate("cycle_l8", committed_objects, manifest)
+
+    assert candidate["object_refs"] == {
+        WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot/cycle_l8/ref",
+    }
+    assert candidate["manifest_ref"] == "manifest/cycle_l8"
+    assert candidate["table_snapshots"] == {
+        WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot-snapshot",
+    }
+
+
+def test_prepare_publish_bundle_does_not_write_manifest_after_commit_failure() -> None:
+    publish_port = RecordingPublishPort(fail_on_object_key=ALPHA_RESULT_SNAPSHOT_KEY)
+
+    with pytest.raises(ManifestPublishError, match="failed to commit"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=FakeFormalObjectSource(),
+            publish_port=publish_port,
+        )
+
+    assert [call[1] for call in publish_port.commit_calls] == [
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+    ]
+    assert publish_port.manifest_calls == []
+
+
+def test_prepare_publish_bundle_raises_when_manifest_write_fails() -> None:
+    publish_port = RecordingPublishPort(fail_manifest=True)
+
+    with pytest.raises(ManifestPublishError, match="manifest"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=FakeFormalObjectSource(),
+            publish_port=publish_port,
+        )
+
+    assert [call[1] for call in publish_port.commit_calls] == [
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        RECOMMENDATION_SNAPSHOT_KEY,
+    ]
+    assert len(publish_port.manifest_calls) == 1

--- a/tests/l8_publish/test_publish_integration.py
+++ b/tests/l8_publish/test_publish_integration.py
@@ -1,0 +1,157 @@
+"""Minimal P2 L1-L8 style publication integration tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.schemas import FeatureSignalBundle
+from main_core.l4_world_state import derive_world_state
+from main_core.l5_universe import select_official_alpha_pool
+from main_core.l6_alpha import (
+    AlphaReasonerResponse,
+    SinglePromptAnalyzer,
+    StaticAlphaReasonerPort,
+    analyze_stock,
+)
+from main_core.l7_recommendation import (
+    InMemoryOverrideStore,
+    generate_recommendations,
+    submit_override,
+)
+from main_core.l8_publish import prepare_publish_bundle
+from main_core.l8_publish.refs import RECOMMENDATION_SNAPSHOT_KEY
+from tests.l8_publish import FakeFormalObjectSource, RecordingPublishPort
+
+
+class SourceWithPreviousRecommendationTrap(FakeFormalObjectSource):
+    def load_previous_recommendations(self, cycle_id: str) -> None:
+        raise AssertionError(f"L8 must not read previous recommendations for {cycle_id}")
+
+
+def test_publish_consumes_current_l7_output_without_previous_recommendations() -> None:
+    cycle_id = "cycle_l8_integration"
+    bundles = [
+        _feature_bundle(cycle_id, "ENT_A", 6.0),
+        _feature_bundle(cycle_id, "ENT_B", 4.0),
+    ]
+    world_state = derive_world_state(bundles[0])
+    pool = select_official_alpha_pool(world_state, bundles, capacity=2)
+
+    alpha_results = [
+        analyze_stock(
+            "ENT_A",
+            _analysis_context(cycle_id, "ENT_A", bundles, world_state),
+            analyzer=SinglePromptAnalyzer(
+                StaticAlphaReasonerPort(
+                    AlphaReasonerResponse(
+                        score=0.74,
+                        confidence=0.82,
+                        rationale="current-cycle alpha",
+                        similar_cases=[],
+                    )
+                )
+            ),
+        ),
+        analyze_stock(
+            "ENT_B",
+            _analysis_context(cycle_id, "ENT_B", bundles, world_state),
+            analyzer=SinglePromptAnalyzer(
+                StaticAlphaReasonerPort(
+                    AlphaReasonerResponse(
+                        score=None,
+                        confidence=0.0,
+                        rationale="provider timeout",
+                        similar_cases=[],
+                        task_failed=True,
+                        failure_reason="task-level timeout",
+                    )
+                )
+            ),
+        ),
+    ]
+
+    override_store = InMemoryOverrideStore()
+    submit_override(
+        {
+            "cycle_id": cycle_id,
+            "entity_id": "ENT_A",
+            "submitted_by": "analyst",
+            "action_type": "reduce",
+            "rationale": "current-cycle risk review",
+            "submitted_at": datetime(2026, 4, 17, 9, 30, tzinfo=UTC),
+        },
+        store=override_store,
+    )
+    recommendations = generate_recommendations(
+        pool,
+        alpha_results,
+        world_state,
+        override_store=override_store,
+    )
+    source = SourceWithPreviousRecommendationTrap(
+        loaded_world_state=world_state,
+        loaded_pool=pool,
+        loaded_alpha_results=alpha_results,
+        loaded_recommendations=recommendations,
+    )
+
+    bundle = prepare_publish_bundle(
+        cycle_id,
+        source=source,
+        publish_port=RecordingPublishPort(),
+    )
+
+    bundle_payload = bundle.model_dump(mode="json")
+    recommendation_payload = bundle_payload["formal_objects"][
+        RECOMMENDATION_SNAPSHOT_KEY
+    ]["payload"]
+    assert recommendation_payload == [
+        recommendation.model_dump(mode="json")
+        for recommendation in recommendations
+    ]
+    assert recommendation_payload[0]["override_applied"] is True
+    assert recommendation_payload[0]["action_type"] == "reduce"
+    assert recommendation_payload[1]["action_type"] == "inconclusive"
+    assert bundle_payload["audit_payload"]["override_applied_count"] == 1
+    assert bundle_payload["audit_payload"]["inconclusive_count"] == 1
+
+    serialized_bundle = json.dumps(bundle_payload, sort_keys=True)
+    assert "previous_recommendation" not in serialized_bundle
+    assert "last_recommendation" not in serialized_bundle
+    assert "fallback_recommendation_ref" not in serialized_bundle
+
+
+def _feature_bundle(
+    cycle_id: str,
+    entity_id: str,
+    momentum: float,
+) -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_values={"momentum": momentum},
+        signal_values={},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+
+
+def _analysis_context(
+    cycle_id: str,
+    entity_id: str,
+    bundles: list[FeatureSignalBundle],
+    world_state: object,
+) -> AlphaAnalysisContext:
+    bundle_by_entity = {
+        str(bundle.entity_id): bundle
+        for bundle in bundles
+    }
+    return AlphaAnalysisContext(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_bundle=bundle_by_entity[entity_id],
+        world_state=world_state,
+        similar_cases=[],
+    )


### PR DESCRIPTION
Closes #11

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
### 1. 背景与目标
项目文档 §11.4、§12.3、§23 要求 Phase 3 发布链必须先逐类提交 formal object，全部成功后才发起 `cycle_publish_manifest`，且失败时不能让消费方看到半提交结果。当前代码已经有 `main_core.common.schemas.PublishBundle`、`WorldStateSnapshot`、`OfficialAlphaPool`、`AlphaResultSnapshot`、`RecommendationSnapshot` 以及 `main_core.common.errors.ManifestPublishError`，但 `src/main_core/l8_publish/__init__.py` 仍只有包说明，没有装配、commit port、manifest 或 audit seed 逻辑。本 issue 的目标是在 `l8_publish` 内补齐发布装配边界，消费 #10 及其前序链路已经产出的 formal objects，不在 L8 重新计算 L4-L7 业务语义。

### 2. 所属模块
Primary writable paths:
- `src/main_core/l8_publish/__init__.py`
- `src/main_core/l8_publish/assembler.py`（新建）
- `src/main_core/l8_publish/publish_port.py`（新建）
- `src/main_core/l8_publish/manifest.py`（新建）
- `src/main_core/l8_publish/audit_payload.py`（新建）
- `src/main_core/l8_publish/refs.py`（新建）
- `tests/l8_publish/__init__.py`（新建）
- `tests/l8_publish/test_assembler.py`（新建）
- `tests/l8_publish/test_manifest.py`（新建）
- `tests/l8_publish/test_publish_integration.py`（新建）

Adjacent read-only / integration paths:
- `src/main_core/common/schemas/publish.py`
- `src/main_core/common/schemas/world_state.py`
- `src/main_core/common/schemas/pool.py`
- `src/main_core/common/schemas/alpha.py`
- `src/main_core/common/schemas/recommendation.py`
- `src/main_core/common/errors.py`
- `src/main_core/common/types.py`
- #10 落地后的 `src/main_core/l7_recommendation/service.py`、`override.py`、`constraints.py` 只作为 integration input，不在本 issue 修改。

### 3. 实现范围
- 在 `src/main_core/l8_publish/publish_port.py` 定义 L8 内部 port 与结果类型：`FormalObjectSource`、`DataPlatformPublishPort`、`CommittedFormalObject`、`ManifestWriteResult`、`DerivedFormalObjectBuilder`，所有 payload 入参使用 `Mapping[str, Any]`，所有 cycle 使用 `main_core.common.types.CycleId`。
- 在 `src/main_core/l8_publish/refs.py` 定义 canonical object key：`world_state_snapshot`、`official_alpha_pool`、`alpha_result_snapshot`、`recommendation_snapshot`；实现 `formal_object_ref(bundle, object_key)` 与 `formal_object_refs(bundle, object_key)`，统一读取 `PublishBundle.formal_objects` 