### PR TITLE
feat(#40): [milestone-3 review] P0: Manifest can point at snapshots different from committed objects

### DIFF
--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -195,7 +195,11 @@ def _validate_manifest_write_result(
     if not isinstance(manifest.table_snapshots, Mapping):
         raise ManifestPublishError("manifest table_snapshots must be a mapping")
 
-    committed_object_keys = {committed.object_key for committed in committed_objects}
+    expected_snapshots = {
+        committed.object_key: committed.snapshot_id
+        for committed in committed_objects
+    }
+    committed_object_keys = set(expected_snapshots)
     table_snapshot_keys = set(manifest.table_snapshots)
     missing_object_keys = committed_object_keys - table_snapshot_keys
     if missing_object_keys:
@@ -203,13 +207,23 @@ def _validate_manifest_write_result(
         raise ManifestPublishError(
             f"manifest table_snapshots missing committed object keys: {missing}",
         )
-    for object_key in committed_object_keys:
+    unexpected_object_keys = table_snapshot_keys - committed_object_keys
+    if unexpected_object_keys:
+        unexpected = ", ".join(sorted(unexpected_object_keys))
+        raise ManifestPublishError(
+            f"manifest table_snapshots contains unexpected object keys: {unexpected}",
+        )
+    for object_key, expected_snapshot_id in expected_snapshots.items():
         table_snapshot = manifest.table_snapshots[object_key]
         if table_snapshot is None or (
             isinstance(table_snapshot, str) and not table_snapshot.strip()
         ):
             raise ManifestPublishError(
                 f"manifest table_snapshots entry must be non-empty for {object_key}",
+            )
+        if table_snapshot != expected_snapshot_id:
+            raise ManifestPublishError(
+                f"manifest table_snapshots snapshot_id mismatch for {object_key}",
             )
 
 

--- a/tests/l8_publish/test_manifest.py
+++ b/tests/l8_publish/test_manifest.py
@@ -119,6 +119,19 @@ def test_build_manifest_candidate_includes_commit_and_manifest_refs() -> None:
         ({"table_snapshots": []}, "table_snapshots must be a mapping"),
         ({"table_snapshots": {}}, "missing committed object keys"),
         (
+            {"table_snapshots": {WORLD_STATE_SNAPSHOT_KEY: "stale-snapshot"}},
+            "snapshot_id mismatch",
+        ),
+        (
+            {
+                "table_snapshots": {
+                    WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot-snapshot",
+                    "unrelated_snapshot": "unrelated-snapshot",
+                },
+            },
+            "unexpected object keys",
+        ),
+        (
             {"table_snapshots": {WORLD_STATE_SNAPSHOT_KEY: ""}},
             "table_snapshots entry must be non-empty",
         ),


### PR DESCRIPTION
Closes #40

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The manifest validation only checks that table_snapshots contains non-empty entries for committed object keys. It does not require manifest.table_snapshots[object_key] to equal the CommittedFormalObject.snapshot_id returned by commit_formal_object, and it permits extra snapshot keys. A publish port could commit one set of formal objects while writing a manifest that points consumers at stale or unrelated table snapshots. Because manifest-backed reads are the consistency anchor for all L8 formal outputs, this breaks the milestone's core publication guarantee.

## 实现范围
- 修改文件: `src/main_core/l8_publish/manifest.py`
- Validate the manifest snapshot map exactly against the committed objects: build expected = {committed.object_key: committed.snapshot_id for committed in committed_objects}, require every value to match, and reject unexpected extra keys unless the manifest schema explicitly supports them with documented semantics. Add a regression test where the port returns a non-empty but wrong snapshot_id.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
