### PR TITLE
feat(#14): 接入 Layer B 候选信号到 l3_features

### DIFF
--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -1,6 +1,14 @@
 """L3 package: feature and signal bundle assembly."""
 
 from main_core.l3_features.builder import build_feature_signal_bundle, build_feature_signal_bundles
+from main_core.l3_features.candidate_signals import (
+    CandidateSignalError,
+    CandidateSignalPort,
+    CandidateSignalRecord,
+    candidate_signal_multiplier,
+    merge_candidate_signals,
+    normalize_candidate_signals,
+)
 from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
 from main_core.l3_features.graph_adapter import (
     GraphEnginePort,
@@ -25,10 +33,16 @@ __all__ = [
     "InvalidMultiplierError",
     "L3FeatureError",
     "MultiplierStore",
+    "CandidateSignalError",
+    "CandidateSignalPort",
+    "CandidateSignalRecord",
     "apply_weight_multiplier",
     "build_feature_signal_bundle",
     "build_feature_signal_bundles",
+    "candidate_signal_multiplier",
     "get_feature_weight_multiplier",
     "load_graph_features",
+    "merge_candidate_signals",
     "merge_graph_features",
+    "normalize_candidate_signals",
 ]

--- a/src/main_core/l3_features/builder.py
+++ b/src/main_core/l3_features/builder.py
@@ -12,6 +12,12 @@ from main_core.common.types import CycleId, EntityId
 from main_core.l1_l2_basis.models import MarketBar
 from main_core.l1_l2_basis.ports import DataPlatformPort
 from main_core.l1_l2_basis.readers import read_entity_master, read_market_bars
+from main_core.l3_features.candidate_signals import (
+    CandidateSignalPort,
+    CandidateSignalRecord,
+    merge_candidate_signals,
+    normalize_candidate_signals,
+)
 from main_core.l3_features.errors import L3FeatureError
 from main_core.l3_features.feature_math import (
     apply_feature_weight_multiplier,
@@ -36,6 +42,7 @@ def build_feature_signal_bundle(  # noqa: PLR0913
     graph_engine_port: GraphEnginePort | None = None,
     graph_impact: Mapping[str, Mapping[str, Any]] | None = None,
     candidate_signals: Mapping[str, Mapping[str, Any]] | None = None,
+    candidate_signal_port: CandidateSignalPort | None = None,
 ) -> FeatureSignalBundle:
     """Build the documented single L3 feature signal bundle for a cycle.
 
@@ -51,6 +58,7 @@ def build_feature_signal_bundle(  # noqa: PLR0913
         graph_engine_port=graph_engine_port,
         graph_impact=graph_impact,
         candidate_signals=candidate_signals,
+        candidate_signal_port=candidate_signal_port,
     )
     if len(bundles) == 1:
         return bundles[0]
@@ -70,6 +78,7 @@ def build_feature_signal_bundles(  # noqa: PLR0913
     graph_engine_port: GraphEnginePort | None = None,
     graph_impact: Mapping[str, Mapping[str, Any]] | None = None,
     candidate_signals: Mapping[str, Mapping[str, Any]] | None = None,
+    candidate_signal_port: CandidateSignalPort | None = None,
 ) -> list[FeatureSignalBundle]:
     """Build one feature signal bundle per active entity with market data."""
 
@@ -83,6 +92,10 @@ def build_feature_signal_bundles(  # noqa: PLR0913
     }
     latest_bars = _latest_market_bars_by_entity(market_bars)
     multipliers = get_feature_weight_multiplier(cycle_id, store=multiplier_store)
+    candidate_signal_records = _read_candidate_signal_records(
+        CycleId(str(cycle_id)),
+        candidate_signal_port,
+    )
 
     bundles: list[FeatureSignalBundle] = []
     for entity_id in sorted(active_entity_ids):
@@ -113,6 +126,14 @@ def build_feature_signal_bundles(  # noqa: PLR0913
                 bundle,
                 {**dict(bundle.graph_features), **graph_features},
             )
+        normalized_candidate_signals = normalize_candidate_signals(
+            candidate_signal_records,
+            cycle_id=CycleId(str(cycle_id)),
+            entity_id=EntityId(entity_id),
+            multipliers=multipliers,
+        )
+        if normalized_candidate_signals:
+            bundle = merge_candidate_signals(bundle, normalized_candidate_signals)
         bundles.append(bundle)
 
     return bundles
@@ -155,6 +176,15 @@ def _latest_market_bars_by_entity(market_bars: list[MarketBar]) -> dict[str, Mar
         if previous_bar is None or market_bar.as_of_date > previous_bar.as_of_date:
             latest_bars[entity_id] = market_bar
     return latest_bars
+
+
+def _read_candidate_signal_records(
+    cycle_id: CycleId,
+    candidate_signal_port: CandidateSignalPort | None,
+) -> list[CandidateSignalRecord]:
+    if candidate_signal_port is None:
+        return []
+    return list(candidate_signal_port.read_candidate_signals(cycle_id))
 
 
 __all__ = ["build_feature_signal_bundle", "build_feature_signal_bundles"]

--- a/src/main_core/l3_features/candidate_signals.py
+++ b/src/main_core/l3_features/candidate_signals.py
@@ -1,0 +1,157 @@
+"""Read-only Layer B candidate signal adapter for L3 feature bundles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from math import isfinite
+from typing import Any, Protocol, runtime_checkable
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.types import CycleId, EntityId
+
+
+class CandidateSignalError(MainCoreError):
+    """Raised when Layer B candidate signals cannot be consumed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateSignalRecord:
+    """One read-only Layer B candidate signal row."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    signal_name: str
+    value: Any
+    source: str = "layer_b"
+    confidence: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class CandidateSignalPort(Protocol):
+    """Read-only Layer B candidate signal boundary used by L3."""
+
+    def read_candidate_signals(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[CandidateSignalRecord]:
+        """Return candidate signals for the requested cycle."""
+
+
+def candidate_signal_multiplier(
+    signal_name: str,
+    multipliers: Mapping[str, float],
+) -> float:
+    """Return the multiplier for a candidate signal, falling back to 1.0."""
+
+    scoped_name = f"candidate_signals.{signal_name}"
+    if scoped_name in multipliers:
+        return float(multipliers[scoped_name])
+    if signal_name in multipliers:
+        return float(multipliers[signal_name])
+    return 1.0
+
+
+def normalize_candidate_signals(
+    records: Sequence[CandidateSignalRecord],
+    *,
+    cycle_id: CycleId,
+    entity_id: EntityId,
+    multipliers: Mapping[str, float],
+) -> dict[str, Any]:
+    """Normalize Layer B records for one existing market-backed entity."""
+
+    normalized: dict[str, Any] = {}
+    seen_record_keys: set[tuple[str, str, str]] = set()
+    for record in records:
+        if str(record.cycle_id) != str(cycle_id):
+            raise CandidateSignalError(
+                "candidate signal records must match the requested cycle_id"
+            )
+
+        record_key = (str(record.entity_id), record.source, record.signal_name)
+        if record_key in seen_record_keys:
+            raise CandidateSignalError(
+                "candidate signal records contain duplicate entity/source/signal_name"
+            )
+        seen_record_keys.add(record_key)
+
+        if str(record.entity_id) != str(entity_id):
+            continue
+
+        if record.signal_name in normalized:
+            raise CandidateSignalError(
+                "candidate signal names must be unique per entity"
+            )
+
+        raw_value = record.value
+        adjusted_value = raw_value
+        if _is_number(raw_value):
+            multiplier = candidate_signal_multiplier(record.signal_name, multipliers)
+            adjusted_value = raw_value * multiplier
+            if not isfinite(adjusted_value):
+                raise CandidateSignalError(
+                    "candidate signal adjusted_value must be finite"
+                )
+
+        normalized[record.signal_name] = {
+            "raw_value": raw_value,
+            "adjusted_value": adjusted_value,
+            "source": record.source,
+            "confidence": record.confidence,
+            "metadata": dict(record.metadata),
+        }
+
+    return normalized
+
+
+def merge_candidate_signals(
+    bundle: FeatureSignalBundle,
+    candidate_signals: Mapping[str, Any],
+) -> FeatureSignalBundle:
+    """Return a new feature bundle with candidate signals nested in signal_values."""
+
+    merged_signal_values = dict(bundle.signal_values)
+    if not candidate_signals:
+        return bundle.model_copy(update={"signal_values": merged_signal_values})
+
+    if "candidate_signals" not in merged_signal_values:
+        merged_signal_values["candidate_signals"] = dict(candidate_signals)
+        return bundle.model_copy(update={"signal_values": merged_signal_values})
+
+    existing_candidate_payload = merged_signal_values["candidate_signals"]
+    if not isinstance(existing_candidate_payload, Mapping):
+        raise CandidateSignalError(
+            "signal_values.candidate_signals must be a mapping when present"
+        )
+
+    merged_candidate_payload = dict(existing_candidate_payload)
+    duplicate_signal_names = sorted(
+        str(signal_name)
+        for signal_name in candidate_signals
+        if signal_name in merged_candidate_payload
+    )
+    if duplicate_signal_names:
+        raise CandidateSignalError(
+            "candidate signal merge would overwrite existing candidate payload"
+        )
+
+    merged_candidate_payload.update(candidate_signals)
+    merged_signal_values["candidate_signals"] = merged_candidate_payload
+    return bundle.model_copy(update={"signal_values": merged_signal_values})
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+__all__ = [
+    "CandidateSignalError",
+    "CandidateSignalPort",
+    "CandidateSignalRecord",
+    "candidate_signal_multiplier",
+    "merge_candidate_signals",
+    "normalize_candidate_signals",
+]

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -16,8 +16,13 @@ from main_core.common.schemas import (
     RecommendationSnapshot,
     WorldStateSnapshot,
 )
+from main_core.l7_recommendation import override as override_module
 from main_core.l7_recommendation.constraints import DefaultConstraintProvider
-from main_core.l7_recommendation.override import OverrideStore, apply_override, find_override
+from main_core.l7_recommendation.override import (
+    OverrideStore,
+    apply_override,
+    find_override,
+)
 
 BUY_SCORE_THRESHOLD = 0.65
 REDUCE_SCORE_THRESHOLD = 0.35
@@ -103,9 +108,7 @@ def _latest_overrides_by_cycle_entity(
 
 
 def _default_override_store() -> OverrideStore:
-    from main_core.l7_recommendation.override import _DEFAULT_OVERRIDE_STORE
-
-    return _DEFAULT_OVERRIDE_STORE
+    return override_module._DEFAULT_OVERRIDE_STORE
 
 
 def _validate_inputs(

--- a/tests/integration/test_layer_b_candidate_signals.py
+++ b/tests/integration/test_layer_b_candidate_signals.py
@@ -1,0 +1,211 @@
+"""Integration coverage for Layer B candidate signals in L3."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date
+
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import EntityMasterRow, MarketBar
+from main_core.l3_features import (
+    CandidateSignalRecord,
+    GraphImpactRecord,
+    InMemoryMultiplierStore,
+    apply_weight_multiplier,
+    build_feature_signal_bundles,
+)
+from main_core.l4_world_state import derive_world_state
+from main_core.l5_universe import select_official_alpha_pool
+
+
+@dataclass
+class FakeDataPlatformPort:
+    market_bars: Sequence[object] = field(default_factory=tuple)
+    entity_master: Sequence[object] = field(default_factory=tuple)
+
+    def read_market_bars(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return self.market_bars
+
+    def read_calendar(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return ()
+
+    def read_entity_master(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return self.entity_master
+
+
+@dataclass
+class FakeGraphEnginePort:
+    impact_records: Sequence[GraphImpactRecord] = field(default_factory=tuple)
+    impact_calls: list[CycleId] = field(default_factory=list)
+    regime_calls: list[CycleId] = field(default_factory=list)
+
+    def read_graph_impact_snapshot(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[GraphImpactRecord]:
+        self.impact_calls.append(cycle_id)
+        return self.impact_records
+
+    def read_graph_regime_context(self, cycle_id: CycleId) -> None:
+        self.regime_calls.append(cycle_id)
+
+
+@dataclass
+class FakeCandidateSignalPort:
+    records: Sequence[CandidateSignalRecord] = field(default_factory=tuple)
+    calls: list[CycleId] = field(default_factory=list)
+
+    def read_candidate_signals(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[CandidateSignalRecord]:
+        self.calls.append(cycle_id)
+        return self.records
+
+
+def test_empty_layer_b_port_matches_market_only_fallback() -> None:
+    cycle_id = CycleId("cycle-layer-b-fallback")
+    entity = EntityMasterRow(
+        entity_id=EntityId("ENT_001"),
+        ticker="AAA",
+        name="Alpha A",
+        exchange="NASDAQ",
+    )
+    market_bar = MarketBar(
+        cycle_id=cycle_id,
+        entity_id=entity.entity_id,
+        as_of_date=date(2026, 4, 17),
+        close_price=100.0,
+        volume=1000.0,
+        return_1d=0.01,
+    )
+    empty_candidate_port = FakeCandidateSignalPort()
+
+    market_only = build_feature_signal_bundles(
+        cycle_id,
+        data_port=FakeDataPlatformPort(entity_master=(entity,), market_bars=(market_bar,)),
+    )
+    with_empty_layer_b = build_feature_signal_bundles(
+        cycle_id,
+        data_port=FakeDataPlatformPort(entity_master=(entity,), market_bars=(market_bar,)),
+        candidate_signal_port=empty_candidate_port,
+    )
+
+    assert _stable_bundle_payload(with_empty_layer_b[0]) == _stable_bundle_payload(
+        market_only[0]
+    )
+    assert empty_candidate_port.calls == [cycle_id]
+
+
+def test_graph_and_layer_b_candidate_signals_coexist_and_flow_to_l4_l5() -> None:
+    cycle_id = CycleId("cycle-layer-b-integration")
+    entity = EntityMasterRow(
+        entity_id=EntityId("ENT_001"),
+        ticker="AAA",
+        name="Alpha A",
+        exchange="NASDAQ",
+    )
+    data_port = FakeDataPlatformPort(
+        entity_master=(entity,),
+        market_bars=(
+            MarketBar(
+                cycle_id=cycle_id,
+                entity_id=entity.entity_id,
+                as_of_date=date(2026, 4, 17),
+                close_price=100.0,
+                volume=1000.0,
+                return_1d=0.01,
+            ),
+        ),
+    )
+    graph_port = FakeGraphEnginePort(
+        impact_records=(
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=entity.entity_id,
+                features={"impact_score": 0.81},
+                snapshot_id="graph-impact-001",
+            ),
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_Z"),
+                features={"impact_score": 0.99},
+                snapshot_id="graph-impact-extra",
+            ),
+        )
+    )
+    candidate_port = FakeCandidateSignalPort(
+        records=(
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=entity.entity_id,
+                signal_name="layer_b_score",
+                value=2.0,
+                confidence=0.9,
+                metadata={"source_table": "candidate_facts"},
+            ),
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=entity.entity_id,
+                signal_name="sentiment_label",
+                value="positive",
+            ),
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_Z"),
+                signal_name="layer_b_score",
+                value=99.0,
+            ),
+        )
+    )
+    multiplier_store = InMemoryMultiplierStore()
+    apply_weight_multiplier(
+        cycle_id,
+        {"candidate_signals.layer_b_score": 1.5},
+        store=multiplier_store,
+    )
+
+    bundles = build_feature_signal_bundles(
+        cycle_id,
+        data_port=data_port,
+        multiplier_store=multiplier_store,
+        graph_engine_port=graph_port,
+        candidate_signal_port=candidate_port,
+    )
+
+    assert [bundle.entity_id for bundle in bundles] == ["ENT_001"]
+    assert bundles[0].graph_features == {
+        "snapshot_id": "graph-impact-001",
+        "features": {"impact_score": 0.81},
+    }
+    assert bundles[0].signal_values["candidate_signals"] == {
+        "layer_b_score": {
+            "raw_value": 2.0,
+            "adjusted_value": 3.0,
+            "source": "layer_b",
+            "confidence": 0.9,
+            "metadata": {"source_table": "candidate_facts"},
+        },
+        "sentiment_label": {
+            "raw_value": "positive",
+            "adjusted_value": "positive",
+            "source": "layer_b",
+            "confidence": None,
+            "metadata": {},
+        },
+    }
+
+    world_state = derive_world_state(bundles[0])
+    pool = select_official_alpha_pool(world_state, bundles)
+
+    assert world_state.cycle_id == cycle_id
+    assert list(pool.selected_entities) == ["ENT_001"]
+    assert graph_port.impact_calls == [cycle_id]
+    assert candidate_port.calls == [cycle_id]
+
+
+def _stable_bundle_payload(bundle) -> dict:
+    payload = bundle.model_dump(mode="python")
+    payload.pop("generated_at")
+    return payload

--- a/tests/l3_features/test_candidate_signals.py
+++ b/tests/l3_features/test_candidate_signals.py
@@ -1,0 +1,262 @@
+"""Tests for Layer B candidate signal consumption in L3."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import pytest
+
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.types import CycleId, EntityId
+from main_core.l3_features import (
+    CandidateSignalError,
+    CandidateSignalPort,
+    CandidateSignalRecord,
+    build_feature_signal_bundles,
+    candidate_signal_multiplier,
+    merge_candidate_signals,
+    normalize_candidate_signals,
+)
+
+from .conftest import FakeDataPlatformPort
+
+SCOPED_MULTIPLIER = 1.5
+UNSCOPED_MULTIPLIER = 0.75
+
+
+@dataclass
+class FakeCandidateSignalPort:
+    records: Sequence[CandidateSignalRecord] = field(default_factory=tuple)
+    calls: list[CycleId] = field(default_factory=list)
+
+    def read_candidate_signals(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[CandidateSignalRecord]:
+        self.calls.append(cycle_id)
+        return self.records
+
+
+def test_candidate_signal_port_is_runtime_checkable_and_read_only() -> None:
+    port = FakeCandidateSignalPort()
+
+    protocol_methods = {
+        name
+        for name, value in CandidateSignalPort.__dict__.items()
+        if callable(value) and not name.startswith("_")
+    }
+
+    assert isinstance(port, CandidateSignalPort)
+    assert protocol_methods == {"read_candidate_signals"}
+    assert not {
+        name
+        for name in dir(CandidateSignalPort)
+        if name.startswith(("write_", "ack_", "commit_", "mutate_"))
+    }
+    assert not {
+        name
+        for name in dir(port)
+        if name.startswith(("write_", "ack_", "commit_", "mutate_"))
+    }
+
+
+def test_empty_candidate_signal_port_preserves_market_only_bundle(
+    cycle_id: CycleId,
+    active_entity,
+    market_bar,
+) -> None:
+    data_port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(active_entity,),
+    )
+    empty_candidate_port = FakeCandidateSignalPort()
+
+    market_only = build_feature_signal_bundles(cycle_id, data_port=data_port)
+    with_empty_layer_b = build_feature_signal_bundles(
+        cycle_id,
+        data_port=data_port,
+        candidate_signal_port=empty_candidate_port,
+    )
+
+    assert _stable_bundle_payload(with_empty_layer_b[0]) == _stable_bundle_payload(
+        market_only[0]
+    )
+    assert empty_candidate_port.calls == [cycle_id]
+
+
+def test_normalize_candidate_signals_filters_entity_and_applies_multipliers() -> None:
+    cycle_id = CycleId("cycle-layer-b")
+    records = (
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_A"),
+            signal_name="layer_b_score",
+            value=2.0,
+            confidence=0.8,
+            metadata={"window": "5d"},
+        ),
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_A"),
+            signal_name="regime_hint",
+            value="risk_on",
+            metadata={"reason": "news"},
+        ),
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_B"),
+            signal_name="layer_b_score",
+            value=99.0,
+        ),
+    )
+
+    normalized = normalize_candidate_signals(
+        records,
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_A"),
+        multipliers={"candidate_signals.layer_b_score": 1.5},
+    )
+
+    assert normalized == {
+        "layer_b_score": {
+            "raw_value": 2.0,
+            "adjusted_value": 3.0,
+            "source": "layer_b",
+            "confidence": 0.8,
+            "metadata": {"window": "5d"},
+        },
+        "regime_hint": {
+            "raw_value": "risk_on",
+            "adjusted_value": "risk_on",
+            "source": "layer_b",
+            "confidence": None,
+            "metadata": {"reason": "news"},
+        },
+    }
+
+
+def test_candidate_signal_multiplier_prefers_scoped_name() -> None:
+    multipliers = {
+        "layer_b_score": 2.0,
+        "candidate_signals.layer_b_score": SCOPED_MULTIPLIER,
+    }
+
+    assert candidate_signal_multiplier("layer_b_score", multipliers) == SCOPED_MULTIPLIER
+    assert (
+        candidate_signal_multiplier(
+            "other_signal",
+            {"other_signal": UNSCOPED_MULTIPLIER},
+        )
+        == UNSCOPED_MULTIPLIER
+    )
+    assert candidate_signal_multiplier("missing_signal", {}) == 1.0
+
+
+def test_normalize_candidate_signals_rejects_duplicate_signal_records() -> None:
+    cycle_id = CycleId("cycle-layer-b")
+    records = (
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_A"),
+            signal_name="layer_b_score",
+            value=1.0,
+        ),
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_A"),
+            signal_name="layer_b_score",
+            value=2.0,
+        ),
+    )
+
+    with pytest.raises(CandidateSignalError, match="duplicate"):
+        normalize_candidate_signals(
+            records,
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_A"),
+            multipliers={},
+        )
+
+
+def test_normalize_candidate_signals_rejects_cycle_mismatch() -> None:
+    with pytest.raises(CandidateSignalError, match="cycle_id"):
+        normalize_candidate_signals(
+            (
+                CandidateSignalRecord(
+                    cycle_id=CycleId("cycle-other"),
+                    entity_id=EntityId("ENT_A"),
+                    signal_name="layer_b_score",
+                    value=1.0,
+                ),
+            ),
+            cycle_id=CycleId("cycle-current"),
+            entity_id=EntityId("ENT_A"),
+            multipliers={},
+        )
+
+
+def test_normalize_candidate_signals_omits_other_entities() -> None:
+    cycle_id = CycleId("cycle-layer-b")
+
+    assert normalize_candidate_signals(
+        (
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_B"),
+                signal_name="layer_b_score",
+                value=1.0,
+            ),
+        ),
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_A"),
+        multipliers={},
+    ) == {}
+
+
+def test_merge_candidate_signals_preserves_bundle_payload_without_mutating() -> None:
+    bundle = FeatureSignalBundle(
+        cycle_id="cycle-layer-b",
+        entity_id="ENT_A",
+        feature_values={"close_price": 100.0},
+        signal_values={"direction": "positive"},
+        graph_features={"snapshot_id": "graph-001", "features": {"centrality": 0.7}},
+        feature_weight_multiplier={"close_price": 1.0},
+    )
+    before_json = bundle.to_json()
+
+    merged = merge_candidate_signals(
+        bundle,
+        {
+            "layer_b_score": {
+                "raw_value": 2.0,
+                "adjusted_value": 3.0,
+                "source": "layer_b",
+                "confidence": 0.8,
+                "metadata": {},
+            },
+        },
+    )
+
+    assert bundle.to_json() == before_json
+    assert merged is not bundle
+    assert merged.generated_at == bundle.generated_at
+    assert merged.signal_values == {
+        "direction": "positive",
+        "candidate_signals": {
+            "layer_b_score": {
+                "raw_value": 2.0,
+                "adjusted_value": 3.0,
+                "source": "layer_b",
+                "confidence": 0.8,
+                "metadata": {},
+            },
+        },
+    }
+    assert merged.graph_features == bundle.graph_features
+
+
+def _stable_bundle_payload(bundle: FeatureSignalBundle) -> dict:
+    payload = bundle.model_dump(mode="python")
+    payload.pop("generated_at")
+    return payload


