### PR TITLE
feat(#47): [milestone-4 review] P0: Shared graph-engine boundary is owned by L3

### DIFF
--- a/src/main_core/common/protocols/__init__.py
+++ b/src/main_core/common/protocols/__init__.py
@@ -5,6 +5,12 @@ from main_core.common.protocols.constraint_provider import (
     RecommendationConstraintProvider,
     RecommendationConstraintProviderBase,
 )
+from main_core.common.protocols.graph import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+)
 from main_core.common.protocols.world_state_policy import (
     BoundedLlmDelta,
     WorldStatePolicy,
@@ -15,6 +21,10 @@ __all__ = [
     "AnalyzerBase",
     "AnalyzerInterface",
     "BoundedLlmDelta",
+    "GraphEnginePort",
+    "GraphImpactRecord",
+    "GraphRegimeContext",
+    "GraphSnapshotError",
     "RecommendationConstraintProvider",
     "RecommendationConstraintProviderBase",
     "WorldStatePolicy",

--- a/src/main_core/common/protocols/graph.py
+++ b/src/main_core/common/protocols/graph.py
@@ -1,0 +1,58 @@
+"""Graph-engine protocol contracts shared by main-core layers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from main_core.common.errors import MainCoreError
+from main_core.common.types import CycleId, EntityId
+
+
+class GraphSnapshotError(MainCoreError):
+    """Raised when a graph snapshot cannot be consumed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class GraphImpactRecord:
+    """One graph impact row from the read-only graph snapshot surface."""
+
+    cycle_id: CycleId
+    entity_id: EntityId
+    features: Mapping[str, Any]
+    snapshot_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class GraphRegimeContext:
+    """Graph regime context read from the graph snapshot surface."""
+
+    cycle_id: CycleId
+    snapshot_id: str
+    regime_context: Mapping[str, Any]
+
+
+@runtime_checkable
+class GraphEnginePort(Protocol):
+    """Read-only graph-engine boundary used by main-core."""
+
+    def read_graph_impact_snapshot(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[GraphImpactRecord]:
+        """Return per-entity graph impact rows for the requested cycle."""
+
+    def read_graph_regime_context(
+        self,
+        cycle_id: CycleId,
+    ) -> GraphRegimeContext | None:
+        """Return graph regime context for the requested cycle, when available."""
+
+
+__all__ = [
+    "GraphEnginePort",
+    "GraphImpactRecord",
+    "GraphRegimeContext",
+    "GraphSnapshotError",
+]

--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -1,5 +1,11 @@
 """L3 package: feature and signal bundle assembly."""
 
+from main_core.common.protocols import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+)
 from main_core.l3_features.builder import build_feature_signal_bundle, build_feature_signal_bundles
 from main_core.l3_features.candidate_signals import (
     CandidateSignalError,
@@ -10,14 +16,7 @@ from main_core.l3_features.candidate_signals import (
     normalize_candidate_signals,
 )
 from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
-from main_core.l3_features.graph_adapter import (
-    GraphEnginePort,
-    GraphImpactRecord,
-    GraphRegimeContext,
-    GraphSnapshotError,
-    load_graph_features,
-    merge_graph_features,
-)
+from main_core.l3_features.graph_adapter import load_graph_features, merge_graph_features
 from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
 from main_core.l3_features.weight_api import (
     apply_weight_multiplier,

--- a/src/main_core/l3_features/builder.py
+++ b/src/main_core/l3_features/builder.py
@@ -7,6 +7,7 @@ from importlib import import_module
 from os import environ
 from typing import Any
 
+from main_core.common.protocols import GraphEnginePort
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.types import CycleId, EntityId
 from main_core.l1_l2_basis.models import MarketBar
@@ -23,11 +24,7 @@ from main_core.l3_features.feature_math import (
     apply_feature_weight_multiplier,
     market_bar_feature_values,
 )
-from main_core.l3_features.graph_adapter import (
-    GraphEnginePort,
-    load_graph_features,
-    merge_graph_features,
-)
+from main_core.l3_features.graph_adapter import load_graph_features, merge_graph_features
 from main_core.l3_features.multiplier_store import MultiplierStore
 from main_core.l3_features.weight_api import get_feature_weight_multiplier
 

--- a/src/main_core/l3_features/graph_adapter.py
+++ b/src/main_core/l3_features/graph_adapter.py
@@ -2,53 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
-from main_core.common.errors import MainCoreError
+from main_core.common.protocols import GraphSnapshotError as _GraphSnapshotError
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.types import CycleId, EntityId
 
-
-class GraphSnapshotError(MainCoreError):
-    """Raised when a graph snapshot cannot be consumed safely."""
-
-
-@dataclass(frozen=True, slots=True)
-class GraphImpactRecord:
-    """One graph impact row from the read-only graph snapshot surface."""
-
-    cycle_id: CycleId
-    entity_id: EntityId
-    features: Mapping[str, Any]
-    snapshot_id: str
-
-
-@dataclass(frozen=True, slots=True)
-class GraphRegimeContext:
-    """Graph regime context read from the graph snapshot surface."""
-
-    cycle_id: CycleId
-    snapshot_id: str
-    regime_context: Mapping[str, Any]
-
-
-@runtime_checkable
-class GraphEnginePort(Protocol):
-    """Read-only graph-engine boundary used by main-core."""
-
-    def read_graph_impact_snapshot(
-        self,
-        cycle_id: CycleId,
-    ) -> Sequence[GraphImpactRecord]:
-        """Return per-entity graph impact rows for the requested cycle."""
-
-    def read_graph_regime_context(
-        self,
-        cycle_id: CycleId,
-    ) -> GraphRegimeContext | None:
-        """Return graph regime context for the requested cycle, when available."""
+if TYPE_CHECKING:
+    from main_core.common.protocols import GraphEnginePort, GraphImpactRecord
 
 
 def load_graph_features(
@@ -65,7 +27,7 @@ def load_graph_features(
     matching_records: list[GraphImpactRecord] = []
     for record in records:
         if str(record.cycle_id) != str(cycle_id):
-            raise GraphSnapshotError(
+            raise _GraphSnapshotError(
                 "graph impact snapshot contains records from a different cycle"
             )
         if str(record.entity_id) == str(entity_id):
@@ -74,7 +36,7 @@ def load_graph_features(
     if not matching_records:
         return {}
     if len(matching_records) > 1:
-        raise GraphSnapshotError(
+        raise _GraphSnapshotError(
             "graph impact snapshot contains duplicate records for entity"
         )
 
@@ -105,10 +67,6 @@ def _to_plain_json_like(value: Any) -> Any:
 
 
 __all__ = [
-    "GraphEnginePort",
-    "GraphImpactRecord",
-    "GraphRegimeContext",
-    "GraphSnapshotError",
     "load_graph_features",
     "merge_graph_features",
 ]

--- a/src/main_core/l4_world_state/graph_adapter.py
+++ b/src/main_core/l4_world_state/graph_adapter.py
@@ -6,8 +6,8 @@ from collections.abc import Mapping
 from typing import Any
 
 from main_core.common.contexts import WorldStateInputs
+from main_core.common.protocols import GraphEnginePort, GraphSnapshotError
 from main_core.common.types import CycleId
-from main_core.l3_features.graph_adapter import GraphEnginePort, GraphSnapshotError
 
 
 def load_graph_regime_context(

--- a/src/main_core/l4_world_state/service.py
+++ b/src/main_core/l4_world_state/service.py
@@ -7,9 +7,8 @@ from typing import Any
 
 from main_core.common.contexts import WorldStateInputs
 from main_core.common.errors import MainCoreError
-from main_core.common.protocols import WorldStatePolicy
+from main_core.common.protocols import GraphEnginePort, WorldStatePolicy
 from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
-from main_core.l3_features.graph_adapter import GraphEnginePort
 from main_core.l4_world_state.graph_adapter import load_graph_regime_context, with_graph_impact
 from main_core.l4_world_state.reasoner_port import (
     StaticWorldStateReasonerPort,

--- a/tests/integration/test_graph_readonly_consumption.py
+++ b/tests/integration/test_graph_readonly_consumption.py
@@ -7,14 +7,11 @@ from dataclasses import dataclass, field
 from datetime import date
 
 from main_core.common.contexts import WorldStateInputs
+from main_core.common.protocols import GraphImpactRecord, GraphRegimeContext
 from main_core.common.schemas import WorldStateSnapshot
 from main_core.common.types import CycleId, EntityId, Regime
 from main_core.l1_l2_basis import EntityMasterRow, MarketBar
-from main_core.l3_features import (
-    GraphImpactRecord,
-    GraphRegimeContext,
-    build_feature_signal_bundles,
-)
+from main_core.l3_features import build_feature_signal_bundles
 from main_core.l4_world_state import StaticWorldStateReasonerPort, derive_world_state
 from main_core.l4_world_state.reasoner_port import WorldStateDeltaDecision
 
@@ -179,4 +176,3 @@ def test_previous_world_state_feeds_readonly_graph_context_into_l3_and_l4() -> N
     }
     assert graph_port.impact_calls == [current_cycle_id]
     assert graph_port.regime_calls == [current_cycle_id]
-

--- a/tests/integration/test_layer_b_candidate_signals.py
+++ b/tests/integration/test_layer_b_candidate_signals.py
@@ -6,11 +6,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date
 
+from main_core.common.protocols import GraphImpactRecord
 from main_core.common.types import CycleId, EntityId
 from main_core.l1_l2_basis import EntityMasterRow, MarketBar
 from main_core.l3_features import (
     CandidateSignalRecord,
-    GraphImpactRecord,
     InMemoryMultiplierStore,
     apply_weight_multiplier,
     build_feature_signal_bundles,

--- a/tests/l4_world_state/test_boundaries.py
+++ b/tests/l4_world_state/test_boundaries.py
@@ -8,6 +8,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 L4_ROOT = PROJECT_ROOT / "src" / "main_core" / "l4_world_state"
 FORBIDDEN_IMPORT_PREFIXES = (
+    "main_core.l3_features",
     "main_core.l5_universe",
     "main_core.l6_alpha",
     "main_core.l7_recommendation",

--- a/tests/l4_world_state/test_graph_adapter.py
+++ b/tests/l4_world_state/test_graph_adapter.py
@@ -8,14 +8,14 @@ from dataclasses import dataclass, field
 import pytest
 
 from main_core.common.contexts import WorldStateInputs
-from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
-from main_core.common.types import CycleId, Regime
-from main_core.l3_features import (
+from main_core.common.protocols import (
     GraphEnginePort,
     GraphImpactRecord,
     GraphRegimeContext,
     GraphSnapshotError,
 )
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.common.types import CycleId, Regime
 from main_core.l4_world_state import (
     StaticWorldStateReasonerPort,
     derive_world_state,
@@ -202,4 +202,3 @@ def test_fake_graph_port_only_exposes_read_methods() -> None:
         for name in dir(port)
         if name.startswith(("write_", "commit_", "mutate_"))
     }
-

--- a/tests/protocols/test_graph_engine_contract.py
+++ b/tests/protocols/test_graph_engine_contract.py
@@ -1,0 +1,87 @@
+"""Tests for the shared graph-engine protocol contract."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from main_core import l3_features
+from main_core.common.protocols import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+)
+from main_core.common.types import CycleId, EntityId
+from main_core.l3_features import graph_adapter as l3_graph_adapter
+
+
+@dataclass
+class FakeGraphEnginePort:
+    impact_records: Sequence[GraphImpactRecord] = field(default_factory=tuple)
+    regime_context: GraphRegimeContext | None = None
+    impact_calls: list[CycleId] = field(default_factory=list)
+    regime_calls: list[CycleId] = field(default_factory=list)
+
+    def read_graph_impact_snapshot(
+        self,
+        cycle_id: CycleId,
+    ) -> Sequence[GraphImpactRecord]:
+        self.impact_calls.append(cycle_id)
+        return self.impact_records
+
+    def read_graph_regime_context(
+        self,
+        cycle_id: CycleId,
+    ) -> GraphRegimeContext | None:
+        self.regime_calls.append(cycle_id)
+        return self.regime_context
+
+
+def test_graph_contract_is_owned_by_common_protocols() -> None:
+    assert GraphEnginePort.__module__ == "main_core.common.protocols.graph"
+    assert GraphImpactRecord.__module__ == "main_core.common.protocols.graph"
+    assert GraphRegimeContext.__module__ == "main_core.common.protocols.graph"
+    assert GraphSnapshotError.__module__ == "main_core.common.protocols.graph"
+
+
+def test_l3_graph_exports_are_compatibility_aliases() -> None:
+    assert l3_features.GraphEnginePort is GraphEnginePort
+    assert l3_features.GraphImpactRecord is GraphImpactRecord
+    assert l3_features.GraphRegimeContext is GraphRegimeContext
+    assert l3_features.GraphSnapshotError is GraphSnapshotError
+
+
+def test_l3_adapter_only_exports_adapter_helpers() -> None:
+    assert set(l3_graph_adapter.__all__) == {
+        "load_graph_features",
+        "merge_graph_features",
+    }
+
+
+def test_graph_engine_port_is_runtime_checkable_and_read_only() -> None:
+    cycle_id = CycleId("cycle-graph-contract")
+    port = FakeGraphEnginePort(
+        impact_records=(
+            GraphImpactRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_001"),
+                features={"centrality": 0.72},
+                snapshot_id="graph-impact-001",
+            ),
+        ),
+        regime_context=GraphRegimeContext(
+            cycle_id=cycle_id,
+            snapshot_id="graph-regime-001",
+            regime_context={"previous_final_regime": "neutral"},
+        ),
+    )
+
+    assert isinstance(port, GraphEnginePort)
+    assert port.read_graph_impact_snapshot(cycle_id)[0].entity_id == "ENT_001"
+    assert port.read_graph_regime_context(cycle_id) == port.regime_context
+    assert not {
+        name
+        for name in dir(GraphEnginePort)
+        if name.startswith(("write_", "commit_", "mutate_"))
+    }


### PR DESCRIPTION
Closes #47

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/builder.py`, `src/main_core/l3_features/candidate_signals.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l3_features/graph_adapter.py`, `src/main_core/l6_alpha/fallback.py`


---
## 背景与目标
Milestone review for milestone-4 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
GraphEnginePort, GraphImpactRecord, GraphRegimeContext, and GraphSnapshotError live in l3_features.graph_adapter, but L4 imports and uses the same port for world-state regime context. This makes the L4 graph integration depend on an L3 implementation module instead of a shared boundary contract. The project already has common protocol/schema areas; leaving the graph boundary in L3 will make future L5/L6/L8 graph consumers depend on the feature layer or duplicate the contract.

## 实现范围
- 修改文件: `cross-cutting`
- Move the graph-engine protocol and shared record/error types into common.protocols or a common graph contract module. Keep L3 and L4 adapters as layer-specific consumers of that shared contract.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
