### PR TITLE
feat(#41): [milestone-3 review] P0: Alpha results outside the official pool can be published

### DIFF
--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -269,6 +269,13 @@ def _validate_publish_consistency(
         raise ManifestPublishError(
             f"missing alpha result for selected pool entities: {missing}",
         )
+    extra_alpha_entity_ids = alpha_entity_ids - selected_entity_ids
+    if extra_alpha_entity_ids:
+        extra = ", ".join(sorted(extra_alpha_entity_ids))
+        raise ManifestPublishError(
+            "alpha result entity_id must belong to pool.selected_entities: "
+            f"{extra}",
+        )
 
     recommendation_entity_ids = _unique_entity_ids(
         RECOMMENDATION_SNAPSHOT_KEY,

--- a/tests/l8_publish/test_publish_integration.py
+++ b/tests/l8_publish/test_publish_integration.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
+import pytest
+
 from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import FeatureSignalBundle
 from main_core.l4_world_state import derive_world_state
 from main_core.l5_universe import select_official_alpha_pool
@@ -22,7 +25,13 @@ from main_core.l7_recommendation import (
 )
 from main_core.l8_publish import prepare_publish_bundle
 from main_core.l8_publish.refs import RECOMMENDATION_SNAPSHOT_KEY
-from tests.l8_publish import FakeFormalObjectSource, RecordingPublishPort
+from tests.l8_publish import (
+    FakeFormalObjectSource,
+    RecordingPublishPort,
+    alpha_result,
+    pool,
+    recommendation,
+)
 
 
 class SourceWithPreviousRecommendationTrap(FakeFormalObjectSource):
@@ -121,6 +130,32 @@ def test_publish_consumes_current_l7_output_without_previous_recommendations() -
     assert "previous_recommendation" not in serialized_bundle
     assert "last_recommendation" not in serialized_bundle
     assert "fallback_recommendation_ref" not in serialized_bundle
+
+
+def test_publish_rejects_alpha_results_outside_official_pool_before_commit() -> None:
+    source = FakeFormalObjectSource(
+        loaded_pool=pool(("ENT_A", "ENT_B")),
+        loaded_alpha_results=[
+            alpha_result("ENT_A"),
+            alpha_result("ENT_B"),
+            alpha_result("ENT_Z"),
+        ],
+        loaded_recommendations=[
+            recommendation("ENT_A"),
+            recommendation("ENT_B", action_type="hold"),
+        ],
+    )
+    publish_port = RecordingPublishPort()
+
+    with pytest.raises(ManifestPublishError, match="alpha result entity_id"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=source,
+            publish_port=publish_port,
+        )
+
+    assert publish_port.commit_calls == []
+    assert publish_port.manifest_calls == []
 
 
 def _feature_bundle(


### PR DESCRIPTION
Closes #41

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
_validate_publish_consistency requires every selected pool entity to have an alpha result, and it constrains recommendations to pool.selected_entities, but it never rejects alpha_result_snapshot rows whose entity_id is not in the official pool. commit_formal_objects then publishes the full alpha result sequence, and dashboard/report summaries count all alpha results. A stale or over-broad source can therefore formalize non-official entities, violating the documented L5 OfficialAlphaPool -> L6 AlphaResultSnapshot -> L7/L8 flow.

## 实现范围
- 修改文件: `src/main_core/l8_publish/assembler.py`
- Add an extra_alpha_entity_ids = alpha_entity_ids - selected_entity_ids check and raise ManifestPublishError before any commit. Cover it with an integration test that includes an ENT_Z alpha result while ENT_Z is absent from selected_entities, and assert no formal object commit or manifest write occurs.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