### PR DESCRIPTION
Closes #14

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l3_features/graph_adapter.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
### 1. 背景与目标
项目文档 §5.2、§11.1、§21 阶段 3 要求 `main-core` 读取 `data-platform` 承载的 Layer B candidate facts/signals，并在 L3 合并到 `FeatureSignalBundle.signal_values`。当前代码已经有 `src/main_core/common/schemas/feature_bundle.py` 的 `signal_values: dict[str, Any]` 与 `feature_weight_multiplier: dict[str, float]`，但 `src/main_core/l3_features/` 还没有 candidate signal port、规范化模型或和 bundle builder 的接线。本 issue 的目标是在 #13 的 graph 接入之后，为 L3 增加只读 Layer B candidate signal 输入，保证无 Layer B 时纯市场数据 fallback 不变，且 candidate signal 与既有 multiplier 规则同轮生效。

### 2. 所属模块
Primary writable paths:
- `src/main_core/l3_features/candidate_signals.py`（新增）
- `src/main_core/l3_features/__init__.py`（导出 candidate signal 公共符号）
- #6 / #13 已交付的 `src/main_core/l3_features` builder / feature math 接线文件（只在 L3 内部改，不跨层）
- `tests/l3_features/test_candidate_signals.py`（新增）
- `tests/integration/test_layer_b_candidate_signals.py`（新增）

