### PR TITLE
feat(#15): 实现 MultiAgentAnalyzer 与 A/B 评估脚本

### DIFF
--- a/src/main_core/l6_alpha/__init__.py
+++ b/src/main_core/l6_alpha/__init__.py
@@ -1,6 +1,14 @@
 """L6 package: single-stock alpha analysis."""
 
+from main_core.l6_alpha.ab_runner import run_ab_evaluation, write_ab_report
 from main_core.l6_alpha.fallback import build_inconclusive_result
+from main_core.l6_alpha.multi_agent_analyzer import (
+    AgentRoleConfig,
+    MultiAgentAnalyzer,
+    MultiAgentReasonerPort,
+    MultiAgentRoleResult,
+    StaticMultiAgentReasonerPort,
+)
 from main_core.l6_alpha.reasoner_port import (
     AlphaReasonerPort,
     AlphaReasonerResponse,
@@ -10,10 +18,17 @@ from main_core.l6_alpha.service import analyze_stock
 from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
 
 __all__ = [
+    "AgentRoleConfig",
     "AlphaReasonerPort",
     "AlphaReasonerResponse",
+    "MultiAgentAnalyzer",
+    "MultiAgentReasonerPort",
+    "MultiAgentRoleResult",
     "SinglePromptAnalyzer",
     "StaticAlphaReasonerPort",
+    "StaticMultiAgentReasonerPort",
     "analyze_stock",
     "build_inconclusive_result",
+    "run_ab_evaluation",
+    "write_ab_report",
 ]

--- a/src/main_core/l6_alpha/ab_runner.py
+++ b/src/main_core/l6_alpha/ab_runner.py
@@ -1,0 +1,272 @@
+"""A/B evaluation utilities for L6 analyzer parity checks."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.protocols import AnalyzerInterface
+from main_core.common.types import EntityId
+
+
+@dataclass(frozen=True)
+class AbEvaluationCase:
+    """One L6 A/B input case with a prebuilt analyzer context."""
+
+    case_id: str
+    entity_id: EntityId
+    context: AlphaAnalysisContext
+
+    def __post_init__(self) -> None:
+        if not self.case_id.strip():
+            raise ValueError("case_id must be non-empty")
+
+
+@dataclass(frozen=True)
+class AbCaseResult:
+    """Per-case L6 A/B comparison result."""
+
+    case_id: str
+    entity_id: EntityId
+    baseline_analyzer_type: str
+    challenger_analyzer_type: str
+    baseline_status: str
+    challenger_status: str
+    baseline_score: float | None
+    challenger_score: float | None
+    baseline_confidence: float
+    challenger_confidence: float
+    score_delta: float | None
+    confidence_delta: float
+    status_matches: bool
+
+
+@dataclass(frozen=True)
+class AbEvaluationReport:
+    """Aggregate L6 A/B report with JSON-compatible fields."""
+
+    baseline_analyzer_type: str
+    challenger_analyzer_type: str
+    total_cases: int
+    status_match_rate: float
+    ok_pair_score_mae: float | None
+    confidence_mae: float | None
+    baseline_inconclusive_count: int
+    challenger_inconclusive_count: int
+    inconclusive_count_delta: int
+    cases: tuple[AbCaseResult, ...]
+
+
+def run_ab_evaluation(
+    cases: Sequence[AbEvaluationCase],
+    *,
+    baseline: AnalyzerInterface,
+    challenger: AnalyzerInterface,
+) -> AbEvaluationReport:
+    """Run baseline and challenger analyzers on the same supplied contexts."""
+
+    case_results: list[AbCaseResult] = []
+    score_abs_deltas: list[float] = []
+    confidence_abs_deltas: list[float] = []
+    status_match_count = 0
+    baseline_inconclusive_count = 0
+    challenger_inconclusive_count = 0
+
+    for case in cases:
+        baseline_result = baseline.analyze(case.entity_id, case.context)
+        challenger_result = challenger.analyze(case.entity_id, case.context)
+
+        status_matches = baseline_result.status == challenger_result.status
+        if status_matches:
+            status_match_count += 1
+        if baseline_result.status == "inconclusive":
+            baseline_inconclusive_count += 1
+        if challenger_result.status == "inconclusive":
+            challenger_inconclusive_count += 1
+
+        score_delta: float | None = None
+        if baseline_result.score is not None and challenger_result.score is not None:
+            score_delta = challenger_result.score - baseline_result.score
+            if baseline_result.status == "ok" and challenger_result.status == "ok":
+                score_abs_deltas.append(abs(score_delta))
+
+        confidence_delta = challenger_result.confidence - baseline_result.confidence
+        confidence_abs_deltas.append(abs(confidence_delta))
+
+        case_results.append(
+            AbCaseResult(
+                case_id=case.case_id,
+                entity_id=case.entity_id,
+                baseline_analyzer_type=baseline_result.analyzer_type,
+                challenger_analyzer_type=challenger_result.analyzer_type,
+                baseline_status=baseline_result.status,
+                challenger_status=challenger_result.status,
+                baseline_score=baseline_result.score,
+                challenger_score=challenger_result.score,
+                baseline_confidence=baseline_result.confidence,
+                challenger_confidence=challenger_result.confidence,
+                score_delta=score_delta,
+                confidence_delta=confidence_delta,
+                status_matches=status_matches,
+            )
+        )
+
+    total_cases = len(cases)
+    return AbEvaluationReport(
+        baseline_analyzer_type=baseline.analyzer_type,
+        challenger_analyzer_type=challenger.analyzer_type,
+        total_cases=total_cases,
+        status_match_rate=(
+            status_match_count / total_cases if total_cases > 0 else 0.0
+        ),
+        ok_pair_score_mae=_mean(score_abs_deltas),
+        confidence_mae=_mean(confidence_abs_deltas),
+        baseline_inconclusive_count=baseline_inconclusive_count,
+        challenger_inconclusive_count=challenger_inconclusive_count,
+        inconclusive_count_delta=(
+            challenger_inconclusive_count - baseline_inconclusive_count
+        ),
+        cases=tuple(case_results),
+    )
+
+
+def format_ab_report_json(report: AbEvaluationReport) -> str:
+    """Format an A/B report as stable, parseable JSON."""
+
+    return json.dumps(_report_payload(report), allow_nan=False, indent=2, sort_keys=True)
+
+
+def format_ab_report_markdown(report: AbEvaluationReport) -> str:
+    """Format an A/B report as stable Markdown tables."""
+
+    summary_rows = [
+        ("baseline_analyzer_type", report.baseline_analyzer_type),
+        ("challenger_analyzer_type", report.challenger_analyzer_type),
+        ("total_cases", report.total_cases),
+        ("status_match_rate", _format_value(report.status_match_rate)),
+        ("ok_pair_score_mae", _format_value(report.ok_pair_score_mae)),
+        ("confidence_mae", _format_value(report.confidence_mae)),
+        ("baseline_inconclusive_count", report.baseline_inconclusive_count),
+        ("challenger_inconclusive_count", report.challenger_inconclusive_count),
+        ("inconclusive_count_delta", report.inconclusive_count_delta),
+    ]
+    lines = [
+        "# L6 A/B Evaluation",
+        "",
+        "## Summary",
+        "",
+        "| metric | value |",
+        "| --- | --- |",
+    ]
+    lines.extend(f"| {metric} | {_escape_markdown(value)} |" for metric, value in summary_rows)
+    lines.extend(
+        [
+            "",
+            "## Per Case",
+            "",
+            (
+                "| case_id | entity_id | baseline_analyzer_type | "
+                "challenger_analyzer_type | baseline_status | challenger_status | "
+                "score_delta | confidence_delta | status_matches |"
+            ),
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(_case_markdown_row(case) for case in report.cases)
+    return "\n".join(lines) + "\n"
+
+
+def write_ab_report(
+    report: AbEvaluationReport,
+    output_dir: Path,
+    *,
+    stem: str = "multi_agent_ab",
+) -> dict[str, Path]:
+    """Write JSON and Markdown A/B reports and return their paths."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / f"{stem}.json"
+    markdown_path = output_dir / f"{stem}.md"
+    json_path.write_text(format_ab_report_json(report), encoding="utf-8")
+    markdown_path.write_text(format_ab_report_markdown(report), encoding="utf-8")
+    return {"json": json_path, "markdown": markdown_path}
+
+
+def _report_payload(report: AbEvaluationReport) -> dict[str, object]:
+    return {
+        "baseline_analyzer_type": report.baseline_analyzer_type,
+        "challenger_analyzer_type": report.challenger_analyzer_type,
+        "total_cases": report.total_cases,
+        "status_match_rate": report.status_match_rate,
+        "ok_pair_score_mae": report.ok_pair_score_mae,
+        "confidence_mae": report.confidence_mae,
+        "baseline_inconclusive_count": report.baseline_inconclusive_count,
+        "challenger_inconclusive_count": report.challenger_inconclusive_count,
+        "inconclusive_count_delta": report.inconclusive_count_delta,
+        "cases": [_case_payload(case) for case in report.cases],
+    }
+
+
+def _case_payload(case: AbCaseResult) -> dict[str, object]:
+    return {
+        "case_id": case.case_id,
+        "entity_id": case.entity_id,
+        "baseline_analyzer_type": case.baseline_analyzer_type,
+        "challenger_analyzer_type": case.challenger_analyzer_type,
+        "baseline_status": case.baseline_status,
+        "challenger_status": case.challenger_status,
+        "baseline_score": case.baseline_score,
+        "challenger_score": case.challenger_score,
+        "baseline_confidence": case.baseline_confidence,
+        "challenger_confidence": case.challenger_confidence,
+        "score_delta": case.score_delta,
+        "confidence_delta": case.confidence_delta,
+        "status_matches": case.status_matches,
+    }
+
+
+def _case_markdown_row(case: AbCaseResult) -> str:
+    values = [
+        case.case_id,
+        case.entity_id,
+        case.baseline_analyzer_type,
+        case.challenger_analyzer_type,
+        case.baseline_status,
+        case.challenger_status,
+        _format_value(case.score_delta),
+        _format_value(case.confidence_delta),
+        case.status_matches,
+    ]
+    return "| " + " | ".join(_escape_markdown(value) for value in values) + " |"
+
+
+def _mean(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _format_value(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.6f}"
+    if value is None:
+        return "null"
+    return str(value)
+
+
+def _escape_markdown(value: object) -> str:
+    return _format_value(value).replace("|", "\\|")
+
+
+__all__ = [
+    "AbCaseResult",
+    "AbEvaluationCase",
+    "AbEvaluationReport",
+    "format_ab_report_json",
+    "format_ab_report_markdown",
+    "run_ab_evaluation",
+    "write_ab_report",
+]

--- a/src/main_core/l6_alpha/multi_agent_analyzer.py
+++ b/src/main_core/l6_alpha/multi_agent_analyzer.py
@@ -1,0 +1,331 @@
+"""Opt-in multi-agent alpha analyzer for L6 A/B evaluation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from math import fsum, isfinite
+from types import MappingProxyType
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import InconclusiveError, MainCoreError
+from main_core.common.protocols import AnalyzerBase
+from main_core.common.schemas import AlphaResultSnapshot
+from main_core.common.types import EntityId
+from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
+
+DEFAULT_MULTI_AGENT_ROLES: tuple[str, ...] = ("fundamental", "technical", "risk")
+
+
+@dataclass(frozen=True)
+class AgentRoleConfig:
+    """Configuration for one deterministic multi-agent role."""
+
+    name: str
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("agent role name must be non-empty")
+        if not isfinite(self.weight) or self.weight <= 0.0:
+            raise ValueError("agent role weight must be finite and > 0")
+
+
+@dataclass(frozen=True)
+class MultiAgentRoleResult:
+    """Raw result emitted by one role before multi-agent aggregation."""
+
+    role: str
+    score: float | None
+    confidence: float
+    rationale: str
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    task_failed: bool = False
+    failure_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.role.strip():
+            raise ValueError("role result role must be non-empty")
+        if not isfinite(self.confidence) or not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("role result confidence must be finite and within 0.0..1.0")
+        if not self.task_failed and (
+            self.score is None or not isfinite(self.score)
+        ):
+            raise ValueError("successful role result score must be finite")
+        object.__setattr__(self, "evidence", MappingProxyType(dict(self.evidence)))
+
+
+@runtime_checkable
+class MultiAgentReasonerPort(Protocol):
+    """Role-scoped L6 reasoner boundary for multi-agent analysis."""
+
+    def analyze_role(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+        role: AgentRoleConfig,
+        payload: Mapping[str, Any],
+    ) -> MultiAgentRoleResult:
+        """Analyze one entity from one role using the prepared context payload."""
+
+
+@dataclass
+class StaticMultiAgentReasonerPort:
+    """Deterministic multi-agent reasoner fake for local A/B runs and tests."""
+
+    role_results: Mapping[str, MultiAgentRoleResult] = field(default_factory=dict)
+    calls: list[tuple[EntityId, AlphaAnalysisContext, AgentRoleConfig, Mapping[str, Any]]] = (
+        field(default_factory=list)
+    )
+
+    def analyze_role(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+        role: AgentRoleConfig,
+        payload: Mapping[str, Any],
+    ) -> MultiAgentRoleResult:
+        """Return a configured role result or a stable zero-score default."""
+
+        self.calls.append((entity_id, context, role, payload))
+        if role.name in self.role_results:
+            return self.role_results[role.name]
+
+        return MultiAgentRoleResult(
+            role=role.name,
+            score=0.0,
+            confidence=0.0,
+            rationale=f"static {role.name} alpha analysis",
+            evidence={"role": role.name},
+        )
+
+
+def build_multi_agent_input_payload(
+    entity_id: EntityId,
+    context: AlphaAnalysisContext,
+) -> dict[str, Any]:
+    """Build the structured role input without provider prompt construction."""
+
+    return {
+        "cycle_id": context.cycle_id,
+        "entity_id": entity_id,
+        "feature_values": _plain_value(context.feature_bundle.feature_values),
+        "signal_values": _plain_value(context.feature_bundle.signal_values),
+        "graph_features": _plain_value(context.feature_bundle.graph_features),
+        "world_state": {
+            "final_regime": context.world_state.final_regime,
+            "llm_delta": context.world_state.llm_delta,
+        },
+        "similar_cases": _plain_value(context.similar_cases),
+    }
+
+
+def aggregate_role_results(
+    entity_id: EntityId,
+    context: AlphaAnalysisContext,
+    role_results: Sequence[MultiAgentRoleResult],
+    *,
+    roles: Sequence[AgentRoleConfig],
+) -> AlphaResultSnapshot:
+    """Aggregate role-level outputs into one formal multi-agent alpha result."""
+
+    role_weight_map = _role_weight_map(roles)
+    result_map = _role_result_map(role_results, role_weight_map)
+    failed_results = tuple(result for result in result_map.values() if result.task_failed)
+    healthy_results = tuple(
+        sorted(
+            (result for result in result_map.values() if not result.task_failed),
+            key=lambda result: result.role,
+        )
+    )
+
+    if not healthy_results:
+        return _multi_agent_result(
+            entity_id,
+            context,
+            {
+                "score": None,
+                "confidence": 0.0,
+                "rationale": _all_failed_rationale(failed_results, roles),
+                "status": "inconclusive",
+            },
+        )
+
+    total_weight = fsum(role_weight_map[result.role] for result in healthy_results)
+    weighted_score = fsum(
+        result.score * role_weight_map[result.role]
+        for result in healthy_results
+        if result.score is not None
+    ) / total_weight
+    weighted_confidence = fsum(
+        result.confidence * role_weight_map[result.role] for result in healthy_results
+    ) / total_weight
+
+    return _multi_agent_result(
+        entity_id,
+        context,
+        {
+            "score": weighted_score,
+            "confidence": weighted_confidence,
+            "rationale": _aggregate_rationale(healthy_results, failed_results),
+            "status": "ok",
+        },
+    )
+
+
+class MultiAgentAnalyzer(AnalyzerBase):
+    """Explicit opt-in multi-agent analyzer for phase 4 parity evaluation."""
+
+    analyzer_type: ClassVar[str] = "multi_agent_v1"
+
+    def __init__(
+        self,
+        reasoner_port: MultiAgentReasonerPort | None = None,
+        *,
+        roles: Sequence[AgentRoleConfig] | None = None,
+    ) -> None:
+        self._reasoner_port = reasoner_port or StaticMultiAgentReasonerPort()
+        self._roles = tuple(
+            roles
+            if roles is not None
+            else tuple(AgentRoleConfig(name) for name in DEFAULT_MULTI_AGENT_ROLES)
+        )
+        _role_weight_map(self._roles)
+
+    def analyze(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        """Analyze one entity by invoking each configured role exactly once."""
+
+        if entity_id != context.entity_id:
+            raise AlphaAnalyzerError("entity_id must match context.entity_id")
+
+        payload = build_multi_agent_input_payload(entity_id, context)
+        role_results: list[MultiAgentRoleResult] = []
+        for role in self._roles:
+            try:
+                result = self._reasoner_port.analyze_role(
+                    entity_id,
+                    context,
+                    role,
+                    payload,
+                )
+            except InconclusiveError as exc:
+                result = MultiAgentRoleResult(
+                    role=role.name,
+                    score=None,
+                    confidence=0.0,
+                    rationale="role task failed",
+                    task_failed=True,
+                    failure_reason=str(exc),
+                )
+            except MainCoreError:
+                raise
+            role_results.append(result)
+
+        return aggregate_role_results(
+            entity_id,
+            context,
+            role_results,
+            roles=self._roles,
+        )
+
+
+def _multi_agent_result(
+    entity_id: EntityId,
+    context: AlphaAnalysisContext,
+    fields: Mapping[str, Any],
+) -> AlphaResultSnapshot:
+    return AlphaResultSnapshot(
+        cycle_id=context.cycle_id,
+        entity_id=entity_id,
+        analyzer_type="multi_agent_v1",
+        score=fields["score"],
+        confidence=fields["confidence"],
+        rationale=fields["rationale"],
+        similar_cases=[dict(case) for case in context.similar_cases],
+        status=fields["status"],
+    )
+
+
+def _role_weight_map(roles: Sequence[AgentRoleConfig]) -> dict[str, float]:
+    if not roles:
+        raise AlphaAnalyzerError("at least one multi-agent role is required")
+
+    role_weight_map: dict[str, float] = {}
+    for role in roles:
+        if role.name in role_weight_map:
+            raise AlphaAnalyzerError(f"duplicate multi-agent role: {role.name}")
+        role_weight_map[role.name] = role.weight
+    return role_weight_map
+
+
+def _role_result_map(
+    role_results: Sequence[MultiAgentRoleResult],
+    role_weight_map: Mapping[str, float],
+) -> dict[str, MultiAgentRoleResult]:
+    result_map: dict[str, MultiAgentRoleResult] = {}
+    for result in role_results:
+        if result.role not in role_weight_map:
+            raise AlphaAnalyzerError(f"role result is not configured: {result.role}")
+        if result.role in result_map:
+            raise AlphaAnalyzerError(f"duplicate role result: {result.role}")
+        result_map[result.role] = result
+    return result_map
+
+
+def _aggregate_rationale(
+    healthy_results: Sequence[MultiAgentRoleResult],
+    failed_results: Sequence[MultiAgentRoleResult],
+) -> str:
+    role_summaries = [
+        (
+            f"{result.role}: score={result.score}, confidence={result.confidence}; "
+            f"{result.rationale}"
+        )
+        for result in healthy_results
+    ]
+    failure_summaries = [
+        f"{result.role} failed: {result.failure_reason or result.rationale}"
+        for result in sorted(failed_results, key=lambda result: result.role)
+    ]
+    return "multi-agent aggregation: " + "; ".join(role_summaries + failure_summaries)
+
+
+def _all_failed_rationale(
+    failed_results: Sequence[MultiAgentRoleResult],
+    roles: Sequence[AgentRoleConfig],
+) -> str:
+    if failed_results:
+        failures = "; ".join(
+            f"{result.role}: {result.failure_reason or result.rationale}"
+            for result in sorted(failed_results, key=lambda result: result.role)
+        )
+    else:
+        role_names = ", ".join(sorted(role.name for role in roles))
+        failures = f"no successful role results for roles: {role_names}"
+    return f"inconclusive: all multi-agent roles failed: {failures}"
+
+
+def _plain_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _plain_value(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_plain_value(item) for item in value]
+    if isinstance(value, frozenset | set):
+        return sorted(_plain_value(item) for item in value)
+    return value
+
+
+__all__ = [
+    "AgentRoleConfig",
+    "MultiAgentAnalyzer",
+    "MultiAgentReasonerPort",
+    "MultiAgentRoleResult",
+    "StaticMultiAgentReasonerPort",
+    "aggregate_role_results",
+    "build_multi_agent_input_payload",
+]

--- a/tests/integration/test_l6_multi_agent_enriched_inputs.py
+++ b/tests/integration/test_l6_multi_agent_enriched_inputs.py
@@ -1,0 +1,106 @@
+"""Integration coverage for L6 multi-agent consumption of enriched contexts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.l6_alpha import AgentRoleConfig, MultiAgentAnalyzer, MultiAgentRoleResult
+
+EXPECTED_LAYER_B_SCORE = 0.75
+
+
+class PayloadRecordingPort:
+    def __init__(self) -> None:
+        self.payloads: list[Mapping[str, Any]] = []
+
+    def analyze_role(
+        self,
+        entity_id: str,
+        context: AlphaAnalysisContext,
+        role: AgentRoleConfig,
+        payload: Mapping[str, Any],
+    ) -> MultiAgentRoleResult:
+        self.payloads.append(payload)
+        candidate_signals = payload["signal_values"]["candidate_signals"]
+        score = candidate_signals["layer_b_score"]["adjusted_value"]
+        return MultiAgentRoleResult(
+            role=role.name,
+            score=score,
+            confidence=0.9,
+            rationale=f"{role.name} consumed enriched context for {entity_id}",
+            evidence={"cycle_id": context.cycle_id},
+        )
+
+
+def test_multi_agent_payload_preserves_candidate_signals_and_graph_features() -> None:
+    cycle_id = "cycle-l6-enriched"
+    candidate_signals = {
+        "layer_b_score": {
+            "raw_value": 2.0,
+            "adjusted_value": EXPECTED_LAYER_B_SCORE,
+            "source": "layer_b",
+            "confidence": 0.9,
+            "metadata": {"source_table": "candidate_facts", "rank": 1},
+        },
+        "sentiment_label": {
+            "raw_value": "positive",
+            "adjusted_value": "positive",
+            "source": "layer_b",
+            "confidence": None,
+            "metadata": {"language": "en"},
+        },
+    }
+    graph_features = {
+        "snapshot_id": "graph-impact-001",
+        "features": {"impact_score": 0.81, "community": "growth"},
+    }
+    context = AlphaAnalysisContext(
+        cycle_id=cycle_id,
+        entity_id="ENT_ENRICHED",
+        feature_bundle=FeatureSignalBundle(
+            cycle_id=cycle_id,
+            entity_id="ENT_ENRICHED",
+            feature_values={"momentum": 4.2},
+            signal_values={"candidate_signals": candidate_signals},
+            graph_features=graph_features,
+            feature_weight_multiplier={"momentum": 1.0},
+        ),
+        world_state=WorldStateSnapshot(
+            cycle_id=cycle_id,
+            baseline_regime="neutral",
+            llm_delta=1,
+            final_regime="risk_on",
+            llm_rationale="fixture",
+            actual_model_used="fixture",
+            actual_provider="local",
+            fallback_path=[],
+        ),
+        similar_cases=[{"entity_id": "ENT_SIM", "score": 0.44}],
+    )
+    port = PayloadRecordingPort()
+    analyzer = MultiAgentAnalyzer(port, roles=(AgentRoleConfig("fundamental"),))
+
+    result = analyzer.analyze("ENT_ENRICHED", context)
+
+    assert result.analyzer_type == "multi_agent_v1"
+    assert result.status == "ok"
+    assert result.score == EXPECTED_LAYER_B_SCORE
+    assert port.payloads[0]["signal_values"]["candidate_signals"] == candidate_signals
+    assert port.payloads[0]["graph_features"] == graph_features
+    assert port.payloads[0]["world_state"] == {
+        "final_regime": "risk_on",
+        "llm_delta": 1,
+    }
+    assert port.payloads[0]["similar_cases"] == [{"entity_id": "ENT_SIM", "score": 0.44}]
+
+
+def test_l6_multi_agent_does_not_import_l3_graph_or_graph_engine_ports() -> None:
+    l6_root = Path("src/main_core/l6_alpha")
+    source = "\n".join(path.read_text(encoding="utf-8") for path in l6_root.glob("*.py"))
+
+    assert "main_core.l3_features.graph_adapter" not in source
+    assert "graph_engine" not in source

--- a/tests/l6_alpha/test_ab_runner.py
+++ b/tests/l6_alpha/test_ab_runner.py
@@ -1,0 +1,200 @@
+"""Tests for L6 analyzer A/B report generation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.schemas import AlphaResultSnapshot, FeatureSignalBundle, WorldStateSnapshot
+from main_core.l6_alpha.ab_runner import (
+    AbEvaluationCase,
+    format_ab_report_json,
+    format_ab_report_markdown,
+    run_ab_evaluation,
+    write_ab_report,
+)
+
+EXPECTED_CONFIDENCE_MAE = 0.25
+EXPECTED_OK_SCORE_MAE = 0.3
+EXPECTED_STATUS_MATCH_RATE = 0.5
+TOTAL_AB_CASES = 2
+
+
+class RecordingAnalyzer:
+    def __init__(
+        self,
+        analyzer_type: str,
+        results: dict[str, AlphaResultSnapshot],
+    ) -> None:
+        self.analyzer_type = analyzer_type
+        self.results = results
+        self.calls: list[tuple[str, AlphaAnalysisContext]] = []
+
+    def analyze(
+        self,
+        entity_id: str,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        self.calls.append((entity_id, context))
+        return self.results[entity_id]
+
+
+def test_run_ab_evaluation_computes_metrics_from_same_contexts(monkeypatch) -> None:
+    def fail_if_l3_builder_is_called(*args, **kwargs):
+        raise AssertionError("A/B runner must use supplied contexts")
+
+    monkeypatch.setattr(
+        "main_core.l3_features.build_feature_signal_bundle",
+        fail_if_l3_builder_is_called,
+    )
+    monkeypatch.setattr(
+        "main_core.l3_features.build_feature_signal_bundles",
+        fail_if_l3_builder_is_called,
+    )
+    contexts = [_context("ENT_A"), _context("ENT_B")]
+    cases = [
+        AbEvaluationCase("case-a", "ENT_A", contexts[0]),
+        AbEvaluationCase("case-b", "ENT_B", contexts[1]),
+    ]
+    baseline = RecordingAnalyzer(
+        "single_prompt_v1",
+        {
+            "ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok"),
+            "ENT_B": _alpha_result("ENT_B", "single_prompt_v1", None, 0.0, "inconclusive"),
+        },
+    )
+    challenger = RecordingAnalyzer(
+        "multi_agent_v1",
+        {
+            "ENT_A": _alpha_result("ENT_A", "multi_agent_v1", 0.8, 0.6, "ok"),
+            "ENT_B": _alpha_result("ENT_B", "multi_agent_v1", 0.2, 0.4, "ok"),
+        },
+    )
+
+    report = run_ab_evaluation(cases, baseline=baseline, challenger=challenger)
+
+    assert baseline.calls == [("ENT_A", contexts[0]), ("ENT_B", contexts[1])]
+    assert challenger.calls == [("ENT_A", contexts[0]), ("ENT_B", contexts[1])]
+    assert report.total_cases == TOTAL_AB_CASES
+    assert report.status_match_rate == EXPECTED_STATUS_MATCH_RATE
+    assert report.ok_pair_score_mae == pytest.approx(EXPECTED_OK_SCORE_MAE)
+    assert report.confidence_mae == pytest.approx(EXPECTED_CONFIDENCE_MAE)
+    assert report.baseline_inconclusive_count == 1
+    assert report.challenger_inconclusive_count == 0
+    assert report.inconclusive_count_delta == -1
+    assert report.cases[0].score_delta == pytest.approx(EXPECTED_OK_SCORE_MAE)
+    assert report.cases[1].score_delta is None
+
+
+def test_ab_report_json_is_parseable_and_excludes_context_models() -> None:
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=RecordingAnalyzer(
+            "single_prompt_v1",
+            {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+        ),
+        challenger=RecordingAnalyzer(
+            "multi_agent_v1",
+            {"ENT_A": _alpha_result("ENT_A", "multi_agent_v1", 0.6, 0.8, "ok")},
+        ),
+    )
+
+    payload = json.loads(format_ab_report_json(report))
+
+    assert payload["baseline_analyzer_type"] == "single_prompt_v1"
+    assert payload["challenger_analyzer_type"] == "multi_agent_v1"
+    assert payload["cases"][0]["case_id"] == "case-a"
+    assert "context" not in payload["cases"][0]
+    assert "feature_bundle" not in json.dumps(payload)
+
+
+def test_ab_report_markdown_uses_stable_summary_and_case_tables() -> None:
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=RecordingAnalyzer(
+            "single_prompt_v1",
+            {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+        ),
+        challenger=RecordingAnalyzer(
+            "multi_agent_v1",
+            {"ENT_A": _alpha_result("ENT_A", "multi_agent_v1", 0.6, 0.8, "ok")},
+        ),
+    )
+
+    markdown = format_ab_report_markdown(report)
+
+    assert "| metric | value |" in markdown
+    assert (
+        "| case_id | entity_id | baseline_analyzer_type | challenger_analyzer_type |"
+        in markdown
+    )
+    assert "| case-a | ENT_A | single_prompt_v1 | multi_agent_v1 |" in markdown
+
+
+def test_write_ab_report_writes_json_and_markdown(tmp_path) -> None:
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=RecordingAnalyzer(
+            "single_prompt_v1",
+            {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+        ),
+        challenger=RecordingAnalyzer(
+            "multi_agent_v1",
+            {"ENT_A": _alpha_result("ENT_A", "multi_agent_v1", 0.6, 0.8, "ok")},
+        ),
+    )
+
+    paths = write_ab_report(report, tmp_path, stem="custom_ab")
+
+    assert paths["json"].name == "custom_ab.json"
+    assert paths["markdown"].name == "custom_ab.md"
+    assert json.loads(paths["json"].read_text(encoding="utf-8"))["total_cases"] == 1
+    assert "# L6 A/B Evaluation" in paths["markdown"].read_text(encoding="utf-8")
+
+
+def _context(entity_id: str) -> AlphaAnalysisContext:
+    cycle_id = "cycle_ab"
+    return AlphaAnalysisContext(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_bundle=FeatureSignalBundle(
+            cycle_id=cycle_id,
+            entity_id=entity_id,
+            feature_values={"momentum": 1.0},
+            signal_values={"signal": "positive"},
+            graph_features={},
+            feature_weight_multiplier={"momentum": 1.0},
+        ),
+        world_state=WorldStateSnapshot(
+            cycle_id=cycle_id,
+            baseline_regime="neutral",
+            llm_delta=0,
+            final_regime="neutral",
+            llm_rationale="fixture",
+            actual_model_used="fixture",
+            actual_provider="local",
+            fallback_path=[],
+        ),
+        similar_cases=[],
+    )
+
+
+def _alpha_result(
+    entity_id: str,
+    analyzer_type: str,
+    score: float | None,
+    confidence: float,
+    status: str,
+) -> AlphaResultSnapshot:
+    return AlphaResultSnapshot(
+        cycle_id="cycle_ab",
+        entity_id=entity_id,
+        analyzer_type=analyzer_type,
+        score=score,
+        confidence=confidence,
+        rationale=f"{analyzer_type} {status}",
+        similar_cases=[],
+        status=status,
+    )

--- a/tests/l6_alpha/test_multi_agent_analyzer.py
+++ b/tests/l6_alpha/test_multi_agent_analyzer.py
@@ -1,0 +1,261 @@
+"""Tests for the explicit opt-in multi-agent L6 analyzer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import inf, nan
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import InconclusiveError, MainCoreError
+from main_core.common.schemas import AlphaResultSnapshot
+from main_core.l6_alpha import (
+    AgentRoleConfig,
+    MultiAgentAnalyzer,
+    MultiAgentReasonerPort,
+    MultiAgentRoleResult,
+    StaticMultiAgentReasonerPort,
+    analyze_stock,
+)
+from main_core.l6_alpha.multi_agent_analyzer import aggregate_role_results
+from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
+
+EXPECTED_WEIGHTED_CONFIDENCE = 0.75
+EXPECTED_WEIGHTED_SCORE = 0.6
+HEALTHY_ONLY_SCORE = 0.8
+
+
+class RecordingMultiAgentPort:
+    def __init__(
+        self,
+        results: Mapping[str, MultiAgentRoleResult] | None = None,
+        errors: Mapping[str, BaseException] | None = None,
+    ) -> None:
+        self.results = dict(results or {})
+        self.errors = dict(errors or {})
+        self.calls: list[tuple[object, AlphaAnalysisContext, AgentRoleConfig, Mapping]] = []
+
+    def analyze_role(
+        self,
+        entity_id: object,
+        context: AlphaAnalysisContext,
+        role: AgentRoleConfig,
+        payload: Mapping,
+    ) -> MultiAgentRoleResult:
+        self.calls.append((entity_id, context, role, payload))
+        if role.name in self.errors:
+            raise self.errors[role.name]
+        if role.name in self.results:
+            return self.results[role.name]
+        return MultiAgentRoleResult(
+            role=role.name,
+            score=0.5,
+            confidence=0.6,
+            rationale=f"{role.name} default",
+        )
+
+
+def test_agent_role_config_validates_name_and_weight() -> None:
+    with pytest.raises(ValueError, match="name"):
+        AgentRoleConfig(" ")
+    with pytest.raises(ValueError, match="weight"):
+        AgentRoleConfig("risk", 0.0)
+    with pytest.raises(ValueError, match="weight"):
+        AgentRoleConfig("risk", inf)
+
+
+def test_multi_agent_role_result_validates_success_fields() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        MultiAgentRoleResult("risk", 0.5, 1.1, "too confident")
+    with pytest.raises(ValueError, match="score"):
+        MultiAgentRoleResult("risk", None, 0.5, "missing score")
+    with pytest.raises(ValueError, match="score"):
+        MultiAgentRoleResult("risk", nan, 0.5, "nan score")
+
+
+def test_static_multi_agent_port_matches_runtime_protocol() -> None:
+    assert isinstance(StaticMultiAgentReasonerPort(), MultiAgentReasonerPort)
+
+
+def test_multi_agent_analyzer_happy_path_returns_formal_result(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    roles = (AgentRoleConfig("fundamental", 2.0), AgentRoleConfig("technical", 1.0))
+    port = RecordingMultiAgentPort(
+        {
+            "fundamental": MultiAgentRoleResult(
+                "fundamental",
+                0.7,
+                0.8,
+                "fundamental case is strong",
+                evidence={"metric": "quality"},
+            ),
+            "technical": MultiAgentRoleResult(
+                "technical",
+                0.4,
+                0.65,
+                "technical case is mixed",
+            ),
+        }
+    )
+    analyzer = MultiAgentAnalyzer(port, roles=roles)
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert isinstance(result, AlphaResultSnapshot)
+    assert result.analyzer_type == "multi_agent_v1"
+    assert result.status == "ok"
+    assert result.score == pytest.approx(EXPECTED_WEIGHTED_SCORE)
+    assert result.confidence == pytest.approx(EXPECTED_WEIGHTED_CONFIDENCE)
+    assert "fundamental case is strong" in result.rationale
+    assert "technical case is mixed" in result.rationale
+    assert [call[2].name for call in port.calls] == ["fundamental", "technical"]
+
+
+def test_multi_agent_analyzer_rejects_entity_mismatch_without_calling_port(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    port = RecordingMultiAgentPort()
+    analyzer = MultiAgentAnalyzer(port)
+
+    with pytest.raises(AlphaAnalyzerError, match="context.entity_id"):
+        analyzer.analyze("ENT_OTHER", analysis_context)
+
+    assert port.calls == []
+
+
+def test_aggregate_role_results_is_stable_when_role_order_changes(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    roles = (AgentRoleConfig("technical", 1.0), AgentRoleConfig("fundamental", 2.0))
+    reversed_roles = tuple(reversed(roles))
+    role_results = (
+        MultiAgentRoleResult("fundamental", 0.7, 0.8, "fundamental"),
+        MultiAgentRoleResult("technical", 0.4, 0.65, "technical"),
+    )
+    reversed_results = tuple(reversed(role_results))
+
+    result = aggregate_role_results("ENT_A", analysis_context, role_results, roles=roles)
+    reversed_result = aggregate_role_results(
+        "ENT_A",
+        analysis_context,
+        reversed_results,
+        roles=reversed_roles,
+    )
+
+    assert reversed_result.score == result.score
+    assert reversed_result.confidence == result.confidence
+    assert reversed_result.rationale == result.rationale
+
+
+def test_single_role_task_failure_keeps_ok_result_and_records_reason(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    roles = (AgentRoleConfig("fundamental"), AgentRoleConfig("risk"))
+    analyzer = MultiAgentAnalyzer(
+        RecordingMultiAgentPort(
+            {
+                "fundamental": MultiAgentRoleResult(
+                    "fundamental",
+                    0.8,
+                    0.7,
+                    "healthy role",
+                ),
+                "risk": MultiAgentRoleResult(
+                    "risk",
+                    None,
+                    0.0,
+                    "risk task failed",
+                    task_failed=True,
+                    failure_reason="risk provider timeout",
+                ),
+            }
+        ),
+        roles=roles,
+    )
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert result.status == "ok"
+    assert result.score == HEALTHY_ONLY_SCORE
+    assert "risk failed: risk provider timeout" in result.rationale
+
+
+def test_inconclusive_role_error_is_downgraded_to_role_failure(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    roles = (AgentRoleConfig("fundamental"), AgentRoleConfig("risk"))
+    analyzer = MultiAgentAnalyzer(
+        RecordingMultiAgentPort(errors={"risk": InconclusiveError("risk had no answer")}),
+        roles=roles,
+    )
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert result.status == "ok"
+    assert "risk failed: risk had no answer" in result.rationale
+
+
+def test_all_role_task_failures_return_multi_agent_inconclusive(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    roles = (AgentRoleConfig("fundamental"), AgentRoleConfig("risk"))
+    analyzer = MultiAgentAnalyzer(
+        RecordingMultiAgentPort(
+            {
+                "fundamental": MultiAgentRoleResult(
+                    "fundamental",
+                    None,
+                    0.0,
+                    "fundamental failed",
+                    task_failed=True,
+                    failure_reason="no data",
+                ),
+                "risk": MultiAgentRoleResult(
+                    "risk",
+                    None,
+                    0.0,
+                    "risk failed",
+                    task_failed=True,
+                    failure_reason="timeout",
+                ),
+            }
+        ),
+        roles=roles,
+    )
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert result.analyzer_type == "multi_agent_v1"
+    assert result.status == "inconclusive"
+    assert result.score is None
+    assert result.confidence == 0.0
+    assert "fundamental: no data" in result.rationale
+    assert "risk: timeout" in result.rationale
+
+
+def test_main_core_error_from_role_hard_stops_without_fallback(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = MultiAgentAnalyzer(
+        RecordingMultiAgentPort(errors={"fundamental": MainCoreError("reasoner down")}),
+        roles=(AgentRoleConfig("fundamental"),),
+    )
+
+    with pytest.raises(MainCoreError, match="reasoner down"):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+def test_default_analyze_stock_stays_single_prompt_without_explicit_analyzer(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    default_result = analyze_stock("ENT_A", analysis_context)
+    explicit_result = analyze_stock(
+        "ENT_A",
+        analysis_context,
+        analyzer=MultiAgentAnalyzer(roles=(AgentRoleConfig("fundamental"),)),
+    )
+
+    assert default_result.analyzer_type == "single_prompt_v1"
+    assert explicit_result.analyzer_type == "multi_agent_v1"

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -7,11 +7,17 @@ from inspect import signature
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.protocols import AnalyzerBase, AnalyzerInterface
 from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
-from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer, StaticAlphaReasonerPort
+from main_core.l6_alpha import (
+    AlphaReasonerResponse,
+    MultiAgentAnalyzer,
+    SinglePromptAnalyzer,
+    StaticAlphaReasonerPort,
+)
 
 CYCLE_ID = "cycle_001"
 ENTITY_ID = "ENT_001"
 SINGLE_PROMPT_ANALYZER = "single_prompt_v1"
+MULTI_AGENT_ANALYZER = "multi_agent_v1"
 
 
 def _feature_bundle() -> FeatureSignalBundle:
@@ -60,12 +66,20 @@ def test_single_prompt_analyzer_matches_runtime_protocol() -> None:
     assert analyzer.analyzer_type == SINGLE_PROMPT_ANALYZER
 
 
+def test_multi_agent_analyzer_matches_runtime_protocol() -> None:
+    analyzer = MultiAgentAnalyzer()
+
+    assert isinstance(analyzer, AnalyzerInterface)
+    assert analyzer.analyzer_type == MULTI_AGENT_ANALYZER
+
+
 def test_analyzer_protocol_requires_explicit_entity_argument() -> None:
     expected_parameters = ["self", "entity_id", "context"]
 
     assert list(signature(AnalyzerInterface.analyze).parameters) == expected_parameters
     assert list(signature(AnalyzerBase.analyze).parameters) == expected_parameters
     assert list(signature(SinglePromptAnalyzer.analyze).parameters) == expected_parameters
+    assert list(signature(MultiAgentAnalyzer.analyze).parameters) == expected_parameters
 
 
 def test_single_prompt_analyzer_returns_single_prompt_result() -> None:
@@ -83,4 +97,13 @@ def test_single_prompt_analyzer_returns_single_prompt_result() -> None:
     result = analyzer.analyze(ENTITY_ID, _analysis_context())
 
     assert result.analyzer_type == SINGLE_PROMPT_ANALYZER
+    assert result.status == "ok"
+
+
+def test_multi_agent_analyzer_returns_multi_agent_result() -> None:
+    analyzer = MultiAgentAnalyzer()
+
+    result = analyzer.analyze(ENTITY_ID, _analysis_context())
+
+    assert result.analyzer_type == MULTI_AGENT_ANALYZER
     assert result.status == "ok"

--- a/tests/schemas/test_alpha.py
+++ b/tests/schemas/test_alpha.py
@@ -36,6 +36,16 @@ def test_single_prompt_result_factory_sets_p2_default_analyzer_type() -> None:
     assert result.analyzer_type == "single_prompt_v1"
 
 
+def test_alpha_result_accepts_multi_agent_v1_happy_path() -> None:
+    payload = _alpha_payload()
+    payload["analyzer_type"] = "multi_agent_v1"
+
+    result = AlphaResultSnapshot(**payload)
+
+    assert result.analyzer_type == "multi_agent_v1"
+    assert result.status == "ok"
+
+
 def test_alpha_result_missing_field_fails() -> None:
     payload = _alpha_payload()
     payload.pop("entity_id")


### PR DESCRIPTION
Closes #15

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/candidate_signals.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l3_features/graph_adapter.py`, `src/main_core/l6_alpha/fallback.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`


---
### 1. 背景与目标
项目文档 §16.3 与 §21 阶段 4 允许在 P8/阶段 4 引入 `multi_agent_v1`，但生产默认仍必须保持 `single_prompt_v1`，是否切换生产由后续独立配置 issue 决定。当前可见代码已经在 `src/main_core/common/protocols/analyzer.py` 固定了 `AnalyzerInterface.analyze(self, entity_id, context) -> AlphaResultSnapshot`，在 `src/main_core/common/schemas/alpha.py` 允许 `AnalyzerType = Literal["single_prompt_v1", "multi_agent_v1"]`，并对 `inconclusive` 结果禁止携带 score。`AlphaAnalysisContext` 已经承载 `FeatureSignalBundle`、`WorldStateSnapshot` 与 `similar_cases`，所以本 issue 的目标是在 L6 内新增一个显式 opt-in 的 `MultiAgentAnalyzer`，并提供 A/B parity/scoring 报告，用同一批 context 对比 #9 的 `SinglePromptAnalyzer`，不改默认分析路径。

### 2. 所属模块
Primary writable paths:
- `src/main_core/l6_alpha/multi_agent_analyzer.py`（新建）
- `src/main_core/l6_alpha/ab_runner.py`（新建）
- `src/main_core/l6_alpha/__init__.py`（仅导出新增 public symbols）
- `tests/l6_alpha/test_multi_agent_analyzer.py`（新建）
- `tests/l6_alpha/test_ab_runner.py`（新建）
- `tests/integration/test_l6_multi_agent_enriched_inputs.py`（新建）
- `tests/protocols/test_analyzer_interface.py`（补充 `MultiAgentAnalyzer` 协议断言）
- `tests/schemas/test_alpha.py`（补充 `multi_agent_v1` schema happy path）

Adjacent read-only / integration paths:
- `src/main_core/common/protocols/analyzer.py`：复用 `AnalyzerBase`, `AnalyzerInterface`
- `src/main_core/common/contexts.py`：消费 `AlphaAnalysisContext`
- `src/main_core/common/schemas/alpha.py`：产出 `AlphaResultSnapshot`，不新增字段
- `src/main_core/common/schemas/feature_bundle.py`：通过 context 消费 `signal_values` / `graph_features`
- `src/main_core/common/errors.py`：复用 `MainCoreError`, `InconclusiveError`
- `src/main_core/common/types.py`：复用 `CycleId`, `EntityId`
- #9 产出的 `src/main_core/l6_alpha/single_prompt_analyzer.py`、`service.py`、`fallback.py`、`reasoner_port.py`：只作为 read-only baseline / fallback 语义参考，不修改主流程
- #14 产出的 L3 candidate signal public shape：只通过 `AlphaAnalysisContext.feature_bundle.signal_values["candidate_signals"]` 消费

### 3. 实现范围
- 在 `src/main_core/l6_alpha/multi_agent_analyzer.py` 新建 frozen dataclass `AgentRoleConfig(n