### PR TITLE
feat(#12): 实现 dashboard_snapshot 与 formal report 的正式业务内容

### DIFF
--- a/src/main_core/l8_publish/__init__.py
+++ b/src/main_core/l8_publish/__init__.py
@@ -1,6 +1,7 @@
 """L8 package — publish bundle assembly and manifest publication."""
 
 from main_core.l8_publish.assembler import prepare_publish_bundle
+from main_core.l8_publish.dashboard import build_dashboard_snapshot
 from main_core.l8_publish.publish_port import (
     CommittedFormalObject,
     DataPlatformPublishPort,
@@ -9,6 +10,7 @@ from main_core.l8_publish.publish_port import (
     ManifestWriteResult,
 )
 from main_core.l8_publish.refs import formal_object_ref, formal_object_refs
+from main_core.l8_publish.report import build_dashboard_and_report, build_formal_report
 
 __all__ = [
     "CommittedFormalObject",
@@ -16,6 +18,9 @@ __all__ = [
     "DerivedFormalObjectBuilder",
     "FormalObjectSource",
     "ManifestWriteResult",
+    "build_dashboard_and_report",
+    "build_dashboard_snapshot",
+    "build_formal_report",
     "formal_object_ref",
     "formal_object_refs",
     "prepare_publish_bundle",

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -87,11 +87,17 @@ def prepare_publish_bundle(
 
     requested_cycle_id = CycleId(str(cycle_id))
     formal_objects = collect_formal_objects(requested_cycle_id, source)
+    reserved_manifest_ref = (
+        _reserve_cycle_manifest_ref(requested_cycle_id, publish_port)
+        if derived_builders
+        else None
+    )
     formal_objects, committed_objects = _commit_with_derived_builders(
         cycle_id=requested_cycle_id,
         formal_objects=formal_objects,
         publish_port=publish_port,
         derived_builders=derived_builders,
+        reserved_manifest_ref=reserved_manifest_ref,
     )
 
     manifest = write_manifest_after_commits(
@@ -99,6 +105,13 @@ def prepare_publish_bundle(
         committed_objects,
         publish_port,
     )
+    if (
+        reserved_manifest_ref is not None
+        and manifest.manifest_ref != reserved_manifest_ref
+    ):
+        raise ManifestPublishError(
+            "manifest write result must match reserved manifest_ref",
+        )
     bundle_formal_objects = _build_bundle_formal_objects(
         formal_objects,
         committed_objects,
@@ -132,6 +145,7 @@ def _commit_with_derived_builders(
     formal_objects: Mapping[str, FormalObjectValue],
     publish_port: DataPlatformPublishPort,
     derived_builders: Sequence[DerivedFormalObjectBuilder],
+    reserved_manifest_ref: str | None,
 ) -> tuple[dict[str, FormalObjectValue], tuple[CommittedFormalObject, ...]]:
     active_formal_objects = dict(formal_objects)
     if not derived_builders:
@@ -154,10 +168,13 @@ def _commit_with_derived_builders(
             active_formal_objects,
             committed_objects,
         )
+        manifest_candidate = build_manifest_candidate(cycle_id, committed_objects)
+        if reserved_manifest_ref is not None:
+            manifest_candidate["manifest_ref"] = reserved_manifest_ref
         draft_bundle = PublishBundle(
             cycle_id=cycle_id,
             formal_objects=bundle_formal_objects,
-            manifest_candidate=build_manifest_candidate(cycle_id, committed_objects),
+            manifest_candidate=manifest_candidate,
             audit_payload={
                 "cycle_id": str(cycle_id),
                 "audit_payload_ref": f"audit_payload/{cycle_id}",
@@ -192,6 +209,29 @@ def _commit_with_derived_builders(
         )
 
     return active_formal_objects, tuple(committed_objects)
+
+
+def _reserve_cycle_manifest_ref(
+    cycle_id: CycleId,
+    publish_port: DataPlatformPublishPort,
+) -> str:
+    try:
+        reserve_manifest_ref = publish_port.reserve_cycle_manifest_ref
+    except AttributeError as exc:
+        raise ManifestPublishError(
+            "publish port must reserve manifest_ref before derived formal objects",
+        ) from exc
+
+    try:
+        manifest_ref = reserve_manifest_ref(cycle_id=cycle_id)
+    except ManifestPublishError:
+        raise
+    except Exception as exc:
+        raise ManifestPublishError("failed to reserve cycle manifest_ref") from exc
+
+    if not isinstance(manifest_ref, str) or not manifest_ref.strip():
+        raise ManifestPublishError("reserved manifest_ref must be non-empty")
+    return manifest_ref
 
 
 def _validate_formal_object_cycles(

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -37,6 +37,11 @@ from main_core.l8_publish.refs import (
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
 )
+from main_core.l8_publish.report import build_dashboard_and_report
+
+DEFAULT_DERIVED_BUILDERS: tuple[DerivedFormalObjectBuilder, ...] = (
+    build_dashboard_and_report,
+)
 
 
 def collect_formal_objects(
@@ -76,23 +81,19 @@ def prepare_publish_bundle(
     *,
     source: FormalObjectSource,
     publish_port: DataPlatformPublishPort,
-    derived_builders: Sequence[DerivedFormalObjectBuilder] = (),
+    derived_builders: Sequence[DerivedFormalObjectBuilder] = DEFAULT_DERIVED_BUILDERS,
 ) -> PublishBundle:
     """Prepare, commit, manifest, and return the formal L8 publish bundle."""
 
     requested_cycle_id = CycleId(str(cycle_id))
     formal_objects = collect_formal_objects(requested_cycle_id, source)
-    formal_objects = _apply_derived_builders(
-        requested_cycle_id,
-        formal_objects,
-        derived_builders,
+    formal_objects, committed_objects = _commit_with_derived_builders(
+        cycle_id=requested_cycle_id,
+        formal_objects=formal_objects,
+        publish_port=publish_port,
+        derived_builders=derived_builders,
     )
 
-    committed_objects = commit_formal_objects(
-        requested_cycle_id,
-        formal_objects,
-        publish_port,
-    )
     manifest = write_manifest_after_commits(
         requested_cycle_id,
         committed_objects,
@@ -125,22 +126,47 @@ def prepare_publish_bundle(
     )
 
 
-def _apply_derived_builders(
+def _commit_with_derived_builders(
+    *,
     cycle_id: CycleId,
     formal_objects: Mapping[str, FormalObjectValue],
+    publish_port: DataPlatformPublishPort,
     derived_builders: Sequence[DerivedFormalObjectBuilder],
-) -> dict[str, FormalObjectValue]:
-    if not derived_builders:
-        return dict(formal_objects)
-
+) -> tuple[dict[str, FormalObjectValue], tuple[CommittedFormalObject, ...]]:
     active_formal_objects = dict(formal_objects)
+    if not derived_builders:
+        committed_objects = commit_formal_objects(
+            cycle_id,
+            active_formal_objects,
+            publish_port,
+        )
+        return active_formal_objects, committed_objects
+
+    committed_objects = list(
+        commit_formal_objects(
+            cycle_id,
+            active_formal_objects,
+            publish_port,
+        )
+    )
     for builder in derived_builders:
+        bundle_formal_objects = _build_bundle_formal_objects(
+            active_formal_objects,
+            committed_objects,
+        )
         draft_bundle = PublishBundle(
             cycle_id=cycle_id,
-            formal_objects=_build_uncommitted_bundle_formal_objects(active_formal_objects),
-            manifest_candidate={},
-            audit_payload={},
-            retrospective_seed={},
+            formal_objects=bundle_formal_objects,
+            manifest_candidate=build_manifest_candidate(cycle_id, committed_objects),
+            audit_payload={
+                "cycle_id": str(cycle_id),
+                "audit_payload_ref": f"audit_payload/{cycle_id}",
+            },
+            retrospective_seed=build_retrospective_seed(
+                cycle_id,
+                bundle_formal_objects,
+                committed_objects,
+            ),
         )
         try:
             derived_objects = builder(cycle_id, draft_bundle)
@@ -161,7 +187,11 @@ def _apply_derived_builders(
             _ensure_cycle_id(object_key, formal_object, cycle_id)
             active_formal_objects[object_key] = formal_object
 
-    return active_formal_objects
+        committed_objects.extend(
+            commit_formal_objects(cycle_id, derived_objects, publish_port)
+        )
+
+    return active_formal_objects, tuple(committed_objects)
 
 
 def _validate_formal_object_cycles(
@@ -258,15 +288,6 @@ def _build_bundle_formal_objects(
             committed_object.ref,
         )
     return bundle_formal_objects
-
-
-def _build_uncommitted_bundle_formal_objects(
-    formal_objects: Mapping[str, FormalObjectValue],
-) -> dict[str, dict[str, Any]]:
-    return {
-        object_key: _bundle_formal_object_entry(value, "")
-        for object_key, value in formal_objects.items()
-    }
 
 
 def _bundle_formal_object_entry(

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -104,14 +104,8 @@ def prepare_publish_bundle(
         requested_cycle_id,
         committed_objects,
         publish_port,
+        expected_manifest_ref=reserved_manifest_ref,
     )
-    if (
-        reserved_manifest_ref is not None
-        and manifest.manifest_ref != reserved_manifest_ref
-    ):
-        raise ManifestPublishError(
-            "manifest write result must match reserved manifest_ref",
-        )
     bundle_formal_objects = _build_bundle_formal_objects(
         formal_objects,
         committed_objects,

--- a/src/main_core/l8_publish/dashboard.py
+++ b/src/main_core/l8_publish/dashboard.py
@@ -1,0 +1,237 @@
+"""Formal dashboard snapshot builders for L8 publication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import DashboardSnapshot, PublishBundle
+from main_core.common.types import CycleId
+from main_core.l8_publish.refs import (
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    OFFICIAL_ALPHA_POOL_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+    WORLD_STATE_SNAPSHOT_KEY,
+    formal_object_ref,
+)
+
+DASHBOARD_SNAPSHOT_KEY = "dashboard_snapshot"
+
+_ACTION_TYPES = ("buy", "hold", "reduce", "inconclusive")
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class _FormalObjectEntry:
+    ref: str
+    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...]
+    count: int
+
+
+@dataclass(frozen=True)
+class _RequiredFormalObjects:
+    world_state: _FormalObjectEntry
+    pool: _FormalObjectEntry
+    alpha_results: _FormalObjectEntry
+    recommendations: _FormalObjectEntry
+
+
+def build_dashboard_snapshot(
+    cycle_id: CycleId,
+    bundle: PublishBundle,
+) -> DashboardSnapshot:
+    """Build the formal dashboard snapshot from same-cycle published refs."""
+
+    requested_cycle_id = CycleId(str(cycle_id))
+    objects = _extract_required_formal_objects(requested_cycle_id, bundle)
+    summary_cards = _build_summary_cards(objects)
+
+    return DashboardSnapshot(
+        cycle_id=requested_cycle_id,
+        world_state_ref=objects.world_state.ref,
+        pool_ref=objects.pool.ref,
+        recommendation_ref=objects.recommendations.ref,
+        summary_cards=summary_cards,
+    )
+
+
+def _extract_required_formal_objects(
+    cycle_id: CycleId,
+    bundle: PublishBundle,
+) -> _RequiredFormalObjects:
+    if bundle.cycle_id != cycle_id:
+        raise ManifestPublishError("publish bundle cycle_id must match requested cycle_id")
+
+    return _RequiredFormalObjects(
+        world_state=_mapping_entry(bundle, WORLD_STATE_SNAPSHOT_KEY, cycle_id),
+        pool=_mapping_entry(bundle, OFFICIAL_ALPHA_POOL_KEY, cycle_id),
+        alpha_results=_list_entry(bundle, ALPHA_RESULT_SNAPSHOT_KEY, cycle_id),
+        recommendations=_list_entry(bundle, RECOMMENDATION_SNAPSHOT_KEY, cycle_id),
+    )
+
+
+def _build_summary_cards(objects: _RequiredFormalObjects) -> dict[str, Any]:
+    world_state = _as_mapping(objects.world_state.payload)
+    pool = _as_mapping(objects.pool.payload)
+    alpha_results = _as_payload_list(objects.alpha_results.payload)
+    recommendations = _as_payload_list(objects.recommendations.payload)
+
+    by_action = dict.fromkeys(_ACTION_TYPES, 0)
+    override_entity_ids: list[str] = []
+    inconclusive_recommendation_entity_ids: list[str] = []
+    for recommendation in recommendations:
+        action_type = str(recommendation.get("action_type", ""))
+        by_action[action_type] = by_action.get(action_type, 0) + 1
+        if recommendation.get("override_applied") is True:
+            override_entity_ids.append(str(recommendation.get("entity_id", "")))
+        if action_type == "inconclusive":
+            inconclusive_recommendation_entity_ids.append(
+                str(recommendation.get("entity_id", ""))
+            )
+
+    alpha_inconclusive_entity_ids = [
+        str(alpha_result.get("entity_id", ""))
+        for alpha_result in alpha_results
+        if alpha_result.get("status") == "inconclusive"
+    ]
+    selected_entities = _string_list(pool.get("selected_entities", []))
+    added_entities = _string_list(pool.get("added_entities", []))
+    removed_entities = _string_list(pool.get("removed_entities", []))
+    freeze_reason_map = pool.get("freeze_reason_map", {})
+    frozen_count = len(freeze_reason_map) if isinstance(freeze_reason_map, Mapping) else 0
+    override_applied_count = len(override_entity_ids)
+
+    return {
+        "regime": {
+            "baseline_regime": world_state.get("baseline_regime"),
+            "llm_delta": world_state.get("llm_delta"),
+            "final_regime": world_state.get("final_regime"),
+            "llm_rationale": world_state.get("llm_rationale"),
+            "actual_model_used": world_state.get("actual_model_used"),
+            "actual_provider": world_state.get("actual_provider"),
+        },
+        "pool": {
+            "selected_count": len(selected_entities),
+            "capacity": pool.get("official_alpha_pool_capacity"),
+            "added_count": len(added_entities),
+            "removed_count": len(removed_entities),
+            "observation_pool_size": pool.get("observation_pool_size"),
+            "frozen_count": frozen_count,
+        },
+        "recommendations": {
+            "total_count": len(recommendations),
+            "by_action": by_action,
+            "override_applied_count": override_applied_count,
+        },
+        "inconclusive": {
+            "alpha_count": len(alpha_inconclusive_entity_ids),
+            "recommendation_count": by_action.get("inconclusive", 0),
+            "alpha_entity_ids": alpha_inconclusive_entity_ids,
+            "recommendation_entity_ids": inconclusive_recommendation_entity_ids,
+        },
+        "overrides": {
+            "override_applied_count": override_applied_count,
+            "entity_ids": override_entity_ids,
+        },
+    }
+
+
+def _mapping_entry(
+    bundle: PublishBundle,
+    object_key: str,
+    cycle_id: CycleId,
+) -> _FormalObjectEntry:
+    entry = _entry_mapping(bundle, object_key)
+    ref = formal_object_ref(bundle, object_key)
+    payload = entry.get("payload", _MISSING)
+    if not isinstance(payload, Mapping):
+        raise ManifestPublishError(f"{object_key}.payload must be a mapping")
+
+    count = _entry_count(entry, object_key)
+    if count != 1:
+        raise ManifestPublishError(f"{object_key}.count must be 1")
+    _ensure_payload_cycle(object_key, payload, cycle_id)
+    return _FormalObjectEntry(ref=ref, payload=dict(payload), count=count)
+
+
+def _list_entry(
+    bundle: PublishBundle,
+    object_key: str,
+    cycle_id: CycleId,
+) -> _FormalObjectEntry:
+    entry = _entry_mapping(bundle, object_key)
+    ref = formal_object_ref(bundle, object_key)
+    payload = entry.get("payload", _MISSING)
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
+        raise ManifestPublishError(f"{object_key}.payload must be a list")
+
+    payload_items: list[Mapping[str, Any]] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, Mapping):
+            raise ManifestPublishError(
+                f"{object_key}.payload[{index}] must be a mapping"
+            )
+        _ensure_payload_cycle(object_key, item, cycle_id)
+        payload_items.append(dict(item))
+
+    count = _entry_count(entry, object_key)
+    if count != len(payload_items):
+        raise ManifestPublishError(f"{object_key}.count must match payload length")
+    return _FormalObjectEntry(ref=ref, payload=tuple(payload_items), count=count)
+
+
+def _entry_mapping(bundle: PublishBundle, object_key: str) -> Mapping[str, Any]:
+    try:
+        entry = bundle.formal_objects[object_key]
+    except KeyError as exc:
+        raise ManifestPublishError(f"missing formal object entry {object_key}") from exc
+    if not isinstance(entry, Mapping):
+        raise ManifestPublishError(f"{object_key} formal object entry must be a mapping")
+    return entry
+
+
+def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
+    count = entry.get("count", _MISSING)
+    if (
+        not isinstance(count, int)
+        or isinstance(count, bool)
+        or count < 0
+    ):
+        raise ManifestPublishError(f"{object_key}.count must be a non-negative integer")
+    return count
+
+
+def _ensure_payload_cycle(
+    object_key: str,
+    payload: Mapping[str, Any],
+    cycle_id: CycleId,
+) -> None:
+    if payload.get("cycle_id") != str(cycle_id):
+        raise ManifestPublishError(f"{object_key}.payload cycle_id must match")
+
+
+def _as_mapping(
+    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...],
+) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ManifestPublishError("expected single formal object payload")
+    return payload
+
+
+def _as_payload_list(
+    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...],
+) -> tuple[Mapping[str, Any], ...]:
+    if isinstance(payload, Mapping):
+        raise ManifestPublishError("expected formal object payload list")
+    return payload
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+__all__ = ["DASHBOARD_SNAPSHOT_KEY", "build_dashboard_snapshot"]

--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -56,6 +56,8 @@ def write_manifest_after_commits(
     cycle_id: CycleId,
     committed_objects: Sequence[CommittedFormalObject],
     publish_port: DataPlatformPublishPort,
+    *,
+    expected_manifest_ref: str | None = None,
 ) -> ManifestWriteResult:
     """Write the cycle manifest only after all formal object commits succeed."""
 
@@ -64,12 +66,20 @@ def write_manifest_after_commits(
         manifest = publish_port.write_cycle_manifest(
             cycle_id=cycle_id,
             committed_objects=committed_tuple,
+            expected_manifest_ref=expected_manifest_ref,
         )
     except ManifestPublishError:
         raise
     except Exception as exc:
         raise ManifestPublishError("failed to write cycle publish manifest") from exc
     _validate_manifest_write_result(manifest, committed_tuple)
+    if (
+        expected_manifest_ref is not None
+        and manifest.manifest_ref != expected_manifest_ref
+    ):
+        raise ManifestPublishError(
+            "manifest write result must match expected manifest_ref",
+        )
     return manifest
 
 

--- a/src/main_core/l8_publish/publish_port.py
+++ b/src/main_core/l8_publish/publish_port.py
@@ -58,6 +58,13 @@ class FormalObjectSource(Protocol):
 class DataPlatformPublishPort(Protocol):
     """Manifest-backed formal object publication boundary."""
 
+    def reserve_cycle_manifest_ref(
+        self,
+        *,
+        cycle_id: CycleId,
+    ) -> str:
+        """Reserve the exact manifest ref that write_cycle_manifest will publish."""
+
     def commit_formal_object(
         self,
         *,

--- a/src/main_core/l8_publish/publish_port.py
+++ b/src/main_core/l8_publish/publish_port.py
@@ -79,8 +79,13 @@ class DataPlatformPublishPort(Protocol):
         *,
         cycle_id: CycleId,
         committed_objects: Sequence[CommittedFormalObject],
+        expected_manifest_ref: str | None = None,
     ) -> ManifestWriteResult:
-        """Write the cycle manifest after all formal object commits succeed."""
+        """Write the cycle manifest after all formal object commits succeed.
+
+        When ``expected_manifest_ref`` is provided, the port must either publish
+        the manifest at exactly that ref or fail before the manifest is visible.
+        """
 
 
 class DerivedFormalObjectBuilder(Protocol):

--- a/src/main_core/l8_publish/report.py
+++ b/src/main_core/l8_publish/report.py
@@ -144,7 +144,9 @@ def _manifest_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
     if isinstance(manifest_ref, str) and manifest_ref:
         _ensure_ref_points_to_cycle("manifest_ref", manifest_ref, cycle_id)
         return manifest_ref
-    return f"manifest/{cycle_id}"
+    raise ManifestPublishError(
+        "manifest_candidate.manifest_ref must be reserved before formal report build",
+    )
 
 
 def _audit_payload_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:

--- a/src/main_core/l8_publish/report.py
+++ b/src/main_core/l8_publish/report.py
@@ -1,0 +1,226 @@
+"""Formal report builders for L8 publication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import DashboardSnapshot, FormalReport, PublishBundle
+from main_core.common.types import CycleId
+from main_core.l8_publish.dashboard import (
+    DASHBOARD_SNAPSHOT_KEY,
+    _as_mapping,
+    _as_payload_list,
+    _build_summary_cards,
+    _extract_required_formal_objects,
+    _RequiredFormalObjects,
+    build_dashboard_snapshot,
+)
+
+FORMAL_REPORT_KEY = "formal_report"
+
+
+def build_formal_report(
+    cycle_id: CycleId,
+    bundle: PublishBundle,
+    *,
+    report_type: str = "daily",
+) -> FormalReport:
+    """Build deterministic analyst-facing report content from published refs."""
+
+    requested_cycle_id = CycleId(str(cycle_id))
+    objects = _extract_required_formal_objects(requested_cycle_id, bundle)
+    summary_cards = _build_summary_cards(objects)
+
+    return FormalReport(
+        cycle_id=requested_cycle_id,
+        report_type=report_type,
+        recommendation_ref=objects.recommendations.ref,
+        narrative_sections=_build_narrative_sections(objects, summary_cards),
+        appendix_refs=_build_appendix_refs(requested_cycle_id, bundle, objects),
+    )
+
+
+def build_dashboard_and_report(
+    cycle_id: CycleId,
+    bundle: PublishBundle,
+) -> Mapping[str, DashboardSnapshot | FormalReport]:
+    """Build all deterministic L8 derived formal objects for a publish cycle."""
+
+    dashboard = build_dashboard_snapshot(cycle_id, bundle)
+    report = build_formal_report(cycle_id, bundle)
+    return {
+        DASHBOARD_SNAPSHOT_KEY: dashboard,
+        FORMAL_REPORT_KEY: report,
+    }
+
+
+def _build_narrative_sections(
+    objects: _RequiredFormalObjects,
+    summary_cards: Mapping[str, Any],
+) -> dict[str, Any]:
+    world_state = _as_mapping(objects.world_state.payload)
+    pool = _as_mapping(objects.pool.payload)
+    alpha_results = _as_payload_list(objects.alpha_results.payload)
+    recommendations = _as_payload_list(objects.recommendations.payload)
+
+    by_action = dict(summary_cards["recommendations"]["by_action"])
+    selected_count = summary_cards["pool"]["selected_count"]
+    recommendation_count = summary_cards["recommendations"]["total_count"]
+    final_regime = world_state.get("final_regime")
+    alpha_inconclusive = summary_cards["inconclusive"]["alpha_entity_ids"]
+    recommendation_inconclusive = summary_cards["inconclusive"][
+        "recommendation_entity_ids"
+    ]
+    override_entity_ids = summary_cards["overrides"]["entity_ids"]
+
+    return {
+        "overview": {
+            "summary": (
+                f"{final_regime} regime with {selected_count} selected entities "
+                f"and {recommendation_count} current-cycle recommendations."
+            ),
+            "recommendation_mix": by_action,
+        },
+        "world_state": {
+            "baseline_regime": world_state.get("baseline_regime"),
+            "llm_delta": world_state.get("llm_delta"),
+            "final_regime": final_regime,
+            "rationale": world_state.get("llm_rationale"),
+            "fallback_path": world_state.get("fallback_path", []),
+        },
+        "pool_changes": {
+            "selected_count": selected_count,
+            "capacity": summary_cards["pool"]["capacity"],
+            "added_entities": _string_list(pool.get("added_entities", [])),
+            "removed_entities": _string_list(pool.get("removed_entities", [])),
+            "freeze_reason_map": dict(pool.get("freeze_reason_map", {})),
+        },
+        "recommendation_summary": {
+            "by_action": by_action,
+            "entity_ids_by_action": _entity_ids_by_action(recommendations),
+            "override_applied_count": summary_cards["recommendations"][
+                "override_applied_count"
+            ],
+        },
+        "inconclusive_summary": {
+            "summary": _inconclusive_summary(
+                alpha_entity_ids=alpha_inconclusive,
+                recommendation_entity_ids=recommendation_inconclusive,
+            ),
+            "alpha_inconclusive_count": len(alpha_inconclusive),
+            "recommendation_inconclusive_count": len(recommendation_inconclusive),
+            "alpha_entity_ids": alpha_inconclusive,
+            "recommendation_entity_ids": recommendation_inconclusive,
+            "alpha_result_count": len(alpha_results),
+        },
+        "override_summary": {
+            "summary": _override_summary(override_entity_ids),
+            "override_applied_count": len(override_entity_ids),
+            "entity_ids": override_entity_ids,
+        },
+    }
+
+
+def _build_appendix_refs(
+    cycle_id: CycleId,
+    bundle: PublishBundle,
+    objects: _RequiredFormalObjects,
+) -> dict[str, Any]:
+    return {
+        "world_state_ref": objects.world_state.ref,
+        "pool_ref": objects.pool.ref,
+        "alpha_result_ref": objects.alpha_results.ref,
+        "recommendation_ref": objects.recommendations.ref,
+        "manifest_ref": _manifest_ref(cycle_id, bundle),
+        "audit_payload_ref": _audit_payload_ref(cycle_id, bundle),
+    }
+
+
+def _manifest_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
+    _ensure_same_cycle("manifest_candidate", bundle.manifest_candidate, cycle_id)
+    manifest_ref = bundle.manifest_candidate.get("manifest_ref")
+    if isinstance(manifest_ref, str) and manifest_ref:
+        _ensure_ref_points_to_cycle("manifest_ref", manifest_ref, cycle_id)
+        return manifest_ref
+    return f"manifest/{cycle_id}"
+
+
+def _audit_payload_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
+    _ensure_same_cycle("audit_payload", bundle.audit_payload, cycle_id)
+    for key in ("audit_payload_ref", "ref"):
+        value = bundle.audit_payload.get(key)
+        if isinstance(value, str) and value:
+            _ensure_ref_points_to_cycle(key, value, cycle_id)
+            return value
+    return f"audit_payload/{cycle_id}"
+
+
+def _ensure_same_cycle(
+    payload_name: str,
+    payload: Mapping[str, Any],
+    cycle_id: CycleId,
+) -> None:
+    payload_cycle_id = payload.get("cycle_id")
+    if payload_cycle_id is not None and payload_cycle_id != str(cycle_id):
+        raise ManifestPublishError(f"{payload_name}.cycle_id must match")
+
+
+def _ensure_ref_points_to_cycle(
+    ref_name: str,
+    ref: str,
+    cycle_id: CycleId,
+) -> None:
+    if str(cycle_id) not in ref:
+        raise ManifestPublishError(f"{ref_name} must point to requested cycle_id")
+
+
+def _entity_ids_by_action(
+    recommendations: tuple[Mapping[str, Any], ...],
+) -> dict[str, list[str]]:
+    entity_ids_by_action = {
+        "buy": [],
+        "hold": [],
+        "reduce": [],
+        "inconclusive": [],
+    }
+    for recommendation in recommendations:
+        action_type = str(recommendation.get("action_type", ""))
+        entity_ids_by_action.setdefault(action_type, []).append(
+            str(recommendation.get("entity_id", ""))
+        )
+    return entity_ids_by_action
+
+
+def _inconclusive_summary(
+    *,
+    alpha_entity_ids: list[str],
+    recommendation_entity_ids: list[str],
+) -> str:
+    if alpha_entity_ids or recommendation_entity_ids:
+        return (
+            "Inconclusive outcomes remain explicit for analyst review: "
+            f"{len(alpha_entity_ids)} alpha results and "
+            f"{len(recommendation_entity_ids)} recommendations."
+        )
+    return "No inconclusive alpha results or recommendations for this cycle."
+
+
+def _override_summary(entity_ids: list[str]) -> str:
+    if entity_ids:
+        return f"Human overrides applied to {len(entity_ids)} recommendations."
+    return "No human overrides applied for this cycle."
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [str(item) for item in value]
+
+
+__all__ = [
+    "FORMAL_REPORT_KEY",
+    "build_dashboard_and_report",
+    "build_formal_report",
+]

--- a/tests/l8_publish/__init__.py
+++ b/tests/l8_publish/__init__.py
@@ -74,8 +74,10 @@ def recommendation(
         cycle_id=cycle_id,
         entity_id=entity_id,
         action_type=action_type,
-        rating="A" if action_type == "buy" else "B",
-        confidence=0.8,
+        rating=None if action_type == "inconclusive" else (
+            "A" if action_type == "buy" else "B"
+        ),
+        confidence=None if action_type == "inconclusive" else 0.8,
         triggered_by="human_decision" if override_applied else "system",
         override_applied=override_applied,
         constraints_applied={},
@@ -93,28 +95,32 @@ class FakeFormalObjectSource:
     ) -> None:
         self.world_state = loaded_world_state or world_state()
         self.pool = loaded_pool or pool()
+        default_alpha_results = (
+            alpha_result("ENT_A"),
+            alpha_result("ENT_B", score=None, status="inconclusive"),
+        )
         self.alpha_results = tuple(
-            loaded_alpha_results
-            or (
-                alpha_result("ENT_A"),
-                alpha_result("ENT_B", score=None, status="inconclusive"),
-            )
+            default_alpha_results
+            if loaded_alpha_results is None
+            else loaded_alpha_results
+        )
+        default_recommendations = (
+            recommendation("ENT_A", override_applied=True),
+            RecommendationSnapshot(
+                cycle_id="cycle_l8",
+                entity_id="ENT_B",
+                action_type="inconclusive",
+                rating=None,
+                confidence=None,
+                triggered_by="system",
+                override_applied=False,
+                constraints_applied={},
+            ),
         )
         self.recommendations = tuple(
-            loaded_recommendations
-            or (
-                recommendation("ENT_A", override_applied=True),
-                RecommendationSnapshot(
-                    cycle_id="cycle_l8",
-                    entity_id="ENT_B",
-                    action_type="inconclusive",
-                    rating=None,
-                    confidence=None,
-                    triggered_by="system",
-                    override_applied=False,
-                    constraints_applied={},
-                ),
-            )
+            default_recommendations
+            if loaded_recommendations is None
+            else loaded_recommendations
         )
         self.calls: list[tuple[str, CycleId]] = []
 

--- a/tests/l8_publish/__init__.py
+++ b/tests/l8_publish/__init__.py
@@ -147,13 +147,24 @@ class RecordingPublishPort:
         *,
         fail_on_object_key: str | None = None,
         fail_manifest: bool = False,
+        manifest_ref: str | None = None,
     ) -> None:
         self.fail_on_object_key = fail_on_object_key
         self.fail_manifest = fail_manifest
+        self.manifest_ref = manifest_ref
         self.commit_calls: list[tuple[CycleId, str, Mapping[str, Any]]] = []
         self.manifest_calls: list[
             tuple[CycleId, tuple[CommittedFormalObject, ...]]
         ] = []
+        self.reserve_manifest_ref_calls: list[CycleId] = []
+
+    def reserve_cycle_manifest_ref(
+        self,
+        *,
+        cycle_id: CycleId,
+    ) -> str:
+        self.reserve_manifest_ref_calls.append(cycle_id)
+        return self.manifest_ref or f"manifest/{cycle_id}"
 
     def commit_formal_object(
         self,
@@ -185,7 +196,7 @@ class RecordingPublishPort:
         if self.fail_manifest:
             raise RuntimeError("manifest write failed")
         return ManifestWriteResult(
-            manifest_ref=f"manifest/{cycle_id}",
+            manifest_ref=self.manifest_ref or f"manifest/{cycle_id}",
             manifest_version="v1",
             table_snapshots={
                 committed.object_key: committed.snapshot_id

--- a/tests/l8_publish/__init__.py
+++ b/tests/l8_publish/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import (
     AlphaResultSnapshot,
     OfficialAlphaPool,
@@ -190,13 +191,22 @@ class RecordingPublishPort:
         *,
         cycle_id: CycleId,
         committed_objects: Sequence[CommittedFormalObject],
+        expected_manifest_ref: str | None = None,
     ) -> ManifestWriteResult:
         committed_tuple = tuple(committed_objects)
-        self.manifest_calls.append((cycle_id, committed_tuple))
         if self.fail_manifest:
             raise RuntimeError("manifest write failed")
+        manifest_ref = self.manifest_ref or f"manifest/{cycle_id}"
+        if (
+            expected_manifest_ref is not None
+            and manifest_ref != expected_manifest_ref
+        ):
+            raise ManifestPublishError(
+                "reserved manifest_ref does not match publish target",
+            )
+        self.manifest_calls.append((cycle_id, committed_tuple))
         return ManifestWriteResult(
-            manifest_ref=self.manifest_ref or f"manifest/{cycle_id}",
+            manifest_ref=manifest_ref,
             manifest_version="v1",
             table_snapshots={
                 committed.object_key: committed.snapshot_id

--- a/tests/l8_publish/test_assembler.py
+++ b/tests/l8_publish/test_assembler.py
@@ -7,6 +7,7 @@ import pytest
 from main_core.common.errors import ManifestPublishError
 from main_core.l8_publish import formal_object_ref, formal_object_refs, prepare_publish_bundle
 from main_core.l8_publish.assembler import collect_formal_objects
+from main_core.l8_publish.dashboard import DASHBOARD_SNAPSHOT_KEY
 from main_core.l8_publish.refs import (
     ALPHA_RESULT_SNAPSHOT_KEY,
     CANONICAL_FORMAL_OBJECT_KEYS,
@@ -14,6 +15,7 @@ from main_core.l8_publish.refs import (
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
 )
+from main_core.l8_publish.report import FORMAL_REPORT_KEY
 from tests.l8_publish import (
     FakeFormalObjectSource,
     RecordingPublishPort,
@@ -54,7 +56,11 @@ def test_prepare_publish_bundle_returns_canonical_formal_object_entries() -> Non
     bundle_payload = bundle.model_dump(mode="json")
     formal_objects = bundle_payload["formal_objects"]
     assert bundle.cycle_id == "cycle_l8"
-    assert tuple(formal_objects) == CANONICAL_FORMAL_OBJECT_KEYS
+    assert tuple(formal_objects) == (
+        *CANONICAL_FORMAL_OBJECT_KEYS,
+        DASHBOARD_SNAPSHOT_KEY,
+        FORMAL_REPORT_KEY,
+    )
     assert set(formal_objects[WORLD_STATE_SNAPSHOT_KEY]) == {
         "count",
         "payload",
@@ -81,6 +87,8 @@ def test_prepare_publish_bundle_returns_canonical_formal_object_entries() -> Non
         OFFICIAL_ALPHA_POOL_KEY: SINGLE_OBJECT_COUNT,
         ALPHA_RESULT_SNAPSHOT_KEY: ALPHA_RESULT_COUNT,
         RECOMMENDATION_SNAPSHOT_KEY: ALPHA_RESULT_COUNT,
+        DASHBOARD_SNAPSHOT_KEY: SINGLE_OBJECT_COUNT,
+        FORMAL_REPORT_KEY: SINGLE_OBJECT_COUNT,
     }
     assert bundle_payload["audit_payload"]["inconclusive_count"] == SINGLE_OBJECT_COUNT
     assert bundle_payload["audit_payload"]["override_applied_count"] == SINGLE_OBJECT_COUNT
@@ -92,6 +100,18 @@ def test_prepare_publish_bundle_returns_canonical_formal_object_entries() -> Non
         "ENT_A",
         "ENT_B",
     ]
+    assert formal_objects[DASHBOARD_SNAPSHOT_KEY]["payload"]["world_state_ref"] == (
+        "world_state_snapshot/cycle_l8/ref"
+    )
+    assert formal_objects[FORMAL_REPORT_KEY]["payload"]["recommendation_ref"] == (
+        formal_objects[DASHBOARD_SNAPSHOT_KEY]["payload"]["recommendation_ref"]
+    )
+    assert bundle_payload["manifest_candidate"]["table_snapshots"][
+        DASHBOARD_SNAPSHOT_KEY
+    ] == "dashboard_snapshot-snapshot"
+    assert bundle_payload["manifest_candidate"]["table_snapshots"][
+        FORMAL_REPORT_KEY
+    ] == "formal_report-snapshot"
 
 
 @pytest.mark.parametrize(
@@ -210,4 +230,4 @@ def test_formal_object_ref_rejects_missing_entry() -> None:
     )
 
     with pytest.raises(ManifestPublishError, match="missing formal object"):
-        formal_object_ref(bundle, "dashboard_snapshot")
+        formal_object_ref(bundle, "backtest_result")

--- a/tests/l8_publish/test_dashboard.py
+++ b/tests/l8_publish/test_dashboard.py
@@ -1,0 +1,124 @@
+"""Tests for L8 dashboard snapshot builders."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import PublishBundle
+from main_core.l8_publish import build_dashboard_snapshot, prepare_publish_bundle
+from main_core.l8_publish.refs import WORLD_STATE_SNAPSHOT_KEY
+from tests.l8_publish import FakeFormalObjectSource, RecordingPublishPort, pool
+
+
+def test_build_dashboard_snapshot_happy_path() -> None:
+    bundle = _base_bundle()
+
+    dashboard = build_dashboard_snapshot("cycle_l8", bundle)
+
+    assert dashboard.cycle_id == "cycle_l8"
+    assert dashboard.world_state_ref == "world_state_snapshot/cycle_l8/ref"
+    assert dashboard.pool_ref == "official_alpha_pool/cycle_l8/ref"
+    assert dashboard.recommendation_ref == "recommendation_snapshot/cycle_l8/ref"
+    assert dashboard.summary_cards["regime"]["final_regime"] == "neutral"
+    assert dashboard.summary_cards["pool"] == {
+        "selected_count": 2,
+        "capacity": 100,
+        "added_count": 2,
+        "removed_count": 0,
+        "observation_pool_size": 2,
+        "frozen_count": 0,
+    }
+    assert dashboard.summary_cards["recommendations"]["by_action"] == {
+        "buy": 1,
+        "hold": 0,
+        "reduce": 0,
+        "inconclusive": 1,
+    }
+
+
+def test_build_dashboard_snapshot_rejects_missing_ref() -> None:
+    bundle = _mutated_bundle(
+        lambda payload: payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY].pop("ref")
+    )
+
+    with pytest.raises(ManifestPublishError, match="ref"):
+        build_dashboard_snapshot("cycle_l8", bundle)
+
+
+def test_build_dashboard_snapshot_rejects_cycle_mismatch() -> None:
+    bundle = _mutated_bundle(
+        lambda payload: payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY][
+            "payload"
+        ].__setitem__("cycle_id", "cycle_other")
+    )
+
+    with pytest.raises(ManifestPublishError, match="cycle_id"):
+        build_dashboard_snapshot("cycle_l8", bundle)
+
+
+def test_build_dashboard_snapshot_keeps_inconclusive_recommendations_visible() -> None:
+    dashboard = build_dashboard_snapshot("cycle_l8", _base_bundle()).model_dump(
+        mode="json"
+    )
+
+    assert dashboard["summary_cards"]["inconclusive"] == {
+        "alpha_count": 1,
+        "recommendation_count": 1,
+        "alpha_entity_ids": ["ENT_B"],
+        "recommendation_entity_ids": ["ENT_B"],
+    }
+
+
+def test_build_dashboard_snapshot_counts_override_applied_recommendations() -> None:
+    dashboard = build_dashboard_snapshot("cycle_l8", _base_bundle()).model_dump(
+        mode="json"
+    )
+
+    assert dashboard["summary_cards"]["recommendations"]["override_applied_count"] == 1
+    assert dashboard["summary_cards"]["overrides"] == {
+        "override_applied_count": 1,
+        "entity_ids": ["ENT_A"],
+    }
+
+
+def test_build_dashboard_snapshot_allows_empty_recommendation_list() -> None:
+    bundle = _base_bundle(
+        FakeFormalObjectSource(
+            loaded_pool=pool(()),
+            loaded_alpha_results=[],
+            loaded_recommendations=[],
+        )
+    )
+
+    dashboard = build_dashboard_snapshot("cycle_l8", bundle)
+
+    assert dashboard.summary_cards["pool"]["selected_count"] == 0
+    assert dashboard.summary_cards["recommendations"] == {
+        "total_count": 0,
+        "by_action": {
+            "buy": 0,
+            "hold": 0,
+            "reduce": 0,
+            "inconclusive": 0,
+        },
+        "override_applied_count": 0,
+    }
+
+
+def _base_bundle(source: FakeFormalObjectSource | None = None) -> PublishBundle:
+    return prepare_publish_bundle(
+        "cycle_l8",
+        source=source or FakeFormalObjectSource(),
+        publish_port=RecordingPublishPort(),
+        derived_builders=(),
+    )
+
+
+def _mutated_bundle(mutator: Callable[[dict[str, Any]], None]) -> PublishBundle:
+    payload = _base_bundle().model_dump(mode="python")
+    mutator(payload)
+    return PublishBundle(**payload)

--- a/tests/l8_publish/test_dashboard_report_publish_integration.py
+++ b/tests/l8_publish/test_dashboard_report_publish_integration.py
@@ -2,8 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
+import pytest
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.types import CycleId
 from main_core.l8_publish import prepare_publish_bundle
 from main_core.l8_publish.dashboard import DASHBOARD_SNAPSHOT_KEY
+from main_core.l8_publish.publish_port import (
+    CommittedFormalObject,
+    ManifestWriteResult,
+)
 from main_core.l8_publish.refs import (
     ALPHA_RESULT_SNAPSHOT_KEY,
     OFFICIAL_ALPHA_POOL_KEY,
@@ -98,3 +108,64 @@ def test_formal_report_uses_reserved_manifest_ref_in_committed_payload() -> None
         "manifest_ref"
     ] == manifest_ref
     assert report_commit_payload["appendix_refs"]["manifest_ref"] == manifest_ref
+
+
+def test_manifest_ref_mismatch_fails_before_visible_manifest_write() -> None:
+    publish_port = MismatchedManifestRefPublishPort(
+        reserved_manifest_ref="manifest/cycle_l8/reserved",
+        actual_manifest_ref="pg://cycle_publish_manifest/cycle_l8/v43",
+    )
+
+    with pytest.raises(ManifestPublishError, match="reserved manifest_ref"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=FakeFormalObjectSource(),
+            publish_port=publish_port,
+        )
+
+    report_commit_payload = next(
+        commit_payload
+        for _, object_key, commit_payload in publish_port.commit_calls
+        if object_key == FORMAL_REPORT_KEY
+    )
+    assert publish_port.reserve_manifest_ref_calls == ["cycle_l8"]
+    assert publish_port.manifest_calls == []
+    assert report_commit_payload["appendix_refs"]["manifest_ref"] == (
+        "manifest/cycle_l8/reserved"
+    )
+    assert report_commit_payload["appendix_refs"]["manifest_ref"] != (
+        "pg://cycle_publish_manifest/cycle_l8/v43"
+    )
+
+
+class MismatchedManifestRefPublishPort(RecordingPublishPort):
+    def __init__(
+        self,
+        *,
+        reserved_manifest_ref: str,
+        actual_manifest_ref: str,
+    ) -> None:
+        super().__init__(manifest_ref=reserved_manifest_ref)
+        self.actual_manifest_ref = actual_manifest_ref
+
+    def write_cycle_manifest(
+        self,
+        *,
+        cycle_id: CycleId,
+        committed_objects: Sequence[CommittedFormalObject],
+        expected_manifest_ref: str | None = None,
+    ) -> ManifestWriteResult:
+        committed_tuple = tuple(committed_objects)
+        if expected_manifest_ref != self.actual_manifest_ref:
+            raise ManifestPublishError(
+                "reserved manifest_ref does not match publish target",
+            )
+        self.manifest_calls.append((cycle_id, committed_tuple))
+        return ManifestWriteResult(
+            manifest_ref=self.actual_manifest_ref,
+            manifest_version="v1",
+            table_snapshots={
+                committed.object_key: committed.snapshot_id
+                for committed in committed_tuple
+            },
+        )

--- a/tests/l8_publish/test_dashboard_report_publish_integration.py
+++ b/tests/l8_publish/test_dashboard_report_publish_integration.py
@@ -1,0 +1,76 @@
+"""Integration coverage for dashboard/report publication."""
+
+from __future__ import annotations
+
+from main_core.l8_publish import prepare_publish_bundle
+from main_core.l8_publish.dashboard import DASHBOARD_SNAPSHOT_KEY
+from main_core.l8_publish.refs import (
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    OFFICIAL_ALPHA_POOL_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+    WORLD_STATE_SNAPSHOT_KEY,
+)
+from main_core.l8_publish.report import FORMAL_REPORT_KEY
+from tests.l8_publish import FakeFormalObjectSource, RecordingPublishPort
+
+
+def test_prepare_publish_bundle_commits_dashboard_and_report_before_manifest() -> None:
+    publish_port = RecordingPublishPort()
+
+    bundle = prepare_publish_bundle(
+        "cycle_l8",
+        source=FakeFormalObjectSource(),
+        publish_port=publish_port,
+    )
+    payload = bundle.model_dump(mode="json")
+
+    assert tuple(payload["formal_objects"]) == (
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        RECOMMENDATION_SNAPSHOT_KEY,
+        DASHBOARD_SNAPSHOT_KEY,
+        FORMAL_REPORT_KEY,
+    )
+    assert [call[1] for call in publish_port.commit_calls] == [
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        RECOMMENDATION_SNAPSHOT_KEY,
+        DASHBOARD_SNAPSHOT_KEY,
+        FORMAL_REPORT_KEY,
+    ]
+    assert len(publish_port.manifest_calls) == 1
+    assert set(payload["manifest_candidate"]["table_snapshots"]) == {
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        RECOMMENDATION_SNAPSHOT_KEY,
+        DASHBOARD_SNAPSHOT_KEY,
+        FORMAL_REPORT_KEY,
+    }
+
+    dashboard = payload["formal_objects"][DASHBOARD_SNAPSHOT_KEY]["payload"]
+    report = payload["formal_objects"][FORMAL_REPORT_KEY]["payload"]
+    assert dashboard["world_state_ref"] == payload["formal_objects"][
+        WORLD_STATE_SNAPSHOT_KEY
+    ]["ref"]
+    assert dashboard["pool_ref"] == payload["formal_objects"][OFFICIAL_ALPHA_POOL_KEY][
+        "ref"
+    ]
+    assert dashboard["recommendation_ref"] == payload["formal_objects"][
+        RECOMMENDATION_SNAPSHOT_KEY
+    ]["ref"]
+    assert report["recommendation_ref"] == dashboard["recommendation_ref"]
+    assert dashboard["summary_cards"]["recommendations"][
+        "override_applied_count"
+    ] == 1
+    assert dashboard["summary_cards"]["recommendations"]["by_action"][
+        "inconclusive"
+    ] == 1
+    assert report["narrative_sections"]["inconclusive_summary"][
+        "recommendation_inconclusive_count"
+    ] == 1
+    assert report["narrative_sections"]["override_summary"][
+        "override_applied_count"
+    ] == 1

--- a/tests/l8_publish/test_dashboard_report_publish_integration.py
+++ b/tests/l8_publish/test_dashboard_report_publish_integration.py
@@ -74,3 +74,27 @@ def test_prepare_publish_bundle_commits_dashboard_and_report_before_manifest() -
     assert report["narrative_sections"]["override_summary"][
         "override_applied_count"
     ] == 1
+
+
+def test_formal_report_uses_reserved_manifest_ref_in_committed_payload() -> None:
+    manifest_ref = "pg://cycle_publish_manifest/cycle_l8/v42"
+    publish_port = RecordingPublishPort(manifest_ref=manifest_ref)
+
+    bundle = prepare_publish_bundle(
+        "cycle_l8",
+        source=FakeFormalObjectSource(),
+        publish_port=publish_port,
+    )
+    payload = bundle.model_dump(mode="json")
+    report_commit_payload = next(
+        commit_payload
+        for _, object_key, commit_payload in publish_port.commit_calls
+        if object_key == FORMAL_REPORT_KEY
+    )
+
+    assert publish_port.reserve_manifest_ref_calls == ["cycle_l8"]
+    assert payload["manifest_candidate"]["manifest_ref"] == manifest_ref
+    assert payload["formal_objects"][FORMAL_REPORT_KEY]["payload"]["appendix_refs"][
+        "manifest_ref"
+    ] == manifest_ref
+    assert report_commit_payload["appendix_refs"]["manifest_ref"] == manifest_ref

--- a/tests/l8_publish/test_manifest.py
+++ b/tests/l8_publish/test_manifest.py
@@ -14,6 +14,7 @@ from main_core.l8_publish import (
     ManifestWriteResult,
     prepare_publish_bundle,
 )
+from main_core.l8_publish.dashboard import DASHBOARD_SNAPSHOT_KEY
 from main_core.l8_publish.manifest import (
     build_manifest_candidate,
     commit_formal_objects,
@@ -25,6 +26,7 @@ from main_core.l8_publish.refs import (
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
 )
+from main_core.l8_publish.report import FORMAL_REPORT_KEY
 from tests.l8_publish import (
     FakeFormalObjectSource,
     RecordingPublishPort,
@@ -175,6 +177,8 @@ def test_prepare_publish_bundle_raises_when_manifest_write_fails() -> None:
         OFFICIAL_ALPHA_POOL_KEY,
         ALPHA_RESULT_SNAPSHOT_KEY,
         RECOMMENDATION_SNAPSHOT_KEY,
+        DASHBOARD_SNAPSHOT_KEY,
+        FORMAL_REPORT_KEY,
     ]
     assert len(publish_port.manifest_calls) == 1
 

--- a/tests/l8_publish/test_manifest.py
+++ b/tests/l8_publish/test_manifest.py
@@ -180,7 +180,7 @@ def test_prepare_publish_bundle_raises_when_manifest_write_fails() -> None:
         DASHBOARD_SNAPSHOT_KEY,
         FORMAL_REPORT_KEY,
     ]
-    assert len(publish_port.manifest_calls) == 1
+    assert publish_port.manifest_calls == []
 
 
 class InvalidCommitResultPublishPort(RecordingPublishPort):
@@ -219,6 +219,7 @@ class InvalidManifestResultPublishPort(RecordingPublishPort):
         *,
         cycle_id: CycleId,
         committed_objects: Sequence[CommittedFormalObject],
+        expected_manifest_ref: str | None = None,
     ) -> ManifestWriteResult:
         committed_tuple = tuple(committed_objects)
         self.manifest_calls.append((cycle_id, committed_tuple))

--- a/tests/l8_publish/test_report.py
+++ b/tests/l8_publish/test_report.py
@@ -49,6 +49,15 @@ def test_build_formal_report_rejects_missing_ref() -> None:
         build_formal_report("cycle_l8", bundle)
 
 
+def test_build_formal_report_rejects_missing_manifest_ref() -> None:
+    bundle = _mutated_bundle(
+        lambda payload: payload["manifest_candidate"].pop("manifest_ref")
+    )
+
+    with pytest.raises(ManifestPublishError, match="manifest_ref"):
+        build_formal_report("cycle_l8", bundle)
+
+
 def test_build_formal_report_rejects_cycle_mismatch() -> None:
     bundle = _mutated_bundle(
         lambda payload: payload.__setitem__("cycle_id", "cycle_other")

--- a/tests/l8_publish/test_report.py
+++ b/tests/l8_publish/test_report.py
@@ -1,0 +1,119 @@
+"""Tests for L8 formal report builders."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import PublishBundle
+from main_core.l8_publish import build_formal_report, prepare_publish_bundle
+from main_core.l8_publish.refs import RECOMMENDATION_SNAPSHOT_KEY
+from tests.l8_publish import FakeFormalObjectSource, RecordingPublishPort, pool
+
+
+def test_build_formal_report_happy_path() -> None:
+    bundle = _base_bundle()
+
+    report = build_formal_report("cycle_l8", bundle)
+
+    assert report.cycle_id == "cycle_l8"
+    assert report.report_type == "daily"
+    assert report.recommendation_ref == "recommendation_snapshot/cycle_l8/ref"
+    assert set(report.narrative_sections) == {
+        "overview",
+        "world_state",
+        "pool_changes",
+        "recommendation_summary",
+        "inconclusive_summary",
+        "override_summary",
+    }
+    assert report.appendix_refs == {
+        "world_state_ref": "world_state_snapshot/cycle_l8/ref",
+        "pool_ref": "official_alpha_pool/cycle_l8/ref",
+        "alpha_result_ref": "alpha_result_snapshot/cycle_l8/ref",
+        "recommendation_ref": "recommendation_snapshot/cycle_l8/ref",
+        "manifest_ref": "manifest/cycle_l8",
+        "audit_payload_ref": "audit_payload/cycle_l8",
+    }
+
+
+def test_build_formal_report_rejects_missing_ref() -> None:
+    bundle = _mutated_bundle(
+        lambda payload: payload["formal_objects"][RECOMMENDATION_SNAPSHOT_KEY].pop("ref")
+    )
+
+    with pytest.raises(ManifestPublishError, match="ref"):
+        build_formal_report("cycle_l8", bundle)
+
+
+def test_build_formal_report_rejects_cycle_mismatch() -> None:
+    bundle = _mutated_bundle(
+        lambda payload: payload.__setitem__("cycle_id", "cycle_other")
+    )
+
+    with pytest.raises(ManifestPublishError, match="cycle_id"):
+        build_formal_report("cycle_l8", bundle)
+
+
+def test_build_formal_report_keeps_inconclusive_outcomes_visible() -> None:
+    report = build_formal_report("cycle_l8", _base_bundle()).model_dump(mode="json")
+
+    inconclusive = report["narrative_sections"]["inconclusive_summary"]
+    assert inconclusive["alpha_inconclusive_count"] == 1
+    assert inconclusive["recommendation_inconclusive_count"] == 1
+    assert inconclusive["alpha_entity_ids"] == ["ENT_B"]
+    assert inconclusive["recommendation_entity_ids"] == ["ENT_B"]
+    assert "Inconclusive outcomes remain explicit" in inconclusive["summary"]
+
+
+def test_build_formal_report_counts_override_applied_recommendations() -> None:
+    report = build_formal_report("cycle_l8", _base_bundle()).model_dump(mode="json")
+
+    assert report["narrative_sections"]["override_summary"] == {
+        "summary": "Human overrides applied to 1 recommendations.",
+        "override_applied_count": 1,
+        "entity_ids": ["ENT_A"],
+    }
+    assert report["narrative_sections"]["recommendation_summary"][
+        "override_applied_count"
+    ] == 1
+
+
+def test_build_formal_report_allows_empty_recommendation_list() -> None:
+    bundle = _base_bundle(
+        FakeFormalObjectSource(
+            loaded_pool=pool(()),
+            loaded_alpha_results=[],
+            loaded_recommendations=[],
+        )
+    )
+
+    report = build_formal_report("cycle_l8", bundle)
+
+    assert report.narrative_sections["recommendation_summary"]["by_action"] == {
+        "buy": 0,
+        "hold": 0,
+        "reduce": 0,
+        "inconclusive": 0,
+    }
+    assert report.narrative_sections["inconclusive_summary"][
+        "summary"
+    ] == "No inconclusive alpha results or recommendations for this cycle."
+
+
+def _base_bundle(source: FakeFormalObjectSource | None = None) -> PublishBundle:
+    return prepare_publish_bundle(
+        "cycle_l8",
+        source=source or FakeFormalObjectSource(),
+        publish_port=RecordingPublishPort(),
+        derived_builders=(),
+    )
+
+
+def _mutated_bundle(mutator: Callable[[dict[str, Any]], None]) -> PublishBundle:
+    payload = _base_bundle().model_dump(mode="python")
+    mutator(payload)
+    return PublishBundle(**payload)


### PR DESCRIPTION
Closes #12

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
### 1. 背景与目标
项目文档 §9.3 与 §20.1 把 `dashboard_snapshot`、`FormalReport` 列为 L8 的正式业务输出，而不是展示层临时拼装结果。当前代码已经有 `main_core.common.schemas.DashboardSnapshot` 与 `FormalReport`，但 `src/main_core/l8_publish/` 还没有 `dashboard.py`、`report.py` 或构建逻辑；#11 会先提供 `PublishBundle`、canonical refs 与 manifest-backed publish 状态机。本 issue 的目标是在不重复计算 L4-L7 业务语义的前提下，基于 #11 发布后的 refs/payloads 生成 dashboard/report 内容，并把这两类 formal objects 注册进同一轮发布包。

### 2. 所属模块
Primary writable paths:
- `src/main_core/l8_publish/dashboard.py`（新建）
- `src/main_core/l8_publish/report.py`（新建）
- `src/main_core/l8_publish/__init__.py`
- `src/main_core/l8_publish/assembler.py`（仅通过 #11 预留的 derived builder hook 注册 dashboard/report）
- `tests/l8_publish/test_dashboard.py`（新建）
- `tests/l8_publish/test_report.py`（新建）
- `tests/l8_publish/test_dashboard_report_publish_integration.py`（新建或扩展 #11 integration test）

Adjacent read-only / integration paths:
- `src/main_core/common/schemas/dashboard.py`
- `src/main_core/common/schemas/report.py`
- `src/main_core/common/schemas/publish.py`
- `src/main_core/l8_publish/refs.py`（#11 提供，read-only helper）
- `src/main_core/l8_publish/publish_port.py`（#11 提供，read-only port）
- `src/main_core/common/schemas/world_state.py`、`pool.py`、`alpha.py`、`recommendation.py`（只读 payload 类型来源）

### 3. 实现范围
- 在 `src/main_core/l8_publish/dashboard.py` 实现 `build_dashboard_snapshot(cycle_id, bundle) -> DashboardSnapshot`，只读取 #11 `PublishBundle.formal_objects` 内的 refs/payloads，不调用 L4/L5/L6/L7 service。
- 在 `dashboard.py` 中实现内部解析函数：从 #11 canonical object shape 提取 `world_state_snapshot`、`official_alpha_pool`、`alpha_result_snapshot`、`recommendation_snapshot` 的 `ref`、`payload`、`count`；缺失或 cycle 不一致时抛 `ManifestPublishError`。
- `DashboardSnapshot.summary_cards` 至少包含稳定 key：`regime`、`pool`、`recommendations`、`inconclusive`、`overrides`；其中 `recommendations` 必须按 `action_type` 汇总，`pool` 必须包含 selected/capacity/added/removed 计数。
- 在 `src/main_core/l8_publish/report.py` 实现 `build_formal_report(cycle_id, bundle, *, report_type="daily"