Adjacent read-only / integration paths:
- `src/main_core/common/schemas/feature_bundle.py`（已有 `FeatureSignalBundle.signal_values` / `feature_weight_multiplier`）
- `src/main_core/common/types.py`、`src/main_core/common/errors.py`
- `src/main_core/l1_l2_basis/*`（只消费 #5 的 basis 输出，不把 Layer B 读取塞进 L1）
- `src/main_core/l3_features/graph_adapter.py`（#13 已交付，candidate signals 与 `graph_features` 并行合并）
- `src/main_core/l4_world_state/*`、`src/main_core/l5_universe/*`、`src/main_core/l8_publish/*`（只跑回归，不改业务逻辑）

Off-limits paths:
- `data-platform` / Layer B 外部仓库内部实现
- `src/main_core/common/schemas/*` 字段结构调整
- `src/main_core/l1_l2_basis/*` 的 Layer B 专属读取实现

### 3. 实现范围
- 新增 `src/main_core/l3_features/candidate_signals.py`，定义 `@dataclass(frozen=True, slots=True) class CandidateSignalRecord`，字段为 `cycle_id: CycleId`、`entity_id: EntityId`、`signal_name: str`、`value: Any`、`source: str = "layer_b"`、`confidence: float | None = None`、`metadata: Mapping[str, Any] = field(default_factory=dict)`。
- 在同一文件定义 `@runtime_checkable class CandidateSignalPort(Protocol)`，只暴露 `read_candidate_signals(cycle_id: CycleId) -> Sequence[CandidateS