### PR TITLE
feat(#46): [milestone-4 review] P0: Layer B signal payload has two incompatible shapes

### DIFF
--- a/src/main_core/l3_features/builder.py
+++ b/src/main_core/l3_features/builder.py
@@ -92,10 +92,11 @@ def build_feature_signal_bundles(  # noqa: PLR0913
     }
     latest_bars = _latest_market_bars_by_entity(market_bars)
     multipliers = get_feature_weight_multiplier(cycle_id, store=multiplier_store)
-    candidate_signal_records = _read_candidate_signal_records(
-        CycleId(str(cycle_id)),
-        candidate_signal_port,
-    )
+    normalized_cycle_id = CycleId(str(cycle_id))
+    candidate_signal_records = [
+        *_candidate_signal_records_from_mapping(normalized_cycle_id, candidate_signals),
+        *_read_candidate_signal_records(normalized_cycle_id, candidate_signal_port),
+    ]
 
     bundles: list[FeatureSignalBundle] = []
     for entity_id in sorted(active_entity_ids):
@@ -112,7 +113,7 @@ def build_feature_signal_bundles(  # noqa: PLR0913
             cycle_id=cycle_id,
             entity_id=EntityId(entity_id),
             feature_values=feature_values,
-            signal_values=dict((candidate_signals or {}).get(entity_id, {})),
+            signal_values={},
             graph_features=dict((graph_impact or {}).get(entity_id, {})),
             feature_weight_multiplier=effective_multipliers,
         )
@@ -128,7 +129,7 @@ def build_feature_signal_bundles(  # noqa: PLR0913
             )
         normalized_candidate_signals = normalize_candidate_signals(
             candidate_signal_records,
-            cycle_id=CycleId(str(cycle_id)),
+            cycle_id=normalized_cycle_id,
             entity_id=EntityId(entity_id),
             multipliers=multipliers,
         )
@@ -176,6 +177,27 @@ def _latest_market_bars_by_entity(market_bars: list[MarketBar]) -> dict[str, Mar
         if previous_bar is None or market_bar.as_of_date > previous_bar.as_of_date:
             latest_bars[entity_id] = market_bar
     return latest_bars
+
+
+def _candidate_signal_records_from_mapping(
+    cycle_id: CycleId,
+    candidate_signals: Mapping[str, Mapping[str, Any]] | None,
+) -> list[CandidateSignalRecord]:
+    if not candidate_signals:
+        return []
+
+    records: list[CandidateSignalRecord] = []
+    for entity_id, entity_signals in candidate_signals.items():
+        for signal_name, value in entity_signals.items():
+            records.append(
+                CandidateSignalRecord(
+                    cycle_id=cycle_id,
+                    entity_id=EntityId(str(entity_id)),
+                    signal_name=str(signal_name),
+                    value=value,
+                )
+            )
+    return records
 
 
 def _read_candidate_signal_records(

--- a/tests/l3_features/test_builder.py
+++ b/tests/l3_features/test_builder.py
@@ -13,6 +13,7 @@ from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.types import CycleId, EntityId
 from main_core.l1_l2_basis import EntityMasterRow, MarketBar
 from main_core.l3_features import (
+    CandidateSignalRecord,
     InMemoryMultiplierStore,
     InvalidMultiplierError,
     L3FeatureError,
@@ -29,6 +30,19 @@ from .conftest import FakeDataPlatformPort
 
 UPDATED_CLOSE_PRICE = 120.0
 UPDATED_CLOSE_MULTIPLIER = 1.2
+
+
+class FakeCandidateSignalPort:
+    def __init__(self, records: tuple[CandidateSignalRecord, ...]) -> None:
+        self.records = records
+        self.calls: list[CycleId] = []
+
+    def read_candidate_signals(
+        self,
+        cycle_id: CycleId,
+    ) -> tuple[CandidateSignalRecord, ...]:
+        self.calls.append(cycle_id)
+        return self.records
 
 
 def test_feature_math_derives_market_features_and_applies_known_multipliers(
@@ -167,7 +181,17 @@ def test_build_feature_signal_bundle_uses_latest_market_bar_and_sorts_by_entity(
         "volume": 0.5,
         "return_1d": 1.0,
     }
-    assert bundles[0].signal_values == {"direction": "positive"}
+    assert bundles[0].signal_values == {
+        "candidate_signals": {
+            "direction": {
+                "raw_value": "positive",
+                "adjusted_value": "positive",
+                "source": "layer_b",
+                "confidence": None,
+                "metadata": {},
+            },
+        },
+    }
     assert bundles[0].graph_features == {"centrality": 0.7}
     assert bundles[1].feature_values == {
         "close_price": 240.0,
@@ -201,6 +225,60 @@ def test_build_feature_signal_bundle_defaults_optional_inputs_to_empty_dicts(
         "volume": 1.0,
         "return_1d": 1.0,
     }
+
+
+def test_build_feature_signal_bundle_normalizes_all_candidate_signal_inputs(
+    cycle_id: CycleId,
+    active_entity: EntityMasterRow,
+    market_bar: MarketBar,
+) -> None:
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(active_entity,),
+    )
+    candidate_port = FakeCandidateSignalPort(
+        (
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=active_entity.entity_id,
+                signal_name="port_score",
+                value=2.0,
+                confidence=0.7,
+                metadata={"source_table": "candidate_signal_port"},
+            ),
+        )
+    )
+
+    bundle = build_feature_signal_bundle(
+        cycle_id,
+        data_port=port,
+        candidate_signals={
+            str(active_entity.entity_id): {
+                "legacy_direction": "positive",
+            },
+        },
+        candidate_signal_port=candidate_port,
+    )
+
+    assert bundle.signal_values == {
+        "candidate_signals": {
+            "legacy_direction": {
+                "raw_value": "positive",
+                "adjusted_value": "positive",
+                "source": "layer_b",
+                "confidence": None,
+                "metadata": {},
+            },
+            "port_score": {
+                "raw_value": 2.0,
+                "adjusted_value": 2.0,
+                "source": "layer_b",
+                "confidence": 0.7,
+                "metadata": {"source_table": "candidate_signal_port"},
+            },
+        },
+    }
+    assert candidate_port.calls == [cycle_id]
 
 
 def test_default_multiplier_store_update_is_visible_to_same_cycle_build() -> None:


### PR DESCRIPTION
Closes #46

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/candidate_signals.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `src/main_core/l7_recommendation/override.py`


---
## 背景与目标
Milestone review for milestone-4 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The builder still copies the explicit candidate_signals argument directly into signal_values as a flat entity payload, while CandidateSignalPort records are normalized under signal_values.candidate_signals with raw_value, adjusted_value, source, confidence, and metadata. That means the same semantic Layer B signal lands in different contracts depending on whether it came from the legacy mapping or the new port. Downstream analyzers and recommendation logic will not have one reliable shape to consume.

## 实现范围
- 修改文件: `src/main_core/l3_features/builder.py`
- Define one canonical signal_values schema for Layer B signals, then route both candidate_signals and CandidateSignalPort input through the same normalizer and merge path. Add contract tests that assert the public build_feature_signal_bundle path always emits that shape.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
