### PR TITLE
feat(#13): 接入 graph_snapshot 与 graph_impact_snapshot 只读消费

### DIFF
--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -2,6 +2,14 @@
 
 from main_core.l3_features.builder import build_feature_signal_bundle, build_feature_signal_bundles
 from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
+from main_core.l3_features.graph_adapter import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+    load_graph_features,
+    merge_graph_features,
+)
 from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
 from main_core.l3_features.weight_api import (
     apply_weight_multiplier,
@@ -9,6 +17,10 @@ from main_core.l3_features.weight_api import (
 )
 
 __all__ = [
+    "GraphEnginePort",
+    "GraphImpactRecord",
+    "GraphRegimeContext",
+    "GraphSnapshotError",
     "InMemoryMultiplierStore",
     "InvalidMultiplierError",
     "L3FeatureError",
@@ -17,4 +29,6 @@ __all__ = [
     "build_feature_signal_bundle",
     "build_feature_signal_bundles",
     "get_feature_weight_multiplier",
+    "load_graph_features",
+    "merge_graph_features",
 ]

--- a/src/main_core/l3_features/builder.py
+++ b/src/main_core/l3_features/builder.py
@@ -17,17 +17,23 @@ from main_core.l3_features.feature_math import (
     apply_feature_weight_multiplier,
     market_bar_feature_values,
 )
+from main_core.l3_features.graph_adapter import (
+    GraphEnginePort,
+    load_graph_features,
+    merge_graph_features,
+)
 from main_core.l3_features.multiplier_store import MultiplierStore
 from main_core.l3_features.weight_api import get_feature_weight_multiplier
 
 _DATA_PLATFORM_PORT_ENV = "MAIN_CORE_DATA_PLATFORM_PORT"
 
 
-def build_feature_signal_bundle(
+def build_feature_signal_bundle(  # noqa: PLR0913
     cycle_id: CycleId | str,
     *,
     data_port: DataPlatformPort | None = None,
     multiplier_store: MultiplierStore | None = None,
+    graph_engine_port: GraphEnginePort | None = None,
     graph_impact: Mapping[str, Mapping[str, Any]] | None = None,
     candidate_signals: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> FeatureSignalBundle:
@@ -42,6 +48,7 @@ def build_feature_signal_bundle(
         cycle_id,
         data_port=data_port,
         multiplier_store=multiplier_store,
+        graph_engine_port=graph_engine_port,
         graph_impact=graph_impact,
         candidate_signals=candidate_signals,
     )
@@ -55,11 +62,12 @@ def build_feature_signal_bundle(
     )
 
 
-def build_feature_signal_bundles(
+def build_feature_signal_bundles(  # noqa: PLR0913
     cycle_id: CycleId | str,
     *,
     data_port: DataPlatformPort | None = None,
     multiplier_store: MultiplierStore | None = None,
+    graph_engine_port: GraphEnginePort | None = None,
     graph_impact: Mapping[str, Mapping[str, Any]] | None = None,
     candidate_signals: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> list[FeatureSignalBundle]:
@@ -87,16 +95,25 @@ def build_feature_signal_bundles(
             base_feature_values,
             multipliers,
         )
-        bundles.append(
-            FeatureSignalBundle(
-                cycle_id=cycle_id,
-                entity_id=EntityId(entity_id),
-                feature_values=feature_values,
-                signal_values=dict((candidate_signals or {}).get(entity_id, {})),
-                graph_features=dict((graph_impact or {}).get(entity_id, {})),
-                feature_weight_multiplier=effective_multipliers,
-            )
+        bundle = FeatureSignalBundle(
+            cycle_id=cycle_id,
+            entity_id=EntityId(entity_id),
+            feature_values=feature_values,
+            signal_values=dict((candidate_signals or {}).get(entity_id, {})),
+            graph_features=dict((graph_impact or {}).get(entity_id, {})),
+            feature_weight_multiplier=effective_multipliers,
         )
+        graph_features = load_graph_features(
+            CycleId(str(cycle_id)),
+            EntityId(entity_id),
+            graph_engine_port,
+        )
+        if graph_features:
+            bundle = merge_graph_features(
+                bundle,
+                {**dict(bundle.graph_features), **graph_features},
+            )
+        bundles.append(bundle)
 
     return bundles
 

--- a/src/main_core/l3_features/graph_adapter.py
+++ b/src/main_core/l3_features/graph_adapter.py
@@ -1,0 +1,114 @@
+"""Read-only graph-engine adapter for L3 feature enrichment."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.types import CycleId, EntityId
+
+
+class GraphSnapshotError(MainCoreError):
+    """Raised when a graph snapshot cannot be consumed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class GraphImpactRecord:
+    """One graph impact row from the read-only graph snapshot surface."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    features: Mapping[str, Any]
+    snapshot_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class GraphRegimeContext:
+    """Graph regime context read from the graph snapshot surface."""
+
+    cycle_id: CycleId
+    snapshot_id: str
+    regime_context: Mapping[str, Any]
+
+
+@runtime_checkable
+class GraphEnginePort(Protocol):
+    """Read-only graph-engine boundary used by main-core."""
+
+    def read_graph_impact_snapshot(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[GraphImpactRecord]:
+        """Return per-entity graph impact rows for the requested cycle."""
+
+    def read_graph_regime_context(
+        self,
+        cycle_id: CycleId,
+    ) -> GraphRegimeContext | None:
+        """Return graph regime context for the requested cycle, when available."""
+
+
+def load_graph_features(
+    cycle_id: CycleId,
+    entity_id: EntityId,
+    port: GraphEnginePort | None,
+) -> dict[str, Any]:
+    """Load graph impact features for one entity from a read-only graph port."""
+
+    if port is None:
+        return {}
+
+    records = list(port.read_graph_impact_snapshot(cycle_id))
+    matching_records: list[GraphImpactRecord] = []
+    for record in records:
+        if str(record.cycle_id) != str(cycle_id):
+            raise GraphSnapshotError(
+                "graph impact snapshot contains records from a different cycle"
+            )
+        if str(record.entity_id) == str(entity_id):
+            matching_records.append(record)
+
+    if not matching_records:
+        return {}
+    if len(matching_records) > 1:
+        raise GraphSnapshotError(
+            "graph impact snapshot contains duplicate records for entity"
+        )
+
+    record = matching_records[0]
+    return {
+        "snapshot_id": record.snapshot_id,
+        "features": _to_plain_json_like(record.features),
+    }
+
+
+def merge_graph_features(
+    bundle: FeatureSignalBundle,
+    graph_features: Mapping[str, Any],
+) -> FeatureSignalBundle:
+    """Return a new feature bundle with graph features merged in."""
+
+    return bundle.model_copy(
+        update={"graph_features": _to_plain_json_like(graph_features)}
+    )
+
+
+def _to_plain_json_like(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _to_plain_json_like(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_to_plain_json_like(item) for item in value]
+    return value
+
+
+__all__ = [
+    "GraphEnginePort",
+    "GraphImpactRecord",
+    "GraphRegimeContext",
+    "GraphSnapshotError",
+    "load_graph_features",
+    "merge_graph_features",
+]

--- a/src/main_core/l4_world_state/__init__.py
+++ b/src/main_core/l4_world_state/__init__.py
@@ -1,5 +1,9 @@
 """L4 package: shared world-state derivation."""
 
+from main_core.l4_world_state.graph_adapter import (
+    load_graph_regime_context,
+    with_graph_impact,
+)
 from main_core.l4_world_state.reasoner_port import (
     StaticWorldStateReasonerPort,
     WorldStateDeltaDecision,
@@ -14,4 +18,6 @@ __all__ = [
     "WorldStateDeltaDecision",
     "WorldStateReasonerPort",
     "derive_world_state",
+    "load_graph_regime_context",
+    "with_graph_impact",
 ]

--- a/src/main_core/l4_world_state/graph_adapter.py
+++ b/src/main_core/l4_world_state/graph_adapter.py
@@ -1,0 +1,60 @@
+"""Read-only graph-engine adapter for L4 world-state inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.types import CycleId
+from main_core.l3_features.graph_adapter import GraphEnginePort, GraphSnapshotError
+
+
+def load_graph_regime_context(
+    cycle_id: CycleId,
+    port: GraphEnginePort | None,
+) -> dict[str, Any]:
+    """Load graph regime context in the shape expected by WorldStateInputs."""
+
+    if port is None:
+        return {}
+
+    context = port.read_graph_regime_context(cycle_id)
+    if context is None:
+        return {}
+    if str(context.cycle_id) != str(cycle_id):
+        raise GraphSnapshotError(
+            "graph regime context contains records from a different cycle"
+        )
+
+    return {
+        "snapshot_id": context.snapshot_id,
+        "regime_context": _to_plain_json_like(context.regime_context),
+    }
+
+
+def with_graph_impact(
+    inputs: WorldStateInputs,
+    graph_impact: Mapping[str, Any],
+) -> WorldStateInputs:
+    """Return a validated copy of world-state inputs with graph impact attached."""
+
+    return WorldStateInputs.model_validate(
+        {
+            "cycle_id": inputs.cycle_id,
+            "feature_bundle": inputs.feature_bundle,
+            "macro_context": dict(inputs.macro_context),
+            "graph_impact": _to_plain_json_like(graph_impact) if graph_impact else {},
+        }
+    )
+
+
+def _to_plain_json_like(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _to_plain_json_like(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_to_plain_json_like(item) for item in value]
+    return value
+
+
+__all__ = ["load_graph_regime_context", "with_graph_impact"]

--- a/src/main_core/l4_world_state/service.py
+++ b/src/main_core/l4_world_state/service.py
@@ -9,6 +9,8 @@ from main_core.common.contexts import WorldStateInputs
 from main_core.common.errors import MainCoreError
 from main_core.common.protocols import WorldStatePolicy
 from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.l3_features.graph_adapter import GraphEnginePort
+from main_core.l4_world_state.graph_adapter import load_graph_regime_context, with_graph_impact
 from main_core.l4_world_state.reasoner_port import (
     StaticWorldStateReasonerPort,
     WorldStateReasonerError,
@@ -17,23 +19,35 @@ from main_core.l4_world_state.reasoner_port import (
 from main_core.l4_world_state.rules import DefaultWorldStatePolicy
 
 
-def derive_world_state(
+def derive_world_state(  # noqa: PLR0913
     bundle: FeatureSignalBundle,
     policy: WorldStatePolicy | None = None,
     reasoner_port: WorldStateReasonerPort | None = None,
     *,
     macro_context: Mapping[str, Any] | None = None,
+    graph_engine_port: GraphEnginePort | None = None,
     graph_impact: Mapping[str, Any] | None = None,
 ) -> WorldStateSnapshot:
     """Derive a formal shared world-state snapshot from an L3 feature bundle."""
 
     active_policy = policy or DefaultWorldStatePolicy()
     active_reasoner_port = reasoner_port or StaticWorldStateReasonerPort()
-    inputs = WorldStateInputs(
-        cycle_id=bundle.cycle_id,
-        feature_bundle=bundle,
-        macro_context=dict(macro_context or {}),
-        graph_impact=dict(graph_impact or {}),
+    graph_impact_payload = dict(graph_impact or {})
+    graph_regime_context = load_graph_regime_context(
+        bundle.cycle_id,
+        graph_engine_port,
+    )
+    if graph_regime_context:
+        graph_impact_payload = {**graph_impact_payload, **graph_regime_context}
+
+    inputs = with_graph_impact(
+        WorldStateInputs(
+            cycle_id=bundle.cycle_id,
+            feature_bundle=bundle,
+            macro_context=dict(macro_context or {}),
+            graph_impact={},
+        ),
+        graph_impact_payload,
     )
 
     baseline_regime = active_policy.baseline(inputs)

--- a/tests/integration/test_graph_readonly_consumption.py
+++ b/tests/integration/test_graph_readonly_consumption.py
@@ -1,0 +1,182 @@
+"""Integration coverage for read-only graph consumption across L3 and L4."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.schemas import WorldStateSnapshot
+from main_core.common.types import CycleId, EntityId, Regime
+from main_core.l1_l2_basis import EntityMasterRow, MarketBar
+from main_core.l3_features import (
+    GraphImpactRecord,
+    GraphRegimeContext,
+    build_feature_signal_bundles,
+)
+from main_core.l4_world_state import StaticWorldStateReasonerPort, derive_world_state
+from main_core.l4_world_state.reasoner_port import WorldStateDeltaDecision
+
+
+@dataclass
+class FakeDataPlatformPort:
+    market_bars: Sequence[object] = field(default_factory=tuple)
+    entity_master: Sequence[object] = field(default_factory=tuple)
+
+    def read_market_bars(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return self.market_bars
+
+    def read_calendar(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return ()
+
+    def read_entity_master(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return self.entity_master
+
+
+@dataclass
+class FakeGraphEnginePort:
+    previous_world_state: WorldStateSnapshot
+    graph_only_entity_id: EntityId = EntityId("ENT_Z")
+    impact_calls: list[CycleId] = field(default_factory=list)
+    regime_calls: list[CycleId] = field(default_factory=list)
+
+    def read_graph_impact_snapshot(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[GraphImpactRecord]:
+        self.impact_calls.append(cycle_id)
+        return (
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_001"),
+                snapshot_id=f"graph-impact-{cycle_id}",
+                features={
+                    "previous_cycle_id": str(self.previous_world_state.cycle_id),
+                    "previous_final_regime": self.previous_world_state.final_regime,
+                    "impact_score": 0.81,
+                },
+            ),
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=self.graph_only_entity_id,
+                snapshot_id=f"graph-impact-extra-{cycle_id}",
+                features={"impact_score": 0.99},
+            ),
+        )
+
+    def read_graph_regime_context(
+        self,
+        cycle_id: CycleId,
+    ) -> GraphRegimeContext | None:
+        self.regime_calls.append(cycle_id)
+        return GraphRegimeContext(
+            cycle_id=cycle_id,
+            snapshot_id=f"graph-snapshot-{cycle_id}",
+            regime_context={
+                "previous_cycle_id": str(self.previous_world_state.cycle_id),
+                "previous_final_regime": self.previous_world_state.final_regime,
+                "previous_llm_delta": self.previous_world_state.llm_delta,
+            },
+        )
+
+
+@dataclass
+class CapturingWorldStatePolicy:
+    seen_inputs: list[WorldStateInputs] = field(default_factory=list)
+
+    def baseline(self, inputs: WorldStateInputs) -> Regime:
+        self.seen_inputs.append(inputs)
+        return "neutral"
+
+    def bound_delta(self, raw_delta: int) -> int:
+        if raw_delta < 0:
+            return -1
+        if raw_delta > 0:
+            return 1
+        return 0
+
+    def compose(self, baseline: Regime, delta: int) -> Regime:
+        regimes: tuple[Regime, ...] = ("risk_off", "neutral", "risk_on")
+        return regimes[regimes.index(baseline) + delta]
+
+
+def test_previous_world_state_feeds_readonly_graph_context_into_l3_and_l4() -> None:
+    previous_cycle_id = CycleId("cycle-previous")
+    current_cycle_id = CycleId("cycle-current")
+    previous_world_state = WorldStateSnapshot(
+        cycle_id=previous_cycle_id,
+        baseline_regime="neutral",
+        llm_delta=1,
+        final_regime="risk_on",
+        llm_rationale="previous cycle risk appetite improved",
+        actual_model_used="static",
+        actual_provider="local",
+        fallback_path=[],
+    )
+    entity = EntityMasterRow(
+        entity_id=EntityId("ENT_001"),
+        ticker="AAA",
+        name="Alpha A",
+        exchange="NASDAQ",
+    )
+    data_port = FakeDataPlatformPort(
+        entity_master=(entity,),
+        market_bars=(
+            MarketBar(
+                cycle_id=current_cycle_id,
+                entity_id=entity.entity_id,
+                as_of_date=date(2026, 4, 17),
+                close_price=100.0,
+                volume=1000.0,
+                return_1d=0.01,
+            ),
+        ),
+    )
+    graph_port = FakeGraphEnginePort(previous_world_state=previous_world_state)
+
+    bundles = build_feature_signal_bundles(
+        current_cycle_id,
+        data_port=data_port,
+        graph_engine_port=graph_port,
+    )
+
+    assert [bundle.entity_id for bundle in bundles] == ["ENT_001"]
+    assert bundles[0].graph_features == {
+        "snapshot_id": "graph-impact-cycle-current",
+        "features": {
+            "previous_cycle_id": "cycle-previous",
+            "previous_final_regime": "risk_on",
+            "impact_score": 0.81,
+        },
+    }
+
+    policy = CapturingWorldStatePolicy()
+    world_state = derive_world_state(
+        bundles[0],
+        policy=policy,
+        reasoner_port=StaticWorldStateReasonerPort(
+            WorldStateDeltaDecision(
+                raw_delta=0,
+                rationale="static integration delta",
+                actual_model_used="static",
+                actual_provider="local",
+                fallback_path=[],
+            )
+        ),
+        graph_engine_port=graph_port,
+    )
+
+    assert world_state.cycle_id == current_cycle_id
+    assert world_state.final_regime == "neutral"
+    assert policy.seen_inputs[0].graph_impact == {
+        "snapshot_id": "graph-snapshot-cycle-current",
+        "regime_context": {
+            "previous_cycle_id": "cycle-previous",
+            "previous_final_regime": "risk_on",
+            "previous_llm_delta": 1,
+        },
+    }
+    assert graph_port.impact_calls == [current_cycle_id]
+    assert graph_port.regime_calls == [current_cycle_id]
+

--- a/tests/l3_features/test_graph_adapter.py
+++ b/tests/l3_features/test_graph_adapter.py
@@ -1,0 +1,213 @@
+"""Tests for read-only graph adapter consumption in L3."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date
+
+import pytest
+
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import EntityMasterRow, MarketBar
+from main_core.l3_features import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+    build_feature_signal_bundles,
+    load_graph_features,
+    merge_graph_features,
+)
+
+from .conftest import FakeDataPlatformPort
+
+
+@dataclass
+class FakeGraphEnginePort:
+    impact_records: Sequence[GraphImpactRecord] = field(default_factory=tuple)
+    regime_context: GraphRegimeContext | None = None
+    impact_calls: list[CycleId] = field(default_factory=list)
+    regime_calls: list[CycleId] = field(default_factory=list)
+
+    def read_graph_impact_snapshot(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[GraphImpactRecord]:
+        self.impact_calls.append(cycle_id)
+        return self.impact_records
+
+    def read_graph_regime_context(
+        self,
+        cycle_id: CycleId,
+    ) -> GraphRegimeContext | None:
+        self.regime_calls.append(cycle_id)
+        return self.regime_context
+
+
+def test_graph_engine_port_is_runtime_checkable_and_read_only() -> None:
+    port = FakeGraphEnginePort()
+
+    protocol_methods = {
+        name
+        for name, value in GraphEnginePort.__dict__.items()
+        if callable(value) and not name.startswith("_")
+    }
+
+    assert isinstance(port, GraphEnginePort)
+    assert protocol_methods == {
+        "read_graph_impact_snapshot",
+        "read_graph_regime_context",
+    }
+    assert not {
+        name
+        for name in dir(GraphEnginePort)
+        if name.startswith(("write_", "commit_", "mutate_"))
+    }
+    assert not {
+        name
+        for name in dir(port)
+        if name.startswith(("write_", "commit_", "mutate_"))
+    }
+
+
+def test_load_graph_features_returns_empty_without_port_or_matching_record() -> None:
+    cycle_id = CycleId("cycle-graph-l3")
+    port = FakeGraphEnginePort(
+        impact_records=(
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_Z"),
+                features={"centrality": 0.9},
+                snapshot_id="graph-impact-001",
+            ),
+        )
+    )
+
+    assert load_graph_features(cycle_id, EntityId("ENT_001"), None) == {}
+    assert load_graph_features(cycle_id, EntityId("ENT_001"), port) == {}
+
+
+def test_load_graph_features_returns_snapshot_id_and_features() -> None:
+    cycle_id = CycleId("cycle-graph-l3")
+    port = FakeGraphEnginePort(
+        impact_records=(
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_001"),
+                features={
+                    "centrality": 0.72,
+                    "neighbors": ("ENT_A", "ENT_B"),
+                    "metadata": {"source": "previous_world_state"},
+                },
+                snapshot_id="graph-impact-001",
+            ),
+        )
+    )
+
+    graph_features = load_graph_features(cycle_id, EntityId("ENT_001"), port)
+
+    assert graph_features == {
+        "snapshot_id": "graph-impact-001",
+        "features": {
+            "centrality": 0.72,
+            "neighbors": ["ENT_A", "ENT_B"],
+            "metadata": {"source": "previous_world_state"},
+        },
+    }
+
+
+def test_load_graph_features_rejects_cycle_mismatch() -> None:
+    port = FakeGraphEnginePort(
+        impact_records=(
+            GraphImpactRecord(
+                cycle_id=CycleId("cycle-other"),
+                entity_id=EntityId("ENT_001"),
+                features={"centrality": 0.72},
+                snapshot_id="graph-impact-001",
+            ),
+        )
+    )
+
+    with pytest.raises(GraphSnapshotError, match="different cycle"):
+        load_graph_features(CycleId("cycle-current"), EntityId("ENT_001"), port)
+
+
+def test_merge_graph_features_returns_new_bundle_without_mutating_original() -> None:
+    bundle = FeatureSignalBundle(
+        cycle_id="cycle-graph-l3",
+        entity_id="ENT_001",
+        feature_values={"momentum": 0.4},
+        signal_values={"direction": "positive"},
+        graph_features={"legacy": {"score": 1}},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+    before_json = bundle.to_json()
+
+    merged = merge_graph_features(
+        bundle,
+        {"snapshot_id": "graph-impact-001", "features": {"centrality": 0.72}},
+    )
+
+    assert bundle.to_json() == before_json
+    assert merged is not bundle
+    assert merged.generated_at == bundle.generated_at
+    assert merged.feature_values == bundle.feature_values
+    assert merged.signal_values == bundle.signal_values
+    assert merged.feature_weight_multiplier == bundle.feature_weight_multiplier
+    assert merged.graph_features == {
+        "snapshot_id": "graph-impact-001",
+        "features": {"centrality": 0.72},
+    }
+
+
+def test_builder_enriches_existing_market_entities_and_ignores_graph_only_entity(
+    cycle_id: CycleId,
+) -> None:
+    entity = EntityMasterRow(
+        entity_id=EntityId("ENT_001"),
+        ticker="AAA",
+        name="Alpha A",
+        exchange="NASDAQ",
+    )
+    market_bar = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=entity.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+    )
+    data_port = FakeDataPlatformPort(
+        entity_master=(entity,),
+        market_bars=(market_bar,),
+    )
+    graph_port = FakeGraphEnginePort(
+        impact_records=(
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=entity.entity_id,
+                features={"centrality": 0.72},
+                snapshot_id="graph-impact-001",
+            ),
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_Z"),
+                features={"centrality": 0.95},
+                snapshot_id="graph-impact-extra",
+            ),
+        )
+    )
+
+    bundles = build_feature_signal_bundles(
+        cycle_id,
+        data_port=data_port,
+        graph_engine_port=graph_port,
+    )
+
+    assert [bundle.entity_id for bundle in bundles] == ["ENT_001"]
+    assert bundles[0].graph_features == {
+        "snapshot_id": "graph-impact-001",
+        "features": {"centrality": 0.72},
+    }
+    assert graph_port.impact_calls == [cycle_id]

--- a/tests/l4_world_state/test_graph_adapter.py
+++ b/tests/l4_world_state/test_graph_adapter.py
@@ -1,0 +1,205 @@
+"""Tests for graph regime context consumption in L4."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import pytest
+
+from main_core.common.contexts import WorldStateInputs
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.common.types import CycleId, Regime
+from main_core.l3_features import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+)
+from main_core.l4_world_state import (
+    StaticWorldStateReasonerPort,
+    derive_world_state,
+    load_graph_regime_context,
+    with_graph_impact,
+)
+from main_core.l4_world_state.reasoner_port import WorldStateDeltaDecision
+
+
+@dataclass
+class FakeGraphEnginePort:
+    impact_records: Sequence[GraphImpactRecord] = field(default_factory=tuple)
+    regime_context: GraphRegimeContext | None = None
+    impact_calls: list[CycleId] = field(default_factory=list)
+    regime_calls: list[CycleId] = field(default_factory=list)
+
+    def read_graph_impact_snapshot(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[GraphImpactRecord]:
+        self.impact_calls.append(cycle_id)
+        return self.impact_records
+
+    def read_graph_regime_context(
+        self,
+        cycle_id: CycleId,
+    ) -> GraphRegimeContext | None:
+        self.regime_calls.append(cycle_id)
+        return self.regime_context
+
+
+@dataclass
+class SpyWorldStatePolicy:
+    baseline_regime: Regime = "neutral"
+    seen_inputs: list[WorldStateInputs] = field(default_factory=list)
+
+    def baseline(self, inputs: WorldStateInputs) -> Regime:
+        self.seen_inputs.append(inputs)
+        return self.baseline_regime
+
+    def bound_delta(self, raw_delta: int) -> int:
+        if raw_delta < 0:
+            return -1
+        if raw_delta > 0:
+            return 1
+        return 0
+
+    def compose(self, baseline: Regime, delta: int) -> Regime:
+        regimes: tuple[Regime, ...] = ("risk_off", "neutral", "risk_on")
+        return regimes[regimes.index(baseline) + delta]
+
+
+def _decision(raw_delta: int = 0) -> WorldStateDeltaDecision:
+    return WorldStateDeltaDecision(
+        raw_delta=raw_delta,
+        rationale="static graph test delta",
+        actual_model_used="static",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+def test_load_graph_regime_context_returns_empty_without_port_or_context() -> None:
+    cycle_id = CycleId("cycle-graph-l4")
+    port = FakeGraphEnginePort()
+
+    assert load_graph_regime_context(cycle_id, None) == {}
+    assert load_graph_regime_context(cycle_id, port) == {}
+
+
+def test_load_graph_regime_context_returns_world_state_input_shape() -> None:
+    cycle_id = CycleId("cycle-graph-l4")
+    port = FakeGraphEnginePort(
+        regime_context=GraphRegimeContext(
+            cycle_id=cycle_id,
+            snapshot_id="graph-snapshot-001",
+            regime_context={
+                "previous_final_regime": "risk_on",
+                "contributors": ("ENT_001", "ENT_002"),
+            },
+        )
+    )
+
+    graph_impact = load_graph_regime_context(cycle_id, port)
+
+    assert graph_impact == {
+        "snapshot_id": "graph-snapshot-001",
+        "regime_context": {
+            "previous_final_regime": "risk_on",
+            "contributors": ["ENT_001", "ENT_002"],
+        },
+    }
+    assert port.regime_calls == [cycle_id]
+
+
+def test_load_graph_regime_context_rejects_cycle_mismatch() -> None:
+    port = FakeGraphEnginePort(
+        regime_context=GraphRegimeContext(
+            cycle_id=CycleId("cycle-other"),
+            snapshot_id="graph-snapshot-001",
+            regime_context={"previous_final_regime": "risk_on"},
+        )
+    )
+
+    with pytest.raises(GraphSnapshotError, match="different cycle"):
+        load_graph_regime_context(CycleId("cycle-current"), port)
+
+
+def test_with_graph_impact_returns_validated_copy(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    inputs = WorldStateInputs(
+        cycle_id=feature_bundle.cycle_id,
+        feature_bundle=feature_bundle,
+        macro_context={"baseline_regime": "neutral"},
+        graph_impact={"legacy": True},
+    )
+
+    updated = with_graph_impact(
+        inputs,
+        {"snapshot_id": "graph-snapshot-001", "regime_context": {"stress": "low"}},
+    )
+
+    assert updated is not inputs
+    assert inputs.graph_impact == {"legacy": True}
+    assert updated.graph_impact == {
+        "snapshot_id": "graph-snapshot-001",
+        "regime_context": {"stress": "low"},
+    }
+    assert updated.macro_context == inputs.macro_context
+    assert updated.feature_bundle == inputs.feature_bundle
+
+
+def test_derive_world_state_passes_graph_impact_to_policy(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    port = FakeGraphEnginePort(
+        regime_context=GraphRegimeContext(
+            cycle_id=feature_bundle.cycle_id,
+            snapshot_id="graph-snapshot-001",
+            regime_context={"previous_final_regime": "risk_on"},
+        )
+    )
+    policy = SpyWorldStatePolicy()
+
+    snapshot = derive_world_state(
+        feature_bundle,
+        policy=policy,
+        reasoner_port=StaticWorldStateReasonerPort(_decision()),
+        graph_engine_port=port,
+    )
+
+    assert isinstance(snapshot, WorldStateSnapshot)
+    assert policy.seen_inputs[0].graph_impact == {
+        "snapshot_id": "graph-snapshot-001",
+        "regime_context": {"previous_final_regime": "risk_on"},
+    }
+    assert port.regime_calls == [feature_bundle.cycle_id]
+
+
+def test_derive_world_state_keeps_pure_market_fallback_without_graph(
+    feature_bundle: FeatureSignalBundle,
+) -> None:
+    policy = SpyWorldStatePolicy()
+
+    snapshot = derive_world_state(
+        feature_bundle,
+        policy=policy,
+        reasoner_port=StaticWorldStateReasonerPort(_decision(raw_delta=1)),
+    )
+
+    assert snapshot.baseline_regime == "neutral"
+    assert snapshot.llm_delta == 1
+    assert snapshot.final_regime == "risk_on"
+    assert policy.seen_inputs[0].graph_impact == {}
+
+
+def test_fake_graph_port_only_exposes_read_methods() -> None:
+    port = FakeGraphEnginePort()
+
+    assert isinstance(port, GraphEnginePort)
+    assert not {
+        name
+        for name in dir(port)
+        if name.startswith(("write_", "commit_", "mutate_"))
+    }
+


### PR DESCRIPTION
Closes #13

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l4_world_state/service.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
### 1. 背景与目标
项目文档 §5.2、§8、§21 阶段 3 要求 `main-core` 只读消费 `graph-engine` 的 `graph_snapshot` / `graph_impact_snapshot`，并形成 `world_state -> graph -> L3 -> L4` 的时序闭环。当前代码里已经有可承载该接入点的契约：`src/main_core/common/schemas/feature_bundle.py` 的 `FeatureSignalBundle.graph_features`，以及 `src/main_core/common/contexts.py` 的 `WorldStateInputs.graph_impact`。但 `src/main_core/l3_features/` 和 `src/main_core/l4_world_state/` 目前只有包入口与 L4 stub，还没有 graph adapter、只读 port 或把 graph 上下文送入 `WorldStatePolicy.baseline(inputs)` 的路径。本 issue 的目标是在不写入 graph-engine、不改 formal schema 的前提下，把 graph impact 注入 L3 bundle，并把 graph regime context 注入 L4 baseline 输入。

### 2. 所属模块
Primary writable paths:
- `src/main_core/l3_features/graph_adapter.py`（新增）
- `src/main_core/l4_world_state/graph_adapter.py`（新增）
- `src/main_core/l3_features/__init__.py`（导出 L3 graph adapter 公共符号）
- `src/main_core/l4_world_state/__init__.py`（导出 L4 graph adapter 公共符号）
- `tests/l3_features/test_graph_adapter.py`（新增）
- `tests/l4_world_state/test_graph_adapter.py`（新增）
- `tests/integration/test_graph_readonly_consumption.py`（新增）

Adjacent read-only / integration paths:
- `src/main_core/common/schemas/feature_bundle.py`（已有 `FeatureSignalBundle.graph_features`，不新增字段）
- `src/main_core/common/contexts.py`（已有 `WorldStateInputs.graph_impact`，L4 应复用）
- `src/main_core/common/protocols/world_state_policy.py`（已有 `WorldStatePolicy.baseline(inputs: WorldStateInputs) -> Regime`）
- `src/main_core/common/schemas/world_state.py`（已有 `WorldStateSnapshot` / `REGIME_SEQUENCE`）
- `src/main_core/common/types.py`、`src/main_core/common/errors.py`
- #6 / #7 已交付的 L3 builder 与 L4 service 文件（只做接线，不改变其公开位置参数合同）
- #12 已交付并经 blocking P0 补齐的 L8 publish regression tests（只作为回归验证，不改 L8）

Off-limits paths:
- `graph-engine` 仓库或任何 Neo4j / 图谱写入实现
- `data-platform` formal serving / storage 代码
- `src/main_core/common/schemas/*` 的字段结构调整

### 3. 实现范围
- 新增 `src/main_core/l3_features/graph_adapter.py`，定义只读 `GraphEnginePort` 协议，协议只允许 `read_graph_impact_snapshot(cycle_id: CycleId) -> Sequenc