### PR TITLE
feat(#51): P1 backlog cleanup (33 findings, 18 files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "project-ult-main-core"
 version = "0.1.0"
 description = "Scaffold workspace for main-core."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [project.optional-dependencies]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 line-length = 100
-target-version = "py311"
+target-version = "py312"
 
 [lint]
 select = ["E", "F", "I", "B", "UP", "PL"]

--- a/src/main_core/common/contexts.py
+++ b/src/main_core/common/contexts.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from main_core.common.schemas import (
     FeatureSignalBundle,
@@ -23,6 +23,18 @@ class AlphaAnalysisContext(BaseModel):
     feature_bundle: FeatureSignalBundle
     world_state: WorldStateSnapshot
     similar_cases: list[dict[str, Any]] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_cycle_and_entity_consistency(self) -> Self:
+        """Require L6 context objects to describe the same cycle and entity."""
+
+        if self.feature_bundle.cycle_id != self.cycle_id:
+            raise ValueError("feature_bundle.cycle_id must match context.cycle_id")
+        if self.world_state.cycle_id != self.cycle_id:
+            raise ValueError("world_state.cycle_id must match context.cycle_id")
+        if self.feature_bundle.entity_id != self.entity_id:
+            raise ValueError("feature_bundle.entity_id must match context.entity_id")
+        return self
 
 
 class WorldStateInputs(BaseModel):

--- a/src/main_core/common/json_like.py
+++ b/src/main_core/common/json_like.py
@@ -1,0 +1,21 @@
+"""Helpers for normalizing external adapter payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def to_plain_json_like(value: Any) -> Any:
+    """Return a JSON-like payload with string mapping keys and list containers."""
+
+    if isinstance(value, Mapping):
+        return {str(key): to_plain_json_like(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [to_plain_json_like(item) for item in value]
+    if isinstance(value, frozenset | set):
+        return sorted(to_plain_json_like(item) for item in value)
+    return value
+
+
+__all__ = ["to_plain_json_like"]

--- a/src/main_core/common/schemas/__init__.py
+++ b/src/main_core/common/schemas/__init__.py
@@ -14,7 +14,7 @@ from main_core.common.schemas.dashboard import DashboardSnapshot
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.schemas.override import OverrideRecord
 from main_core.common.schemas.pool import OfficialAlphaPool
-from main_core.common.schemas.publish import PublishBundle
+from main_core.common.schemas.publish import ManifestReference, PublishBundle
 from main_core.common.schemas.recommendation import (
     ActionType,
     RecommendationSnapshot,
@@ -55,6 +55,7 @@ SCHEMA_CONTRACT_LAYER: Final = MappingProxyType(
         "TriggerSource": "l7_recommendation",
         "DashboardSnapshot": "l8_publish",
         "FormalReport": "l8_publish",
+        "ManifestReference": "l8_publish",
         "PublishBundle": "l8_publish",
     }
 )
@@ -97,6 +98,7 @@ __all__ = [
     "FormalObjectBase",
     "FormalReport",
     "LAYER_SCHEMA_IMPORT_POLICY",
+    "ManifestReference",
     "OfficialAlphaPool",
     "OverrideRecord",
     "PublishBundle",

--- a/src/main_core/common/schemas/alpha.py
+++ b/src/main_core/common/schemas/alpha.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId, EntityId
@@ -24,6 +24,7 @@ class AlphaResultSnapshot(FormalObjectBase):
     rationale: str
     similar_cases: list[dict[str, Any]]
     status: AlphaStatus
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_inconclusive_score(self) -> AlphaResultSnapshot:

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from copy import deepcopy
+from decimal import Decimal
+from math import isfinite
 from types import MappingProxyType
 from typing import Any, Self
 
@@ -60,6 +62,25 @@ def _thaw_value(value: Any) -> Any:
     return value
 
 
+def _validate_finite_number(value: Any, path: str) -> None:
+    if isinstance(value, float) and not isfinite(value):
+        raise ValueError(f"{path or 'payload'} must contain only finite numeric values")
+    if isinstance(value, Decimal) and not value.is_finite():
+        raise ValueError(f"{path or 'payload'} must contain only finite numeric values")
+
+
+def _validate_finite_numbers(value: Any, path: str = "") -> None:
+    _validate_finite_number(value, path)
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            _validate_finite_numbers(item, child_path)
+    elif isinstance(value, (list, tuple, frozenset, set)):
+        for index, item in enumerate(value):
+            child_path = f"{path}[{index}]" if path else f"[{index}]"
+            _validate_finite_numbers(item, child_path)
+
+
 class FormalObjectBase(BaseModel):
     """Frozen schema base for formal and runtime contract objects."""
 
@@ -75,6 +96,7 @@ class FormalObjectBase(BaseModel):
         """Recursively freeze validated container fields before sharing objects."""
 
         for field_name in type(self).model_fields:
+            _validate_finite_numbers(getattr(self, field_name), field_name)
             object.__setattr__(self, field_name, _freeze_value(getattr(self, field_name)))
         return self
 

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -63,7 +63,12 @@ def _thaw_value(value: Any) -> Any:
 class FormalObjectBase(BaseModel):
     """Frozen schema base for formal and runtime contract objects."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    model_config = ConfigDict(
+        allow_inf_nan=False,
+        extra="forbid",
+        frozen=True,
+        strict=True,
+    )
 
     @model_validator(mode="after")
     def freeze_nested_containers(self) -> Self:

--- a/src/main_core/common/schemas/pool.py
+++ b/src/main_core/common/schemas/pool.py
@@ -12,7 +12,7 @@ class OfficialAlphaPool(FormalObjectBase):
     """Formal L5 official alpha pool described in §9.3."""
 
     cycle_id: CycleId
-    observation_pool_size: int
+    observation_pool_size: int = Field(ge=0)
     official_alpha_pool_capacity: int = Field(default=100, ge=1, le=100)
     selected_entities: list[EntityId]
     added_entities: list[EntityId]
@@ -25,6 +25,8 @@ class OfficialAlphaPool(FormalObjectBase):
 
         if len(self.selected_entities) > self.official_alpha_pool_capacity:
             raise ValueError("selected_entities length must be <= official_alpha_pool_capacity")
+        if len(self.selected_entities) > self.observation_pool_size:
+            raise ValueError("selected_entities length must be <= observation_pool_size")
         return self
 
 

--- a/src/main_core/common/schemas/publish.py
+++ b/src/main_core/common/schemas/publish.py
@@ -50,9 +50,22 @@ class PublishBundle(FormalObjectBase):
             self.cycle_id,
         )
 
+        manifest_ref = self.manifest_candidate.get("manifest_ref")
         object_refs = self.manifest_candidate.get("object_refs")
-        if object_refs is None:
+        if manifest_ref is None and object_refs is None:
             return self
+        if object_refs is not None and self.manifest_candidate.get("cycle_id") is None:
+            raise ValueError(
+                "manifest_candidate.cycle_id must be set when object_refs is present"
+            )
+        if manifest_ref is not None and self.manifest_candidate.get("cycle_id") is None:
+            raise ValueError(
+                "manifest_candidate.cycle_id must be set when manifest_ref is present"
+            )
+        if object_refs is None:
+            raise ValueError(
+                "manifest_candidate.object_refs must be set when manifest_ref is present"
+            )
         if not isinstance(object_refs, Mapping):
             raise ValueError("manifest_candidate.object_refs must be a mapping")
         manifest_ref = ManifestReference.model_validate(

--- a/src/main_core/common/schemas/publish.py
+++ b/src/main_core/common/schemas/publish.py
@@ -2,10 +2,31 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, Self
+
+from pydantic import Field, model_validator
 
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId
+
+
+class ManifestReference(FormalObjectBase):
+    """Typed manifest anchor embedded in a publish bundle candidate."""
+
+    cycle_id: CycleId
+    manifest_ref: str
+    object_refs: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_manifest_anchor(self) -> Self:
+        """Require the manifest anchor and referenced formal object refs to be present."""
+
+        if not self.manifest_ref.strip():
+            raise ValueError("manifest_ref must be non-empty")
+        if not self.object_refs:
+            raise ValueError("object_refs must not be empty")
+        return self
 
 
 class PublishBundle(FormalObjectBase):
@@ -17,5 +38,50 @@ class PublishBundle(FormalObjectBase):
     audit_payload: dict[str, Any]
     retrospective_seed: dict[str, Any]
 
+    @model_validator(mode="after")
+    def validate_cycle_and_manifest_consistency(self) -> Self:
+        """Validate same-cycle anchors when a manifest candidate is present."""
 
-__all__ = ["PublishBundle"]
+        _ensure_optional_cycle("manifest_candidate", self.manifest_candidate, self.cycle_id)
+        _ensure_optional_cycle("audit_payload", self.audit_payload, self.cycle_id)
+        _ensure_optional_cycle(
+            "retrospective_seed",
+            self.retrospective_seed,
+            self.cycle_id,
+        )
+
+        object_refs = self.manifest_candidate.get("object_refs")
+        if object_refs is None:
+            return self
+        if not isinstance(object_refs, Mapping):
+            raise ValueError("manifest_candidate.object_refs must be a mapping")
+        manifest_ref = ManifestReference.model_validate(
+            {
+                "cycle_id": self.manifest_candidate.get("cycle_id"),
+                "manifest_ref": self.manifest_candidate.get("manifest_ref"),
+                "object_refs": dict(object_refs),
+            }
+        )
+        for object_key, expected_ref in manifest_ref.object_refs.items():
+            entry = self.formal_objects.get(object_key)
+            if not isinstance(entry, Mapping):
+                raise ValueError(
+                    f"manifest_candidate.object_refs contains missing {object_key}"
+                )
+            actual_ref = entry.get("ref")
+            if actual_ref != expected_ref:
+                raise ValueError(f"{object_key}.ref must match manifest_candidate")
+        return self
+
+
+def _ensure_optional_cycle(
+    payload_name: str,
+    payload: Mapping[str, Any],
+    cycle_id: CycleId,
+) -> None:
+    payload_cycle_id = payload.get("cycle_id")
+    if payload_cycle_id is not None and payload_cycle_id != str(cycle_id):
+        raise ValueError(f"{payload_name}.cycle_id must match")
+
+
+__all__ = ["ManifestReference", "PublishBundle"]

--- a/src/main_core/l1_l2_basis/readers.py
+++ b/src/main_core/l1_l2_basis/readers.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import TypeVar
 
 from main_core.common.types import CycleId
 from main_core.l1_l2_basis.errors import DataPlatformReadError
 from main_core.l1_l2_basis.models import CalendarDay, EntityMasterRow, MarketBar
 from main_core.l1_l2_basis.ports import DataPlatformPort
-
-BasisDTO = TypeVar("BasisDTO", MarketBar, CalendarDay, EntityMasterRow)
 
 
 def read_market_bars(cycle_id: CycleId | str, *, port: DataPlatformPort) -> list[MarketBar]:
@@ -40,7 +37,7 @@ def read_entity_master(
     return sorted(records, key=lambda record: record.entity_id)
 
 
-def _read_from_port(
+def _read_from_port[BasisDTO: (MarketBar, CalendarDay, EntityMasterRow)](
     cycle_id: CycleId | str,
     read: Callable[[CycleId | str], Sequence[BasisDTO]],
     expected_type: type[BasisDTO],

--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -17,7 +17,11 @@ from main_core.l3_features.candidate_signals import (
 )
 from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
 from main_core.l3_features.graph_adapter import load_graph_features, merge_graph_features
-from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+from main_core.l3_features.multiplier_store import (
+    InMemoryMultiplierStore,
+    MultiplierStore,
+    validate_multiplier_mapping,
+)
 from main_core.l3_features.weight_api import (
     apply_weight_multiplier,
     get_feature_weight_multiplier,
@@ -44,4 +48,5 @@ __all__ = [
     "merge_candidate_signals",
     "merge_graph_features",
     "normalize_candidate_signals",
+    "validate_multiplier_mapping",
 ]

--- a/src/main_core/l3_features/candidate_signals.py
+++ b/src/main_core/l3_features/candidate_signals.py
@@ -71,15 +71,15 @@ def normalize_candidate_signals(
                 "candidate signal records must match the requested cycle_id"
             )
 
+        if str(record.entity_id) != str(entity_id):
+            continue
+
         record_key = (str(record.entity_id), record.source, record.signal_name)
         if record_key in seen_record_keys:
             raise CandidateSignalError(
                 "candidate signal records contain duplicate entity/source/signal_name"
             )
         seen_record_keys.add(record_key)
-
-        if str(record.entity_id) != str(entity_id):
-            continue
 
         if record.signal_name in normalized:
             raise CandidateSignalError(

--- a/src/main_core/l3_features/feature_math.py
+++ b/src/main_core/l3_features/feature_math.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from decimal import Decimal
 from math import isfinite
 
 from main_core.l1_l2_basis.models import MarketBar
 from main_core.l3_features.errors import InvalidMultiplierError
+from main_core.l3_features.multiplier_store import validate_multiplier_mapping
 
 
 def market_bar_feature_values(market_bar: MarketBar) -> dict[str, float]:
@@ -27,13 +29,16 @@ def apply_feature_weight_multiplier(
 ) -> tuple[dict[str, float], dict[str, float]]:
     """Apply known feature multipliers and return weighted features plus effective weights."""
 
+    validated_multipliers = validate_multiplier_mapping(multipliers)
     effective_multipliers = {
-        feature_name: float(multipliers.get(feature_name, 1.0))
+        feature_name: float(validated_multipliers.get(feature_name, 1.0))
         for feature_name in feature_values
     }
     weighted_feature_values = {}
     for feature_name, feature_value in feature_values.items():
-        weighted_feature_value = feature_value * effective_multipliers[feature_name]
+        weighted_feature_value = float(
+            Decimal(str(feature_value)) * Decimal(str(effective_multipliers[feature_name]))
+        )
         if not isfinite(weighted_feature_value):
             raise InvalidMultiplierError(
                 "weighted feature values must be finite after applying multipliers"

--- a/src/main_core/l3_features/graph_adapter.py
+++ b/src/main_core/l3_features/graph_adapter.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from main_core.common.protocols import GraphSnapshotError as _GraphSnapshotError
+from main_core.common.json_like import to_plain_json_like
+from main_core.common.protocols import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+)
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.types import CycleId, EntityId
-
-if TYPE_CHECKING:
-    from main_core.common.protocols import GraphEnginePort, GraphImpactRecord
 
 
 def load_graph_features(
@@ -27,7 +30,7 @@ def load_graph_features(
     matching_records: list[GraphImpactRecord] = []
     for record in records:
         if str(record.cycle_id) != str(cycle_id):
-            raise _GraphSnapshotError(
+            raise GraphSnapshotError(
                 "graph impact snapshot contains records from a different cycle"
             )
         if str(record.entity_id) == str(entity_id):
@@ -36,14 +39,14 @@ def load_graph_features(
     if not matching_records:
         return {}
     if len(matching_records) > 1:
-        raise _GraphSnapshotError(
+        raise GraphSnapshotError(
             "graph impact snapshot contains duplicate records for entity"
         )
 
     record = matching_records[0]
     return {
         "snapshot_id": record.snapshot_id,
-        "features": _to_plain_json_like(record.features),
+        "features": to_plain_json_like(record.features),
     }
 
 
@@ -53,20 +56,14 @@ def merge_graph_features(
 ) -> FeatureSignalBundle:
     """Return a new feature bundle with graph features merged in."""
 
-    return bundle.model_copy(
-        update={"graph_features": _to_plain_json_like(graph_features)}
-    )
-
-
-def _to_plain_json_like(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _to_plain_json_like(item) for key, item in value.items()}
-    if isinstance(value, tuple | list):
-        return [_to_plain_json_like(item) for item in value]
-    return value
+    return bundle.model_copy(update={"graph_features": to_plain_json_like(graph_features)})
 
 
 __all__ = [
+    "GraphEnginePort",
+    "GraphImpactRecord",
+    "GraphRegimeContext",
+    "GraphSnapshotError",
     "load_graph_features",
     "merge_graph_features",
 ]

--- a/src/main_core/l3_features/multiplier_store.py
+++ b/src/main_core/l3_features/multiplier_store.py
@@ -46,7 +46,7 @@ class InMemoryMultiplierStore:
     ) -> None:
         """Validate and store multiplier updates for the requested cycle."""
 
-        validated_updates = _validated_multiplier_copy(updates)
+        validated_updates = validate_multiplier_mapping(updates)
         cycle_key = str(cycle_id)
         with self._lock:
             current_multipliers = dict(self._multipliers_by_cycle.get(cycle_key, {}))
@@ -54,7 +54,9 @@ class InMemoryMultiplierStore:
             self._multipliers_by_cycle[cycle_key] = current_multipliers
 
 
-def _validated_multiplier_copy(updates: Mapping[str, float]) -> dict[str, float]:
+def validate_multiplier_mapping(updates: Mapping[str, float]) -> dict[str, float]:
+    """Return a validated float copy of feature multiplier updates."""
+
     invalid_keys = [
         feature_name
         for feature_name, multiplier in updates.items()
@@ -68,4 +70,4 @@ def _validated_multiplier_copy(updates: Mapping[str, float]) -> dict[str, float]
     return {feature_name: float(multiplier) for feature_name, multiplier in updates.items()}
 
 
-__all__ = ["InMemoryMultiplierStore", "MultiplierStore"]
+__all__ = ["InMemoryMultiplierStore", "MultiplierStore", "validate_multiplier_mapping"]

--- a/src/main_core/l3_features/weight_api.py
+++ b/src/main_core/l3_features/weight_api.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from main_core.common.types import CycleId
-from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+from main_core.l3_features.multiplier_store import (
+    InMemoryMultiplierStore,
+    MultiplierStore,
+    validate_multiplier_mapping,
+)
 
 _DEFAULT_MULTIPLIER_STORE = InMemoryMultiplierStore()
 
@@ -18,7 +22,8 @@ def apply_weight_multiplier(
 ) -> None:
     """Apply feature weight multiplier updates for a cycle."""
 
-    _resolve_store(store).put_multipliers(cycle_id, updates)
+    validated_updates = validate_multiplier_mapping(updates)
+    _resolve_store(store).put_multipliers(cycle_id, validated_updates)
 
 
 def get_feature_weight_multiplier(
@@ -28,7 +33,7 @@ def get_feature_weight_multiplier(
 ) -> dict[str, float]:
     """Return the currently visible feature weight multipliers for a cycle."""
 
-    return dict(_resolve_store(store).get_multipliers(cycle_id))
+    return validate_multiplier_mapping(_resolve_store(store).get_multipliers(cycle_id))
 
 
 def _resolve_store(store: MultiplierStore | None) -> MultiplierStore:

--- a/src/main_core/l4_world_state/graph_adapter.py
+++ b/src/main_core/l4_world_state/graph_adapter.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from main_core.common.contexts import WorldStateInputs
+from main_core.common.json_like import to_plain_json_like
 from main_core.common.protocols import GraphEnginePort, GraphSnapshotError
 from main_core.common.types import CycleId
 
@@ -29,7 +30,7 @@ def load_graph_regime_context(
 
     return {
         "snapshot_id": context.snapshot_id,
-        "regime_context": _to_plain_json_like(context.regime_context),
+        "regime_context": to_plain_json_like(context.regime_context),
     }
 
 
@@ -44,17 +45,9 @@ def with_graph_impact(
             "cycle_id": inputs.cycle_id,
             "feature_bundle": inputs.feature_bundle,
             "macro_context": dict(inputs.macro_context),
-            "graph_impact": _to_plain_json_like(graph_impact) if graph_impact else {},
+            "graph_impact": to_plain_json_like(graph_impact) if graph_impact else {},
         }
     )
-
-
-def _to_plain_json_like(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _to_plain_json_like(item) for key, item in value.items()}
-    if isinstance(value, tuple | list):
-        return [_to_plain_json_like(item) for item in value]
-    return value
 
 
 __all__ = ["load_graph_regime_context", "with_graph_impact"]

--- a/src/main_core/l6_alpha/__init__.py
+++ b/src/main_core/l6_alpha/__init__.py
@@ -1,6 +1,7 @@
 """L6 package: single-stock alpha analysis."""
 
 from main_core.l6_alpha.ab_runner import run_ab_evaluation, write_ab_report
+from main_core.l6_alpha.errors import AlphaAnalyzerError, AlphaReasonerError
 from main_core.l6_alpha.fallback import build_inconclusive_result
 from main_core.l6_alpha.multi_agent_analyzer import (
     AgentRoleConfig,
@@ -19,8 +20,10 @@ from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
 
 __all__ = [
     "AgentRoleConfig",
+    "AlphaAnalyzerError",
     "AlphaReasonerPort",
     "AlphaReasonerResponse",
+    "AlphaReasonerError",
     "MultiAgentAnalyzer",
     "MultiAgentReasonerPort",
     "MultiAgentRoleResult",

--- a/src/main_core/l6_alpha/__init__.py
+++ b/src/main_core/l6_alpha/__init__.py
@@ -21,9 +21,9 @@ from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
 __all__ = [
     "AgentRoleConfig",
     "AlphaAnalyzerError",
+    "AlphaReasonerError",
     "AlphaReasonerPort",
     "AlphaReasonerResponse",
-    "AlphaReasonerError",
     "MultiAgentAnalyzer",
     "MultiAgentReasonerPort",
     "MultiAgentRoleResult",

--- a/src/main_core/l6_alpha/ab_runner.py
+++ b/src/main_core/l6_alpha/ab_runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.protocols import AnalyzerInterface
+from main_core.common.schemas import AlphaResultSnapshot, AnalyzerType
 from main_core.common.types import EntityId
 
 
@@ -42,6 +43,10 @@ class AbCaseResult:
     score_delta: float | None
     confidence_delta: float
     status_matches: bool
+    baseline_error: str | None = None
+    challenger_error: str | None = None
+    baseline_diagnostics: dict[str, object] | None = None
+    challenger_diagnostics: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)
@@ -57,6 +62,9 @@ class AbEvaluationReport:
     baseline_inconclusive_count: int
     challenger_inconclusive_count: int
     inconclusive_count_delta: int
+    baseline_failure_count: int
+    challenger_failure_count: int
+    failure_count_delta: int
     cases: tuple[AbCaseResult, ...]
 
 
@@ -68,16 +76,27 @@ def run_ab_evaluation(
 ) -> AbEvaluationReport:
     """Run baseline and challenger analyzers on the same supplied contexts."""
 
+    if not cases:
+        raise ValueError("A/B evaluation cases must not be empty")
+
     case_results: list[AbCaseResult] = []
     score_abs_deltas: list[float] = []
     confidence_abs_deltas: list[float] = []
     status_match_count = 0
     baseline_inconclusive_count = 0
     challenger_inconclusive_count = 0
+    baseline_failure_count = 0
+    challenger_failure_count = 0
 
     for case in cases:
-        baseline_result = baseline.analyze(case.entity_id, case.context)
-        challenger_result = challenger.analyze(case.entity_id, case.context)
+        baseline_run = _run_analyzer(baseline, case)
+        challenger_run = _run_analyzer(challenger, case)
+        baseline_result = baseline_run.result
+        challenger_result = challenger_run.result
+        if baseline_run.error is not None:
+            baseline_failure_count += 1
+        if challenger_run.error is not None:
+            challenger_failure_count += 1
 
         status_matches = baseline_result.status == challenger_result.status
         if status_matches:
@@ -111,6 +130,10 @@ def run_ab_evaluation(
                 score_delta=score_delta,
                 confidence_delta=confidence_delta,
                 status_matches=status_matches,
+                baseline_error=baseline_run.error,
+                challenger_error=challenger_run.error,
+                baseline_diagnostics=baseline_run.diagnostics,
+                challenger_diagnostics=challenger_run.diagnostics,
             )
         )
 
@@ -129,6 +152,9 @@ def run_ab_evaluation(
         inconclusive_count_delta=(
             challenger_inconclusive_count - baseline_inconclusive_count
         ),
+        baseline_failure_count=baseline_failure_count,
+        challenger_failure_count=challenger_failure_count,
+        failure_count_delta=challenger_failure_count - baseline_failure_count,
         cases=tuple(case_results),
     )
 
@@ -152,6 +178,9 @@ def format_ab_report_markdown(report: AbEvaluationReport) -> str:
         ("baseline_inconclusive_count", report.baseline_inconclusive_count),
         ("challenger_inconclusive_count", report.challenger_inconclusive_count),
         ("inconclusive_count_delta", report.inconclusive_count_delta),
+        ("baseline_failure_count", report.baseline_failure_count),
+        ("challenger_failure_count", report.challenger_failure_count),
+        ("failure_count_delta", report.failure_count_delta),
     ]
     lines = [
         "# L6 A/B Evaluation",
@@ -206,6 +235,9 @@ def _report_payload(report: AbEvaluationReport) -> dict[str, object]:
         "baseline_inconclusive_count": report.baseline_inconclusive_count,
         "challenger_inconclusive_count": report.challenger_inconclusive_count,
         "inconclusive_count_delta": report.inconclusive_count_delta,
+        "baseline_failure_count": report.baseline_failure_count,
+        "challenger_failure_count": report.challenger_failure_count,
+        "failure_count_delta": report.failure_count_delta,
         "cases": [_case_payload(case) for case in report.cases],
     }
 
@@ -225,7 +257,54 @@ def _case_payload(case: AbCaseResult) -> dict[str, object]:
         "score_delta": case.score_delta,
         "confidence_delta": case.confidence_delta,
         "status_matches": case.status_matches,
+        "baseline_error": case.baseline_error,
+        "challenger_error": case.challenger_error,
+        "baseline_diagnostics": case.baseline_diagnostics,
+        "challenger_diagnostics": case.challenger_diagnostics,
     }
+
+
+@dataclass(frozen=True)
+class _AnalyzerRun:
+    result: AlphaResultSnapshot
+    error: str | None
+    diagnostics: dict[str, object] | None
+
+
+def _run_analyzer(
+    analyzer: AnalyzerInterface,
+    case: AbEvaluationCase,
+) -> _AnalyzerRun:
+    try:
+        result = analyzer.analyze(case.entity_id, case.context)
+    except Exception as exc:  # noqa: BLE001
+        return _AnalyzerRun(
+            result=AlphaResultSnapshot(
+                cycle_id=case.context.cycle_id,
+                entity_id=case.entity_id,
+                analyzer_type=_safe_analyzer_type(analyzer),
+                score=None,
+                confidence=0.0,
+                rationale=f"inconclusive: analyzer failed: {exc}",
+                similar_cases=[],
+                status="inconclusive",
+                diagnostics={"error": type(exc).__name__, "message": str(exc)},
+            ),
+            error=f"{type(exc).__name__}: {exc}",
+            diagnostics={"error": type(exc).__name__, "message": str(exc)},
+        )
+    return _AnalyzerRun(
+        result=result,
+        error=None,
+        diagnostics=dict(result.diagnostics) if result.diagnostics else None,
+    )
+
+
+def _safe_analyzer_type(analyzer: AnalyzerInterface) -> AnalyzerType:
+    analyzer_type = analyzer.analyzer_type
+    if analyzer_type in ("single_prompt_v1", "multi_agent_v1"):
+        return analyzer_type
+    return "single_prompt_v1"
 
 
 def _case_markdown_row(case: AbCaseResult) -> str:

--- a/src/main_core/l6_alpha/ab_runner.py
+++ b/src/main_core/l6_alpha/ab_runner.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.protocols import AnalyzerInterface
-from main_core.common.schemas import AlphaResultSnapshot, AnalyzerType
+from main_core.common.schemas import AlphaResultSnapshot
 from main_core.common.types import EntityId
 
 
@@ -278,11 +278,15 @@ def _run_analyzer(
     try:
         result = analyzer.analyze(case.entity_id, case.context)
     except Exception as exc:  # noqa: BLE001
+        try:
+            analyzer_type = analyzer.analyzer_type
+        except Exception:
+            raise exc from None
         return _AnalyzerRun(
             result=AlphaResultSnapshot(
                 cycle_id=case.context.cycle_id,
                 entity_id=case.entity_id,
-                analyzer_type=_safe_analyzer_type(analyzer),
+                analyzer_type=analyzer_type,
                 score=None,
                 confidence=0.0,
                 rationale=f"inconclusive: analyzer failed: {exc}",
@@ -298,13 +302,6 @@ def _run_analyzer(
         error=None,
         diagnostics=dict(result.diagnostics) if result.diagnostics else None,
     )
-
-
-def _safe_analyzer_type(analyzer: AnalyzerInterface) -> AnalyzerType:
-    analyzer_type = analyzer.analyzer_type
-    if analyzer_type in ("single_prompt_v1", "multi_agent_v1"):
-        return analyzer_type
-    return "single_prompt_v1"
 
 
 def _case_markdown_row(case: AbCaseResult) -> str:

--- a/src/main_core/l6_alpha/errors.py
+++ b/src/main_core/l6_alpha/errors.py
@@ -1,0 +1,16 @@
+"""Shared L6 alpha analyzer error types."""
+
+from __future__ import annotations
+
+from main_core.common.errors import MainCoreError
+
+
+class AlphaAnalyzerError(MainCoreError):
+    """Raised when the L6 analyzer contract is violated before provider work."""
+
+
+class AlphaReasonerError(MainCoreError):
+    """Raised when the L6 reasoner provider returns malformed infrastructure output."""
+
+
+__all__ = ["AlphaAnalyzerError", "AlphaReasonerError"]

--- a/src/main_core/l6_alpha/fallback.py
+++ b/src/main_core/l6_alpha/fallback.py
@@ -9,7 +9,6 @@ from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError
 from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
 from main_core.common.types import EntityId
-from main_core.l6_alpha.reasoner_port import AlphaReasonerResponse
 
 
 def build_inconclusive_result(
@@ -36,9 +35,7 @@ def build_inconclusive_result(
 def is_task_level_failure(error: BaseException) -> bool:
     """Return whether an exception should be downgraded to inconclusive."""
 
-    return isinstance(error, InconclusiveError) or (
-        isinstance(error, AlphaReasonerResponse) and error.task_failed
-    )
+    return isinstance(error, InconclusiveError)
 
 
 __all__ = ["build_inconclusive_result", "is_task_level_failure"]

--- a/src/main_core/l6_alpha/multi_agent_analyzer.py
+++ b/src/main_core/l6_alpha/multi_agent_analyzer.py
@@ -10,10 +10,11 @@ from typing import Any, ClassVar, Protocol, runtime_checkable
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
+from main_core.common.json_like import to_plain_json_like
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot
 from main_core.common.types import EntityId
-from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
+from main_core.l6_alpha.errors import AlphaAnalyzerError
 
 DEFAULT_MULTI_AGENT_ROLES: tuple[str, ...] = ("fundamental", "technical", "risk")
 
@@ -86,7 +87,7 @@ class StaticMultiAgentReasonerPort:
         role: AgentRoleConfig,
         payload: Mapping[str, Any],
     ) -> MultiAgentRoleResult:
-        """Return a configured role result or a stable zero-score default."""
+        """Return a configured role result or an explicit static inconclusive."""
 
         self.calls.append((entity_id, context, role, payload))
         if role.name in self.role_results:
@@ -94,10 +95,12 @@ class StaticMultiAgentReasonerPort:
 
         return MultiAgentRoleResult(
             role=role.name,
-            score=0.0,
+            score=None,
             confidence=0.0,
-            rationale=f"static {role.name} alpha analysis",
+            rationale=f"static {role.name} alpha analysis is not configured",
             evidence={"role": role.name},
+            task_failed=True,
+            failure_reason="static multi-agent role result is not configured",
         )
 
 
@@ -149,6 +152,7 @@ def aggregate_role_results(
                 "confidence": 0.0,
                 "rationale": _all_failed_rationale(failed_results, roles),
                 "status": "inconclusive",
+                "diagnostics": _role_diagnostics(result_map.values(), roles),
             },
         )
 
@@ -170,6 +174,7 @@ def aggregate_role_results(
             "confidence": weighted_confidence,
             "rationale": _aggregate_rationale(healthy_results, failed_results),
             "status": "ok",
+            "diagnostics": _role_diagnostics(result_map.values(), roles),
         },
     )
 
@@ -224,6 +229,10 @@ class MultiAgentAnalyzer(AnalyzerBase):
                 )
             except MainCoreError:
                 raise
+            if result.role != role.name:
+                raise AlphaAnalyzerError(
+                    f"role result {result.role!r} does not match configured role {role.name!r}"
+                )
             role_results.append(result)
 
         return aggregate_role_results(
@@ -248,6 +257,7 @@ def _multi_agent_result(
         rationale=fields["rationale"],
         similar_cases=[dict(case) for case in context.similar_cases],
         status=fields["status"],
+        diagnostics=dict(fields.get("diagnostics", {})),
     )
 
 
@@ -274,6 +284,10 @@ def _role_result_map(
         if result.role in result_map:
             raise AlphaAnalyzerError(f"duplicate role result: {result.role}")
         result_map[result.role] = result
+    missing_roles = set(role_weight_map) - set(result_map)
+    if missing_roles:
+        missing = ", ".join(sorted(missing_roles))
+        raise AlphaAnalyzerError(f"missing role result for configured roles: {missing}")
     return result_map
 
 
@@ -308,6 +322,35 @@ def _all_failed_rationale(
         role_names = ", ".join(sorted(role.name for role in roles))
         failures = f"no successful role results for roles: {role_names}"
     return f"inconclusive: all multi-agent roles failed: {failures}"
+
+
+def _role_diagnostics(
+    role_results: Sequence[MultiAgentRoleResult],
+    roles: Sequence[AgentRoleConfig],
+) -> dict[str, Any]:
+    role_weights = {role.name: role.weight for role in roles}
+    ordered_results = sorted(role_results, key=lambda result: result.role)
+    return {
+        "analyzer_type": "multi_agent_v1",
+        "roles": [
+            {
+                "role": result.role,
+                "configured_weight": role_weights[result.role],
+                "status": "inconclusive" if result.task_failed else "ok",
+                "score": result.score,
+                "confidence": result.confidence,
+                "rationale": result.rationale,
+                "evidence": to_plain_json_like(result.evidence),
+                "failure_reason": result.failure_reason,
+            }
+            for result in ordered_results
+        ],
+        "failed_roles": [
+            result.role
+            for result in ordered_results
+            if result.task_failed
+        ],
+    }
 
 
 def _plain_value(value: Any) -> Any:

--- a/src/main_core/l6_alpha/single_prompt_analyzer.py
+++ b/src/main_core/l6_alpha/single_prompt_analyzer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from math import isfinite
 from typing import ClassVar
 
 from main_core.common.contexts import AlphaAnalysisContext
@@ -9,18 +10,16 @@ from main_core.common.errors import MainCoreError
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
 from main_core.common.types import EntityId
+from main_core.l6_alpha.errors import AlphaAnalyzerError, AlphaReasonerError
 from main_core.l6_alpha.fallback import (
     build_inconclusive_result,
     is_task_level_failure,
 )
 from main_core.l6_alpha.reasoner_port import (
     AlphaReasonerPort,
+    AlphaReasonerResponse,
     StaticAlphaReasonerPort,
 )
-
-
-class AlphaAnalyzerError(MainCoreError):
-    """Raised when the L6 analyzer contract is violated before provider work."""
 
 
 class SinglePromptAnalyzer(AnalyzerBase):
@@ -46,7 +45,9 @@ class SinglePromptAnalyzer(AnalyzerBase):
         except Exception as exc:
             if is_task_level_failure(exc):
                 return build_inconclusive_result(entity_id, context, str(exc))
-            raise
+            if isinstance(exc, MainCoreError):
+                raise
+            raise AlphaReasonerError("alpha reasoner failed") from exc
 
         if response.task_failed:
             reason = response.failure_reason or response.rationale or "alpha task failed"
@@ -57,6 +58,7 @@ class SinglePromptAnalyzer(AnalyzerBase):
                 similar_cases=response.similar_cases,
             )
 
+        _validate_successful_response(response)
         return single_prompt_result(
             cycle_id=context.cycle_id,
             entity_id=entity_id,
@@ -66,6 +68,17 @@ class SinglePromptAnalyzer(AnalyzerBase):
             similar_cases=response.similar_cases,
             status="ok",
         )
+
+
+def _validate_successful_response(response: AlphaReasonerResponse) -> None:
+    if response.score is None or not isfinite(response.score):
+        raise AlphaReasonerError("successful alpha response score must be finite")
+    if not isfinite(response.confidence) or not 0.0 <= response.confidence <= 1.0:
+        raise AlphaReasonerError(
+            "successful alpha response confidence must be finite and within 0.0..1.0"
+        )
+    if not response.rationale.strip():
+        raise AlphaReasonerError("successful alpha response rationale must be non-empty")
 
 
 __all__ = ["AlphaAnalyzerError", "SinglePromptAnalyzer"]

--- a/src/main_core/l7_recommendation/__init__.py
+++ b/src/main_core/l7_recommendation/__init__.py
@@ -8,6 +8,7 @@ from main_core.l7_recommendation.override import (
     find_override,
     submit_override,
 )
+from main_core.l7_recommendation.rules import action_for_score, rating_for_action
 from main_core.l7_recommendation.service import generate_recommendations
 
 __all__ = [
@@ -15,7 +16,9 @@ __all__ = [
     "InMemoryOverrideStore",
     "OverrideStore",
     "apply_override",
+    "action_for_score",
     "find_override",
     "generate_recommendations",
+    "rating_for_action",
     "submit_override",
 ]

--- a/src/main_core/l7_recommendation/override.py
+++ b/src/main_core/l7_recommendation/override.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 from main_core.common.errors import MainCoreError
 from main_core.common.schemas import OverrideRecord, RecommendationSnapshot
 from main_core.common.types import CycleId, EntityId
+from main_core.l7_recommendation.rules import rating_for_action
 
 
 class OverrideStore(Protocol):
@@ -56,7 +57,7 @@ def submit_override(
     """Validate, store, and return a human override record."""
 
     override = _coerce_override(override_input)
-    active_store = store or _DEFAULT_OVERRIDE_STORE
+    active_store = store if store is not None else _DEFAULT_OVERRIDE_STORE
     return active_store.save(override)
 
 
@@ -67,7 +68,7 @@ def find_override(
 ) -> OverrideRecord | None:
     """Return the first override matching a cycle/entity pair."""
 
-    for override in overrides:
+    for override in reversed(overrides):
         if override.cycle_id == cycle_id and override.entity_id == entity_id:
             return override
     return None
@@ -94,7 +95,7 @@ def apply_override(
         updates["rating"] = None
         updates["confidence"] = None
     else:
-        updates["rating"] = _rating_for_action(override.action_type)
+        updates["rating"] = rating_for_action(override.action_type)
 
     return candidate.model_copy(update=updates)
 
@@ -103,15 +104,6 @@ def _coerce_override(override_input: OverrideRecord | Mapping[str, Any]) -> Over
     if isinstance(override_input, OverrideRecord):
         return override_input.model_copy()
     return OverrideRecord.model_validate(dict(override_input))
-
-
-def _rating_for_action(action_type: str) -> str:
-    ratings = {
-        "buy": "A",
-        "hold": "B",
-        "reduce": "C",
-    }
-    return ratings[action_type]
 
 
 __all__ = [

--- a/src/main_core/l7_recommendation/rules.py
+++ b/src/main_core/l7_recommendation/rules.py
@@ -1,0 +1,38 @@
+"""Shared deterministic L7 recommendation rules."""
+
+from __future__ import annotations
+
+from main_core.common.schemas import ActionType
+
+BUY_SCORE_THRESHOLD = 0.65
+REDUCE_SCORE_THRESHOLD = 0.35
+
+_RATING_BY_ACTION: dict[str, str] = {
+    "buy": "A",
+    "hold": "B",
+    "reduce": "C",
+}
+
+
+def action_for_score(score: float) -> ActionType:
+    """Map a validated alpha score into the deterministic action bucket."""
+
+    if score >= BUY_SCORE_THRESHOLD:
+        return "buy"
+    if score <= REDUCE_SCORE_THRESHOLD:
+        return "reduce"
+    return "hold"
+
+
+def rating_for_action(action_type: ActionType | str) -> str:
+    """Map a non-inconclusive recommendation action to its formal rating."""
+
+    return _RATING_BY_ACTION[str(action_type)]
+
+
+__all__ = [
+    "BUY_SCORE_THRESHOLD",
+    "REDUCE_SCORE_THRESHOLD",
+    "action_for_score",
+    "rating_for_action",
+]

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -23,9 +23,12 @@ from main_core.l7_recommendation.override import (
     apply_override,
     find_override,
 )
-
-BUY_SCORE_THRESHOLD = 0.65
-REDUCE_SCORE_THRESHOLD = 0.35
+from main_core.l7_recommendation.rules import (
+    BUY_SCORE_THRESHOLD,
+    REDUCE_SCORE_THRESHOLD,
+    action_for_score,
+    rating_for_action,
+)
 
 
 def generate_recommendations(  # noqa: PLR0913
@@ -164,12 +167,12 @@ def _candidate_from_analysis(analysis: AlphaResultSnapshot) -> RecommendationSna
     if not math.isfinite(analysis.confidence):
         raise MainCoreError("ok analysis confidence must be finite")
 
-    action_type = _action_for_score(analysis.score)
+    action_type = action_for_score(analysis.score)
     return RecommendationSnapshot(
         cycle_id=analysis.cycle_id,
         entity_id=analysis.entity_id,
         action_type=action_type,
-        rating=_rating_for_action(action_type),
+        rating=rating_for_action(action_type),
         confidence=analysis.confidence,
         triggered_by="system",
         override_applied=False,
@@ -202,23 +205,6 @@ def _validate_gated_identity(
         raise MainCoreError("constraint gate must preserve recommendation cycle_id")
     if candidate.entity_id != entity_id:
         raise MainCoreError("constraint gate must preserve recommendation entity_id")
-
-
-def _action_for_score(score: float) -> str:
-    if score >= BUY_SCORE_THRESHOLD:
-        return "buy"
-    if score <= REDUCE_SCORE_THRESHOLD:
-        return "reduce"
-    return "hold"
-
-
-def _rating_for_action(action_type: str) -> str:
-    ratings = {
-        "buy": "A",
-        "hold": "B",
-        "reduce": "C",
-    }
-    return ratings[action_type]
 
 
 __all__ = [

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -18,6 +18,10 @@ from main_core.l8_publish.audit_payload import (
     build_audit_payload,
     build_retrospective_seed,
 )
+from main_core.l8_publish.bundle_entries import (
+    build_bundle_formal_object_entry,
+    ordered_formal_object_keys,
+)
 from main_core.l8_publish.manifest import (
     build_manifest_candidate,
     commit_formal_objects,
@@ -32,7 +36,6 @@ from main_core.l8_publish.publish_port import (
 )
 from main_core.l8_publish.refs import (
     ALPHA_RESULT_SNAPSHOT_KEY,
-    CANONICAL_FORMAL_OBJECT_KEYS,
     OFFICIAL_ALPHA_POOL_KEY,
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
@@ -320,50 +323,15 @@ def _build_bundle_formal_objects(
         for committed in committed_objects
     }
     bundle_formal_objects: dict[str, dict[str, Any]] = {}
-    for object_key in _ordered_object_keys(formal_objects):
+    for object_key in ordered_formal_object_keys(formal_objects):
         committed_object = committed_by_key.get(object_key)
         if committed_object is None:
             raise ManifestPublishError(f"missing commit result for {object_key}")
-        bundle_formal_objects[object_key] = _bundle_formal_object_entry(
+        bundle_formal_objects[object_key] = build_bundle_formal_object_entry(
             formal_objects[object_key],
             committed_object.ref,
         )
     return bundle_formal_objects
-
-
-def _bundle_formal_object_entry(
-    value: FormalObjectValue,
-    ref: str,
-) -> dict[str, Any]:
-    payload = _bundle_payload(value)
-    return {
-        "ref": ref,
-        "payload": payload,
-        "count": len(payload) if isinstance(payload, list) else 1,
-    }
-
-
-def _bundle_payload(value: FormalObjectValue) -> dict[str, Any] | list[dict[str, Any]]:
-    if isinstance(value, FormalObjectBase):
-        return value.model_dump(mode="json")
-    return [
-        item.model_dump(mode="json")
-        for item in value
-    ]
-
-
-def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
-    canonical_keys = [
-        object_key
-        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
-        if object_key in formal_objects
-    ]
-    derived_keys = [
-        object_key
-        for object_key in formal_objects
-        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
-    ]
-    return (*canonical_keys, *derived_keys)
 
 
 __all__ = ["collect_formal_objects", "prepare_publish_bundle"]

--- a/src/main_core/l8_publish/audit_payload.py
+++ b/src/main_core/l8_publish/audit_payload.py
@@ -28,6 +28,16 @@ def build_audit_payload(
 
     alpha_results = _payload_list(formal_objects, ALPHA_RESULT_SNAPSHOT_KEY)
     recommendations = _payload_list(formal_objects, RECOMMENDATION_SNAPSHOT_KEY)
+    alpha_inconclusive_count = sum(
+        1
+        for alpha_result in alpha_results
+        if alpha_result.get("status") == "inconclusive"
+    )
+    recommendation_inconclusive_count = sum(
+        1
+        for recommendation in recommendations
+        if recommendation.get("action_type") == "inconclusive"
+    )
 
     return {
         "cycle_id": str(cycle_id),
@@ -35,11 +45,9 @@ def build_audit_payload(
         "commit_refs": _commit_refs(committed_objects),
         "manifest_ref": manifest.manifest_ref,
         "manifest_version": manifest.manifest_version,
-        "inconclusive_count": sum(
-            1
-            for alpha_result in alpha_results
-            if alpha_result.get("status") == "inconclusive"
-        ),
+        "inconclusive_count": recommendation_inconclusive_count,
+        "alpha_inconclusive_count": alpha_inconclusive_count,
+        "recommendation_inconclusive_count": recommendation_inconclusive_count,
         "override_applied_count": sum(
             1
             for recommendation in recommendations

--- a/src/main_core/l8_publish/bundle_entries.py
+++ b/src/main_core/l8_publish/bundle_entries.py
@@ -1,0 +1,198 @@
+"""Shared helpers for ordered L8 formal object bundle entries."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import FormalObjectBase, PublishBundle
+from main_core.common.types import CycleId
+from main_core.l8_publish.publish_port import FormalObjectValue
+from main_core.l8_publish.refs import CANONICAL_FORMAL_OBJECT_KEYS
+
+PayloadShape = Literal["mapping", "list"]
+MIN_CANONICAL_REF_PARTS = 2
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class FormalObjectEntry:
+    """Validated entry from a PublishBundle.formal_objects mapping."""
+
+    ref: str
+    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...]
+    count: int
+
+
+def ordered_formal_object_keys(formal_objects: Mapping[str, object]) -> tuple[str, ...]:
+    """Return canonical L4-L7 keys first, followed by derived keys in insertion order."""
+
+    canonical_keys = [
+        object_key
+        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
+        if object_key in formal_objects
+    ]
+    derived_keys = [
+        object_key
+        for object_key in formal_objects
+        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
+    ]
+    return (*canonical_keys, *derived_keys)
+
+
+def build_bundle_formal_object_entry(
+    value: FormalObjectValue,
+    ref: str,
+) -> dict[str, Any]:
+    """Build the canonical PublishBundle.formal_objects entry for one object key."""
+
+    payload = _bundle_payload(value)
+    return {
+        "ref": ref,
+        "payload": payload,
+        "count": len(payload) if isinstance(payload, list) else 1,
+    }
+
+
+def parse_bundle_formal_object_entry(
+    bundle: PublishBundle,
+    object_key: str,
+    cycle_id: CycleId,
+    *,
+    payload_shape: PayloadShape,
+) -> FormalObjectEntry:
+    """Validate and parse one committed formal object entry from a publish bundle."""
+
+    if bundle.cycle_id != cycle_id:
+        raise ManifestPublishError("publish bundle cycle_id must match requested cycle_id")
+
+    entry = _entry_mapping(bundle, object_key)
+    ref = _entry_ref(entry, object_key)
+    validate_formal_object_ref_cycle(object_key, ref, cycle_id)
+
+    if payload_shape == "mapping":
+        return _mapping_entry(entry, object_key, ref, cycle_id)
+    return _list_entry(entry, object_key, ref, cycle_id)
+
+
+def validate_formal_object_ref_cycle(
+    object_key: str,
+    ref: str,
+    cycle_id: CycleId,
+) -> None:
+    """Require the canonical object ref shape to include the exact requested cycle."""
+
+    parts = ref.split("/")
+    if (
+        len(parts) < MIN_CANONICAL_REF_PARTS
+        or parts[0] != object_key
+        or parts[1] != str(cycle_id)
+    ):
+        raise ManifestPublishError(f"{object_key}.ref must point to requested cycle_id")
+
+
+def _bundle_payload(value: FormalObjectValue) -> dict[str, Any] | list[dict[str, Any]]:
+    if isinstance(value, FormalObjectBase):
+        return value.model_dump(mode="json")
+    return [
+        item.model_dump(mode="json")
+        for item in value
+    ]
+
+
+def _mapping_entry(
+    entry: Mapping[str, Any],
+    object_key: str,
+    ref: str,
+    cycle_id: CycleId,
+) -> FormalObjectEntry:
+    payload = entry.get("payload", _MISSING)
+    if not isinstance(payload, Mapping):
+        raise ManifestPublishError(f"{object_key}.payload must be a mapping")
+
+    count = _entry_count(entry, object_key)
+    if count != 1:
+        raise ManifestPublishError(f"{object_key}.count must be 1")
+    _ensure_payload_cycle(object_key, payload, cycle_id)
+    return FormalObjectEntry(ref=ref, payload=dict(payload), count=count)
+
+
+def _list_entry(
+    entry: Mapping[str, Any],
+    object_key: str,
+    ref: str,
+    cycle_id: CycleId,
+) -> FormalObjectEntry:
+    payload = entry.get("payload", _MISSING)
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
+        raise ManifestPublishError(f"{object_key}.payload must be a list")
+
+    payload_items: list[Mapping[str, Any]] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, Mapping):
+            raise ManifestPublishError(
+                f"{object_key}.payload[{index}] must be a mapping"
+            )
+        _ensure_payload_cycle(object_key, item, cycle_id)
+        payload_items.append(dict(item))
+
+    count = _entry_count(entry, object_key)
+    if count != len(payload_items):
+        raise ManifestPublishError(f"{object_key}.count must match payload length")
+    return FormalObjectEntry(ref=ref, payload=tuple(payload_items), count=count)
+
+
+def _entry_mapping(bundle: PublishBundle, object_key: str) -> Mapping[str, Any]:
+    try:
+        entry = bundle.formal_objects[object_key]
+    except KeyError as exc:
+        raise ManifestPublishError(f"missing formal object entry {object_key}") from exc
+    if not isinstance(entry, Mapping):
+        raise ManifestPublishError(f"{object_key} formal object entry must be a mapping")
+    return entry
+
+
+def _entry_ref(entry: Mapping[str, Any], object_key: str) -> str:
+    if "refs" in entry:
+        refs = entry["refs"]
+        if (
+            isinstance(refs, Sequence)
+            and not isinstance(refs, (str, bytes))
+            and all(isinstance(ref, str) for ref in refs)
+        ):
+            if len(refs) == 1:
+                return refs[0]
+            raise ManifestPublishError(f"{object_key} must expose exactly one formal ref")
+        raise ManifestPublishError(f"{object_key}.refs must be a sequence of strings")
+
+    ref = entry.get("ref")
+    if not isinstance(ref, str) or not ref:
+        raise ManifestPublishError(f"{object_key}.ref must be a non-empty string")
+    return ref
+
+
+def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
+    count = entry.get("count", _MISSING)
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        raise ManifestPublishError(f"{object_key}.count must be a non-negative integer")
+    return count
+
+
+def _ensure_payload_cycle(
+    object_key: str,
+    payload: Mapping[str, Any],
+    cycle_id: CycleId,
+) -> None:
+    if payload.get("cycle_id") != str(cycle_id):
+        raise ManifestPublishError(f"{object_key}.payload cycle_id must match")
+
+
+__all__ = [
+    "FormalObjectEntry",
+    "build_bundle_formal_object_entry",
+    "ordered_formal_object_keys",
+    "parse_bundle_formal_object_entry",
+    "validate_formal_object_ref_cycle",
+]

--- a/src/main_core/l8_publish/dashboard.py
+++ b/src/main_core/l8_publish/dashboard.py
@@ -9,33 +9,28 @@ from typing import Any
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import DashboardSnapshot, PublishBundle
 from main_core.common.types import CycleId
+from main_core.l8_publish.bundle_entries import (
+    FormalObjectEntry,
+    parse_bundle_formal_object_entry,
+)
 from main_core.l8_publish.refs import (
     ALPHA_RESULT_SNAPSHOT_KEY,
     OFFICIAL_ALPHA_POOL_KEY,
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
-    formal_object_ref,
 )
 
 DASHBOARD_SNAPSHOT_KEY = "dashboard_snapshot"
 
 _ACTION_TYPES = ("buy", "hold", "reduce", "inconclusive")
-_MISSING = object()
-
-
-@dataclass(frozen=True)
-class _FormalObjectEntry:
-    ref: str
-    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...]
-    count: int
 
 
 @dataclass(frozen=True)
 class _RequiredFormalObjects:
-    world_state: _FormalObjectEntry
-    pool: _FormalObjectEntry
-    alpha_results: _FormalObjectEntry
-    recommendations: _FormalObjectEntry
+    world_state: FormalObjectEntry
+    pool: FormalObjectEntry
+    alpha_results: FormalObjectEntry
+    recommendations: FormalObjectEntry
 
 
 def build_dashboard_snapshot(
@@ -61,14 +56,31 @@ def _extract_required_formal_objects(
     cycle_id: CycleId,
     bundle: PublishBundle,
 ) -> _RequiredFormalObjects:
-    if bundle.cycle_id != cycle_id:
-        raise ManifestPublishError("publish bundle cycle_id must match requested cycle_id")
-
     return _RequiredFormalObjects(
-        world_state=_mapping_entry(bundle, WORLD_STATE_SNAPSHOT_KEY, cycle_id),
-        pool=_mapping_entry(bundle, OFFICIAL_ALPHA_POOL_KEY, cycle_id),
-        alpha_results=_list_entry(bundle, ALPHA_RESULT_SNAPSHOT_KEY, cycle_id),
-        recommendations=_list_entry(bundle, RECOMMENDATION_SNAPSHOT_KEY, cycle_id),
+        world_state=parse_bundle_formal_object_entry(
+            bundle,
+            WORLD_STATE_SNAPSHOT_KEY,
+            cycle_id,
+            payload_shape="mapping",
+        ),
+        pool=parse_bundle_formal_object_entry(
+            bundle,
+            OFFICIAL_ALPHA_POOL_KEY,
+            cycle_id,
+            payload_shape="mapping",
+        ),
+        alpha_results=parse_bundle_formal_object_entry(
+            bundle,
+            ALPHA_RESULT_SNAPSHOT_KEY,
+            cycle_id,
+            payload_shape="list",
+        ),
+        recommendations=parse_bundle_formal_object_entry(
+            bundle,
+            RECOMMENDATION_SNAPSHOT_KEY,
+            cycle_id,
+            payload_shape="list",
+        ),
     )
 
 
@@ -136,80 +148,6 @@ def _build_summary_cards(objects: _RequiredFormalObjects) -> dict[str, Any]:
             "entity_ids": override_entity_ids,
         },
     }
-
-
-def _mapping_entry(
-    bundle: PublishBundle,
-    object_key: str,
-    cycle_id: CycleId,
-) -> _FormalObjectEntry:
-    entry = _entry_mapping(bundle, object_key)
-    ref = formal_object_ref(bundle, object_key)
-    payload = entry.get("payload", _MISSING)
-    if not isinstance(payload, Mapping):
-        raise ManifestPublishError(f"{object_key}.payload must be a mapping")
-
-    count = _entry_count(entry, object_key)
-    if count != 1:
-        raise ManifestPublishError(f"{object_key}.count must be 1")
-    _ensure_payload_cycle(object_key, payload, cycle_id)
-    return _FormalObjectEntry(ref=ref, payload=dict(payload), count=count)
-
-
-def _list_entry(
-    bundle: PublishBundle,
-    object_key: str,
-    cycle_id: CycleId,
-) -> _FormalObjectEntry:
-    entry = _entry_mapping(bundle, object_key)
-    ref = formal_object_ref(bundle, object_key)
-    payload = entry.get("payload", _MISSING)
-    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
-        raise ManifestPublishError(f"{object_key}.payload must be a list")
-
-    payload_items: list[Mapping[str, Any]] = []
-    for index, item in enumerate(payload):
-        if not isinstance(item, Mapping):
-            raise ManifestPublishError(
-                f"{object_key}.payload[{index}] must be a mapping"
-            )
-        _ensure_payload_cycle(object_key, item, cycle_id)
-        payload_items.append(dict(item))
-
-    count = _entry_count(entry, object_key)
-    if count != len(payload_items):
-        raise ManifestPublishError(f"{object_key}.count must match payload length")
-    return _FormalObjectEntry(ref=ref, payload=tuple(payload_items), count=count)
-
-
-def _entry_mapping(bundle: PublishBundle, object_key: str) -> Mapping[str, Any]:
-    try:
-        entry = bundle.formal_objects[object_key]
-    except KeyError as exc:
-        raise ManifestPublishError(f"missing formal object entry {object_key}") from exc
-    if not isinstance(entry, Mapping):
-        raise ManifestPublishError(f"{object_key} formal object entry must be a mapping")
-    return entry
-
-
-def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
-    count = entry.get("count", _MISSING)
-    if (
-        not isinstance(count, int)
-        or isinstance(count, bool)
-        or count < 0
-    ):
-        raise ManifestPublishError(f"{object_key}.count must be a non-negative integer")
-    return count
-
-
-def _ensure_payload_cycle(
-    object_key: str,
-    payload: Mapping[str, Any],
-    cycle_id: CycleId,
-) -> None:
-    if payload.get("cycle_id") != str(cycle_id):
-        raise ManifestPublishError(f"{object_key}.payload cycle_id must match")
 
 
 def _as_mapping(

--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -8,13 +8,13 @@ from typing import Any
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import FormalObjectBase
 from main_core.common.types import CycleId
+from main_core.l8_publish.bundle_entries import ordered_formal_object_keys
 from main_core.l8_publish.publish_port import (
     CommittedFormalObject,
     DataPlatformPublishPort,
     FormalObjectValue,
     ManifestWriteResult,
 )
-from main_core.l8_publish.refs import CANONICAL_FORMAL_OBJECT_KEYS
 
 
 def commit_formal_objects(
@@ -25,7 +25,7 @@ def commit_formal_objects(
     """Commit formal object classes in stable order before manifest publication."""
 
     committed_objects: list[CommittedFormalObject] = []
-    for object_key in _ordered_object_keys(formal_objects):
+    for object_key in ordered_formal_object_keys(formal_objects):
         formal_object = formal_objects[object_key]
         payload = _commit_payload(formal_object)
         expected_row_count = _expected_row_count(formal_object)
@@ -116,20 +116,6 @@ def build_manifest_candidate(
             }
         )
     return candidate
-
-
-def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
-    canonical_keys = [
-        object_key
-        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
-        if object_key in formal_objects
-    ]
-    derived_keys = [
-        object_key
-        for object_key in formal_objects
-        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
-    ]
-    return (*canonical_keys, *derived_keys)
 
 
 def _commit_payload(value: FormalObjectValue) -> Mapping[str, Any]:

--- a/src/main_core/l8_publish/report.py
+++ b/src/main_core/l8_publish/report.py
@@ -134,7 +134,6 @@ def _build_appendix_refs(
         "alpha_result_ref": objects.alpha_results.ref,
         "recommendation_ref": objects.recommendations.ref,
         "manifest_ref": _manifest_ref(cycle_id, bundle),
-        "audit_payload_ref": _audit_payload_ref(cycle_id, bundle),
     }
 
 
@@ -142,21 +141,10 @@ def _manifest_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
     _ensure_same_cycle("manifest_candidate", bundle.manifest_candidate, cycle_id)
     manifest_ref = bundle.manifest_candidate.get("manifest_ref")
     if isinstance(manifest_ref, str) and manifest_ref:
-        _ensure_ref_points_to_cycle("manifest_ref", manifest_ref, cycle_id)
         return manifest_ref
     raise ManifestPublishError(
         "manifest_candidate.manifest_ref must be reserved before formal report build",
     )
-
-
-def _audit_payload_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
-    _ensure_same_cycle("audit_payload", bundle.audit_payload, cycle_id)
-    for key in ("audit_payload_ref", "ref"):
-        value = bundle.audit_payload.get(key)
-        if isinstance(value, str) and value:
-            _ensure_ref_points_to_cycle(key, value, cycle_id)
-            return value
-    return f"audit_payload/{cycle_id}"
 
 
 def _ensure_same_cycle(
@@ -167,15 +155,6 @@ def _ensure_same_cycle(
     payload_cycle_id = payload.get("cycle_id")
     if payload_cycle_id is not None and payload_cycle_id != str(cycle_id):
         raise ManifestPublishError(f"{payload_name}.cycle_id must match")
-
-
-def _ensure_ref_points_to_cycle(
-    ref_name: str,
-    ref: str,
-    cycle_id: CycleId,
-) -> None:
-    if str(cycle_id) not in ref:
-        raise ManifestPublishError(f"{ref_name} must point to requested cycle_id")
 
 
 def _entity_ids_by_action(

--- a/tests/integration/test_pure_market_closed_loop.py
+++ b/tests/integration/test_pure_market_closed_loop.py
@@ -1,0 +1,217 @@
+"""Pure-market L1-L8 style closed-loop coverage."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import OfficialAlphaPool
+from main_core.common.types import CycleId, EntityId
+from main_core.l1_l2_basis import EntityMasterRow, MarketBar
+from main_core.l3_features import build_feature_signal_bundles
+from main_core.l4_world_state import StaticWorldStateReasonerPort, derive_world_state
+from main_core.l4_world_state.reasoner_port import WorldStateDeltaDecision
+from main_core.l5_universe import select_official_alpha_pool
+from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer, analyze_stock
+from main_core.l7_recommendation import (
+    InMemoryOverrideStore,
+    generate_recommendations,
+    submit_override,
+)
+
+
+@dataclass
+class MarketOnlyDataPort:
+    entity_master: Sequence[EntityMasterRow]
+    market_bars: Sequence[MarketBar]
+    entity_master_calls: list[CycleId | str] = field(default_factory=list)
+    market_bar_calls: list[CycleId | str] = field(default_factory=list)
+
+    def read_entity_master(self, cycle_id: CycleId | str) -> Sequence[EntityMasterRow]:
+        self.entity_master_calls.append(cycle_id)
+        return self.entity_master
+
+    def read_market_bars(self, cycle_id: CycleId | str) -> Sequence[MarketBar]:
+        self.market_bar_calls.append(cycle_id)
+        return self.market_bars
+
+    def read_calendar(self, cycle_id: CycleId | str) -> Sequence[object]:
+        return ()
+
+
+class PerEntityReasonerPort:
+    def __init__(self, responses: dict[str, AlphaReasonerResponse]) -> None:
+        self.responses = responses
+
+    def analyze_alpha(
+        self,
+        entity_id: EntityId,
+        context: AlphaAnalysisContext,
+    ) -> AlphaReasonerResponse:
+        return self.responses[str(entity_id)]
+
+
+def test_pure_market_closed_loop_with_override_constraint_and_inconclusive() -> None:
+    cycle_id = CycleId("cycle_pure_market")
+    data_port = MarketOnlyDataPort(
+        entity_master=(
+            _entity("ENT_A", "AAA"),
+            _entity("ENT_B", "BBB"),
+        ),
+        market_bars=(
+            _bar(cycle_id, "ENT_A", close_price=100.0, volume=1000.0, return_1d=0.04),
+            _bar(cycle_id, "ENT_B", close_price=80.0, volume=900.0, return_1d=0.02),
+        ),
+    )
+    bundles = build_feature_signal_bundles(cycle_id, data_port=data_port)
+    world_state = derive_world_state(
+        bundles[0],
+        reasoner_port=StaticWorldStateReasonerPort(
+            WorldStateDeltaDecision(
+                raw_delta=-1,
+                rationale="risk appetite deteriorated",
+                actual_model_used="static",
+                actual_provider="local",
+                fallback_path=[],
+            )
+        ),
+    )
+    pool = select_official_alpha_pool(world_state, bundles, capacity=2)
+    reasoner = PerEntityReasonerPort(
+        {
+            "ENT_A": AlphaReasonerResponse(
+                score=0.8,
+                confidence=0.7,
+                rationale="strong but gated by regime",
+                similar_cases=[],
+            ),
+            "ENT_B": AlphaReasonerResponse(
+                score=None,
+                confidence=0.0,
+                rationale="provider timeout",
+                similar_cases=[],
+                task_failed=True,
+                failure_reason="task-level timeout",
+            ),
+        }
+    )
+    analyses = [
+        analyze_stock(
+            entity_id,
+            _context(cycle_id, entity_id, bundles, world_state),
+            analyzer=SinglePromptAnalyzer(reasoner),
+        )
+        for entity_id in pool.selected_entities
+    ]
+    override_store = InMemoryOverrideStore()
+    submit_override(
+        {
+            "cycle_id": cycle_id,
+            "entity_id": "ENT_A",
+            "submitted_by": "analyst",
+            "action_type": "buy",
+            "rationale": "manual conviction",
+            "submitted_at": datetime(2026, 4, 17, 9, 30, tzinfo=UTC),
+        },
+        store=override_store,
+    )
+
+    recommendations = generate_recommendations(
+        pool,
+        analyses,
+        world_state,
+        override_store=override_store,
+    )
+
+    assert [analysis.status for analysis in analyses] == ["ok", "inconclusive"]
+    assert recommendations[0].entity_id == "ENT_A"
+    assert recommendations[0].action_type == "hold"
+    assert recommendations[0].triggered_by == "human_decision"
+    assert recommendations[0].override_applied is True
+    assert recommendations[0].constraints_applied["regime_gate"] == (
+        "risk_off_buy_to_hold"
+    )
+    assert recommendations[1].action_type == "inconclusive"
+    assert recommendations[1].confidence is None
+    assert data_port.entity_master_calls == [cycle_id]
+    assert data_port.market_bar_calls == [cycle_id]
+
+
+def test_pure_market_closed_loop_rejects_stale_freeze_before_recommendation() -> None:
+    cycle_id = CycleId("cycle_pure_market")
+    bundles = build_feature_signal_bundles(
+        cycle_id,
+        data_port=MarketOnlyDataPort(
+            entity_master=(_entity("ENT_A", "AAA"),),
+            market_bars=(_bar(cycle_id, "ENT_A"),),
+        ),
+    )
+    world_state = derive_world_state(bundles[0])
+    previous_pool = OfficialAlphaPool(
+        cycle_id=cycle_id,
+        observation_pool_size=1,
+        official_alpha_pool_capacity=1,
+        selected_entities=["ENT_STALE"],
+        added_entities=[],
+        removed_entities=[],
+        freeze_reason_map={"ENT_STALE": "prior freeze"},
+    )
+
+    with pytest.raises(MainCoreError, match="frozen entities must be present"):
+        select_official_alpha_pool(
+            world_state,
+            bundles,
+            previous_pool=previous_pool,
+            capacity=1,
+        )
+
+
+def _entity(entity_id: str, ticker: str) -> EntityMasterRow:
+    return EntityMasterRow(
+        entity_id=EntityId(entity_id),
+        ticker=ticker,
+        name=f"{ticker} Inc.",
+        exchange="NASDAQ",
+    )
+
+
+def _bar(
+    cycle_id: CycleId,
+    entity_id: str,
+    *,
+    close_price: float = 100.0,
+    volume: float = 1000.0,
+    return_1d: float | None = 0.02,
+) -> MarketBar:
+    return MarketBar(
+        cycle_id=cycle_id,
+        entity_id=EntityId(entity_id),
+        as_of_date=date(2026, 4, 17),
+        close_price=close_price,
+        volume=volume,
+        return_1d=return_1d,
+    )
+
+
+def _context(
+    cycle_id: CycleId,
+    entity_id: EntityId,
+    bundles: Sequence[object],
+    world_state: object,
+) -> AlphaAnalysisContext:
+    bundle_by_entity = {
+        str(bundle.entity_id): bundle
+        for bundle in bundles
+    }
+    return AlphaAnalysisContext(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_bundle=bundle_by_entity[str(entity_id)],
+        world_state=world_state,
+        similar_cases=[],
+    )

--- a/tests/l3_features/test_builder.py
+++ b/tests/l3_features/test_builder.py
@@ -45,6 +45,18 @@ class FakeCandidateSignalPort:
         return self.records
 
 
+class InvalidReadMultiplierStore:
+    def get_multipliers(self, cycle_id: CycleId | str) -> dict[str, float]:
+        return {"close_price": 0.0}
+
+    def put_multipliers(
+        self,
+        cycle_id: CycleId | str,
+        updates: dict[str, float],
+    ) -> None:
+        raise AssertionError("builder read path must not write multipliers")
+
+
 def test_feature_math_derives_market_features_and_applies_known_multipliers(
     cycle_id: CycleId,
 ) -> None:
@@ -78,6 +90,16 @@ def test_feature_math_derives_market_features_and_applies_known_multipliers(
         "volume": 1.0,
         "return_1d": 1.0,
     }
+
+
+def test_feature_math_uses_decimal_weighting_for_deterministic_price_output() -> None:
+    weighted_features, effective_multipliers = apply_feature_weight_multiplier(
+        {"close_price": 0.1},
+        {"close_price": 0.2},
+    )
+
+    assert weighted_features == {"close_price": 0.02}
+    assert effective_multipliers == {"close_price": 0.2}
 
 
 def test_feature_math_omits_missing_return_1d(cycle_id: CycleId) -> None:
@@ -225,6 +247,24 @@ def test_build_feature_signal_bundle_defaults_optional_inputs_to_empty_dicts(
         "volume": 1.0,
         "return_1d": 1.0,
     }
+
+
+def test_build_feature_signal_bundle_rejects_invalid_custom_multiplier_store(
+    cycle_id: CycleId,
+    active_entity: EntityMasterRow,
+    market_bar: MarketBar,
+) -> None:
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(active_entity,),
+    )
+
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        build_feature_signal_bundle(
+            cycle_id,
+            data_port=port,
+            multiplier_store=InvalidReadMultiplierStore(),
+        )
 
 
 def test_build_feature_signal_bundle_normalizes_all_candidate_signal_inputs(

--- a/tests/l3_features/test_candidate_signals.py
+++ b/tests/l3_features/test_candidate_signals.py
@@ -23,6 +23,7 @@ from .conftest import FakeDataPlatformPort
 
 SCOPED_MULTIPLIER = 1.5
 UNSCOPED_MULTIPLIER = 0.75
+EXPECTED_LAYER_B_ADJUSTED_VALUE = 3.0
 
 
 @dataclass
@@ -177,6 +178,39 @@ def test_normalize_candidate_signals_rejects_duplicate_signal_records() -> None:
             entity_id=EntityId("ENT_A"),
             multipliers={},
         )
+
+
+def test_normalize_candidate_signals_ignores_duplicate_out_of_basis_records() -> None:
+    cycle_id = CycleId("cycle-layer-b")
+    records = (
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_Z"),
+            signal_name="layer_b_score",
+            value=1.0,
+        ),
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_Z"),
+            signal_name="layer_b_score",
+            value=2.0,
+        ),
+        CandidateSignalRecord(
+            cycle_id=cycle_id,
+            entity_id=EntityId("ENT_A"),
+            signal_name="layer_b_score",
+            value=3.0,
+        ),
+    )
+
+    normalized = normalize_candidate_signals(
+        records,
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_A"),
+        multipliers={},
+    )
+
+    assert normalized["layer_b_score"]["adjusted_value"] == EXPECTED_LAYER_B_ADJUSTED_VALUE
 
 
 def test_normalize_candidate_signals_rejects_cycle_mismatch() -> None:

--- a/tests/l3_features/test_weight_api.py
+++ b/tests/l3_features/test_weight_api.py
@@ -2,11 +2,27 @@
 
 from __future__ import annotations
 
+import pytest
+
 from main_core.l3_features import (
     InMemoryMultiplierStore,
+    InvalidMultiplierError,
     apply_weight_multiplier,
     get_feature_weight_multiplier,
 )
+
+
+class FalseyMultiplierStore(InMemoryMultiplierStore):
+    def __len__(self) -> int:
+        return 0
+
+
+class InvalidReadMultiplierStore:
+    def get_multipliers(self, cycle_id: str) -> dict[str, float]:
+        return {"close_price": -1.0}
+
+    def put_multipliers(self, cycle_id: str, updates: dict[str, float]) -> None:
+        raise AssertionError("get API must not write multipliers")
 
 
 def test_weight_api_applies_updates_to_injected_store() -> None:
@@ -29,3 +45,16 @@ def test_weight_api_returns_defensive_copy() -> None:
     returned_multipliers["close_price"] = 9.9
 
     assert get_feature_weight_multiplier("cycle-001", store=store) == {"close_price": 1.2}
+
+
+def test_weight_api_honors_falsey_custom_store() -> None:
+    store = FalseyMultiplierStore()
+
+    apply_weight_multiplier("cycle-001", {"close_price": 1.2}, store=store)
+
+    assert get_feature_weight_multiplier("cycle-001", store=store) == {"close_price": 1.2}
+
+
+def test_weight_api_validates_custom_store_read_path() -> None:
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        get_feature_weight_multiplier("cycle-001", store=InvalidReadMultiplierStore())

--- a/tests/l6_alpha/test_ab_runner.py
+++ b/tests/l6_alpha/test_ab_runner.py
@@ -41,6 +41,17 @@ class RecordingAnalyzer:
         return self.results[entity_id]
 
 
+class FailingAnalyzer:
+    analyzer_type = "multi_agent_v1"
+
+    def analyze(
+        self,
+        entity_id: str,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        raise RuntimeError("role provider crashed")
+
+
 def test_run_ab_evaluation_computes_metrics_from_same_contexts(monkeypatch) -> None:
     def fail_if_l3_builder_is_called(*args, **kwargs):
         raise AssertionError("A/B runner must use supplied contexts")
@@ -84,8 +95,39 @@ def test_run_ab_evaluation_computes_metrics_from_same_contexts(monkeypatch) -> N
     assert report.baseline_inconclusive_count == 1
     assert report.challenger_inconclusive_count == 0
     assert report.inconclusive_count_delta == -1
+    assert report.baseline_failure_count == 0
+    assert report.challenger_failure_count == 0
+    assert report.failure_count_delta == 0
     assert report.cases[0].score_delta == pytest.approx(EXPECTED_OK_SCORE_MAE)
     assert report.cases[1].score_delta is None
+
+
+def test_run_ab_evaluation_rejects_empty_cases() -> None:
+    analyzer = RecordingAnalyzer("single_prompt_v1", {})
+
+    with pytest.raises(ValueError, match="cases"):
+        run_ab_evaluation([], baseline=analyzer, challenger=analyzer)
+
+
+def test_run_ab_evaluation_records_analyzer_failures_as_inconclusive() -> None:
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=RecordingAnalyzer(
+            "single_prompt_v1",
+            {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+        ),
+        challenger=FailingAnalyzer(),
+    )
+
+    assert report.total_cases == 1
+    assert report.challenger_failure_count == 1
+    assert report.challenger_inconclusive_count == 1
+    assert report.cases[0].challenger_status == "inconclusive"
+    assert report.cases[0].challenger_error == "RuntimeError: role provider crashed"
+    assert report.cases[0].challenger_diagnostics == {
+        "error": "RuntimeError",
+        "message": "role provider crashed",
+    }
 
 
 def test_ab_report_json_is_parseable_and_excludes_context_models() -> None:

--- a/tests/l6_alpha/test_ab_runner.py
+++ b/tests/l6_alpha/test_ab_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.schemas import AlphaResultSnapshot, FeatureSignalBundle, WorldStateSnapshot
@@ -50,6 +51,30 @@ class FailingAnalyzer:
         context: AlphaAnalysisContext,
     ) -> AlphaResultSnapshot:
         raise RuntimeError("role provider crashed")
+
+
+class InvalidTypeFailingAnalyzer:
+    analyzer_type = "experimental_v1"
+
+    def analyze(
+        self,
+        entity_id: str,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        raise RuntimeError("role provider crashed")
+
+
+class RaisingAnalyzerType:
+    @property
+    def analyzer_type(self) -> str:
+        raise RuntimeError("cannot inspect analyzer_type")
+
+    def analyze(
+        self,
+        entity_id: str,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        raise ValueError("provider failed before metadata")
 
 
 def test_run_ab_evaluation_computes_metrics_from_same_contexts(monkeypatch) -> None:
@@ -128,6 +153,30 @@ def test_run_ab_evaluation_records_analyzer_failures_as_inconclusive() -> None:
         "error": "RuntimeError",
         "message": "role provider crashed",
     }
+
+
+def test_run_ab_evaluation_rejects_invalid_failure_analyzer_type() -> None:
+    with pytest.raises(ValidationError, match="analyzer_type"):
+        run_ab_evaluation(
+            [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+            baseline=RecordingAnalyzer(
+                "single_prompt_v1",
+                {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+            ),
+            challenger=InvalidTypeFailingAnalyzer(),
+        )
+
+
+def test_run_ab_evaluation_reraises_original_failure_when_type_lookup_fails() -> None:
+    with pytest.raises(ValueError, match="provider failed before metadata"):
+        run_ab_evaluation(
+            [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+            baseline=RecordingAnalyzer(
+                "single_prompt_v1",
+                {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+            ),
+            challenger=RaisingAnalyzerType(),
+        )
 
 
 def test_ab_report_json_is_parseable_and_excludes_context_models() -> None:

--- a/tests/l6_alpha/test_fallback.py
+++ b/tests/l6_alpha/test_fallback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
-from main_core.l6_alpha import AlphaReasonerResponse, build_inconclusive_result
+from main_core.l6_alpha import build_inconclusive_result
 from main_core.l6_alpha.fallback import is_task_level_failure
 
 
@@ -42,14 +42,5 @@ def test_build_inconclusive_result_accepts_explicit_similar_cases(
 
 def test_is_task_level_failure_only_accepts_inconclusive_errors() -> None:
     assert is_task_level_failure(InconclusiveError("single stock task failed"))
-    assert is_task_level_failure(
-        AlphaReasonerResponse(
-            score=None,
-            confidence=0.0,
-            rationale="provider task failed",
-            similar_cases=[],
-            task_failed=True,
-        ),
-    )
     assert not is_task_level_failure(MainCoreError("infrastructure failed"))
     assert not is_task_level_failure(RuntimeError("unknown failure"))

--- a/tests/l6_alpha/test_multi_agent_analyzer.py
+++ b/tests/l6_alpha/test_multi_agent_analyzer.py
@@ -110,6 +110,10 @@ def test_multi_agent_analyzer_happy_path_returns_formal_result(
     assert result.confidence == pytest.approx(EXPECTED_WEIGHTED_CONFIDENCE)
     assert "fundamental case is strong" in result.rationale
     assert "technical case is mixed" in result.rationale
+    assert result.diagnostics["analyzer_type"] == "multi_agent_v1"
+    assert result.diagnostics["failed_roles"] == ()
+    assert result.diagnostics["roles"][0]["role"] == "fundamental"
+    assert result.diagnostics["roles"][0]["evidence"] == {"metric": "quality"}
     assert [call[2].name for call in port.calls] == ["fundamental", "technical"]
 
 
@@ -147,6 +151,41 @@ def test_aggregate_role_results_is_stable_when_role_order_changes(
     assert reversed_result.score == result.score
     assert reversed_result.confidence == result.confidence
     assert reversed_result.rationale == result.rationale
+
+
+def test_aggregate_role_results_rejects_missing_configured_role(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    roles = (AgentRoleConfig("fundamental"), AgentRoleConfig("risk"))
+
+    with pytest.raises(AlphaAnalyzerError, match="missing role"):
+        aggregate_role_results(
+            "ENT_A",
+            analysis_context,
+            (MultiAgentRoleResult("fundamental", 0.7, 0.8, "fundamental"),),
+            roles=roles,
+        )
+
+
+def test_multi_agent_analyzer_rejects_permuted_role_result(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = MultiAgentAnalyzer(
+        RecordingMultiAgentPort(
+            {
+                "fundamental": MultiAgentRoleResult(
+                    "risk",
+                    0.7,
+                    0.8,
+                    "wrong role",
+                ),
+            }
+        ),
+        roles=(AgentRoleConfig("fundamental"),),
+    )
+
+    with pytest.raises(AlphaAnalyzerError, match="does not match"):
+        analyzer.analyze("ENT_A", analysis_context)
 
 
 def test_single_role_task_failure_keeps_ok_result_and_records_reason(
@@ -233,6 +272,20 @@ def test_all_role_task_failures_return_multi_agent_inconclusive(
     assert result.confidence == 0.0
     assert "fundamental: no data" in result.rationale
     assert "risk: timeout" in result.rationale
+    assert result.diagnostics["failed_roles"] == ("fundamental", "risk")
+
+
+def test_static_multi_agent_default_returns_inconclusive_when_unconfigured(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    result = MultiAgentAnalyzer(roles=(AgentRoleConfig("fundamental"),)).analyze(
+        "ENT_A",
+        analysis_context,
+    )
+
+    assert result.status == "inconclusive"
+    assert result.score is None
+    assert result.diagnostics["failed_roles"] == ("fundamental",)
 
 
 def test_main_core_error_from_role_hard_stops_without_fallback(

--- a/tests/l6_alpha/test_single_prompt_analyzer.py
+++ b/tests/l6_alpha/test_single_prompt_analyzer.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
-from main_core.common.schemas import AlphaResultSnapshot
-from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer
+from main_core.common.schemas import AlphaResultSnapshot, FeatureSignalBundle, WorldStateSnapshot
+from main_core.l6_alpha import AlphaReasonerError, AlphaReasonerResponse, SinglePromptAnalyzer
 from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
 
 EXPECTED_FEATURE_MOMENTUM = 4.2
@@ -127,6 +128,116 @@ def test_single_prompt_analyzer_propagates_main_core_infrastructure_errors(
 
     with pytest.raises(MainCoreError, match="reasoner unavailable"):
         analyzer.analyze("ENT_A", analysis_context)
+
+
+def test_single_prompt_analyzer_wraps_unknown_provider_errors(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = SinglePromptAnalyzer(
+        RecordingReasonerPort(error=RuntimeError("socket closed")),
+    )
+
+    with pytest.raises(AlphaReasonerError, match="alpha reasoner failed"):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        AlphaReasonerResponse(
+            score=None,
+            confidence=0.6,
+            rationale="missing score",
+            similar_cases=[],
+        ),
+        AlphaReasonerResponse(
+            score=float("nan"),
+            confidence=0.6,
+            rationale="nan score",
+            similar_cases=[],
+        ),
+        AlphaReasonerResponse(
+            score=float("inf"),
+            confidence=0.6,
+            rationale="inf score",
+            similar_cases=[],
+        ),
+        AlphaReasonerResponse(
+            score=0.5,
+            confidence=float("nan"),
+            rationale="nan confidence",
+            similar_cases=[],
+        ),
+        AlphaReasonerResponse(
+            score=0.5,
+            confidence=1.1,
+            rationale="too confident",
+            similar_cases=[],
+        ),
+        AlphaReasonerResponse(
+            score=0.5,
+            confidence=0.6,
+            rationale=" ",
+            similar_cases=[],
+        ),
+    ],
+)
+def test_single_prompt_analyzer_rejects_malformed_successful_response(
+    analysis_context: AlphaAnalysisContext,
+    response: AlphaReasonerResponse,
+) -> None:
+    analyzer = SinglePromptAnalyzer(RecordingReasonerPort(response=response))
+
+    with pytest.raises(AlphaReasonerError):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+@pytest.mark.parametrize(
+    "context_update",
+    [
+        {
+            "feature_bundle": FeatureSignalBundle(
+                cycle_id="cycle_other",
+                entity_id="ENT_A",
+                feature_values={"momentum": 1.0},
+                signal_values={},
+                graph_features={},
+                feature_weight_multiplier={"momentum": 1.0},
+            ),
+        },
+        {
+            "feature_bundle": FeatureSignalBundle(
+                cycle_id="cycle_l6",
+                entity_id="ENT_OTHER",
+                feature_values={"momentum": 1.0},
+                signal_values={},
+                graph_features={},
+                feature_weight_multiplier={"momentum": 1.0},
+            ),
+        },
+        {
+            "world_state": WorldStateSnapshot(
+                cycle_id="cycle_other",
+                baseline_regime="neutral",
+                llm_delta=0,
+                final_regime="neutral",
+                llm_rationale="fixture",
+                actual_model_used="fixture",
+                actual_provider="local",
+                fallback_path=[],
+            ),
+        },
+    ],
+)
+def test_alpha_analysis_context_rejects_upstream_mismatch(
+    analysis_context: AlphaAnalysisContext,
+    context_update: dict[str, object],
+) -> None:
+    payload = analysis_context.model_dump(mode="python")
+    payload.update(context_update)
+
+    with pytest.raises(ValidationError):
+        AlphaAnalysisContext.model_validate(payload)
 
 
 def test_single_prompt_analyzer_does_not_reapply_feature_multipliers(

--- a/tests/l7_recommendation/test_override.py
+++ b/tests/l7_recommendation/test_override.py
@@ -8,11 +8,19 @@ import pytest
 from pydantic import ValidationError
 
 from main_core.common.errors import MainCoreError
-from main_core.common.schemas import OverrideRecord, RecommendationSnapshot
+from main_core.common.schemas import (
+    AlphaResultSnapshot,
+    OfficialAlphaPool,
+    OverrideRecord,
+    RecommendationSnapshot,
+    WorldStateSnapshot,
+)
 from main_core.l7_recommendation import (
     InMemoryOverrideStore,
     apply_override,
     find_override,
+    generate_recommendations,
+    rating_for_action,
     submit_override,
 )
 
@@ -76,6 +84,13 @@ def test_find_override_returns_matching_cycle_entity_record() -> None:
     assert find_override([first, second], "cycle_l7", "ENT_Z") is None
 
 
+def test_find_override_uses_latest_duplicate_submission() -> None:
+    older = OverrideRecord(**_override_payload(action_type="buy"))
+    newer = OverrideRecord(**_override_payload(action_type="reduce"))
+
+    assert find_override([older, newer], "cycle_l7", "ENT_A") == newer
+
+
 def test_apply_override_sets_human_audit_fields_and_keeps_constraints() -> None:
     override = OverrideRecord(**_override_payload(action_type="reduce"))
 
@@ -88,8 +103,62 @@ def test_apply_override_sets_human_audit_fields_and_keeps_constraints() -> None:
     assert result.constraints_applied == {"existing": "kept"}
 
 
+def test_rating_for_action_is_shared_l7_rule() -> None:
+    assert rating_for_action("buy") == "A"
+    assert rating_for_action("hold") == "B"
+    assert rating_for_action("reduce") == "C"
+
+
 def test_apply_override_rejects_non_matching_override() -> None:
     override = OverrideRecord(**_override_payload(entity_id="ENT_B"))
 
     with pytest.raises(MainCoreError, match="entity_id"):
         apply_override(_candidate(), override)
+
+
+def test_submit_override_honors_falsey_custom_store_end_to_end() -> None:
+    class FalseyOverrideStore(InMemoryOverrideStore):
+        def __len__(self) -> int:
+            return 0
+
+    store = FalseyOverrideStore()
+    submit_override(_override_payload(action_type="reduce"), store=store)
+    pool = OfficialAlphaPool(
+        cycle_id="cycle_l7",
+        observation_pool_size=1,
+        official_alpha_pool_capacity=1,
+        selected_entities=["ENT_A"],
+        added_entities=["ENT_A"],
+        removed_entities=[],
+        freeze_reason_map={},
+    )
+    analysis = AlphaResultSnapshot(
+        cycle_id="cycle_l7",
+        entity_id="ENT_A",
+        analyzer_type="single_prompt_v1",
+        score=0.8,
+        confidence=0.7,
+        rationale="fixture alpha",
+        similar_cases=[],
+        status="ok",
+    )
+    world_state = WorldStateSnapshot(
+        cycle_id="cycle_l7",
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [analysis],
+        world_state,
+        override_store=store,
+    )
+
+    assert recommendation.action_type == "reduce"
+    assert recommendation.override_applied is True

--- a/tests/l8_publish/test_assembler.py
+++ b/tests/l8_publish/test_assembler.py
@@ -91,6 +91,12 @@ def test_prepare_publish_bundle_returns_canonical_formal_object_entries() -> Non
         FORMAL_REPORT_KEY: SINGLE_OBJECT_COUNT,
     }
     assert bundle_payload["audit_payload"]["inconclusive_count"] == SINGLE_OBJECT_COUNT
+    assert bundle_payload["audit_payload"]["alpha_inconclusive_count"] == (
+        SINGLE_OBJECT_COUNT
+    )
+    assert bundle_payload["audit_payload"]["recommendation_inconclusive_count"] == (
+        SINGLE_OBJECT_COUNT
+    )
     assert bundle_payload["audit_payload"]["override_applied_count"] == SINGLE_OBJECT_COUNT
     assert bundle_payload["retrospective_seed"]["selected_entity_ids"] == [
         "ENT_A",
@@ -231,3 +237,22 @@ def test_formal_object_ref_rejects_missing_entry() -> None:
 
     with pytest.raises(ManifestPublishError, match="missing formal object"):
         formal_object_ref(bundle, "backtest_result")
+
+
+def test_prepare_publish_bundle_audit_counts_recommendation_inconclusive_separately() -> None:
+    source = FakeFormalObjectSource(
+        loaded_pool=pool(("ENT_A",)),
+        loaded_alpha_results=[alpha_result("ENT_A", score=0.7, status="ok")],
+        loaded_recommendations=[recommendation("ENT_A", action_type="inconclusive")],
+    )
+
+    bundle = prepare_publish_bundle(
+        "cycle_l8",
+        source=source,
+        publish_port=RecordingPublishPort(),
+        derived_builders=(),
+    )
+
+    assert bundle.audit_payload["alpha_inconclusive_count"] == 0
+    assert bundle.audit_payload["recommendation_inconclusive_count"] == 1
+    assert bundle.audit_payload["inconclusive_count"] == 1

--- a/tests/l8_publish/test_dashboard.py
+++ b/tests/l8_publish/test_dashboard.py
@@ -49,6 +49,7 @@ def test_build_dashboard_snapshot_rejects_missing_ref() -> None:
     bundle = _mutated_bundle(
         lambda payload: (
             payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY].pop("ref"),
+            payload["manifest_candidate"].pop("manifest_ref"),
             payload["manifest_candidate"].pop("object_refs"),
         )
     )

--- a/tests/l8_publish/test_dashboard.py
+++ b/tests/l8_publish/test_dashboard.py
@@ -10,7 +10,12 @@ import pytest
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import PublishBundle
 from main_core.l8_publish import build_dashboard_snapshot, prepare_publish_bundle
-from main_core.l8_publish.refs import WORLD_STATE_SNAPSHOT_KEY
+from main_core.l8_publish.refs import (
+    ALPHA_RESULT_SNAPSHOT_KEY,
+    OFFICIAL_ALPHA_POOL_KEY,
+    RECOMMENDATION_SNAPSHOT_KEY,
+    WORLD_STATE_SNAPSHOT_KEY,
+)
 from tests.l8_publish import FakeFormalObjectSource, RecordingPublishPort, pool
 
 
@@ -42,7 +47,10 @@ def test_build_dashboard_snapshot_happy_path() -> None:
 
 def test_build_dashboard_snapshot_rejects_missing_ref() -> None:
     bundle = _mutated_bundle(
-        lambda payload: payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY].pop("ref")
+        lambda payload: (
+            payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY].pop("ref"),
+            payload["manifest_candidate"].pop("object_refs"),
+        )
     )
 
     with pytest.raises(ManifestPublishError, match="ref"):
@@ -57,6 +65,35 @@ def test_build_dashboard_snapshot_rejects_cycle_mismatch() -> None:
     )
 
     with pytest.raises(ManifestPublishError, match="cycle_id"):
+        build_dashboard_snapshot("cycle_l8", bundle)
+
+
+@pytest.mark.parametrize(
+    "object_key",
+    [
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        RECOMMENDATION_SNAPSHOT_KEY,
+    ],
+)
+def test_build_dashboard_snapshot_rejects_stale_formal_object_ref(
+    object_key: str,
+) -> None:
+    bundle = _mutated_bundle(
+        lambda payload: (
+            payload["formal_objects"][object_key].__setitem__(
+                "ref",
+                f"{object_key}/cycle_other/ref",
+            ),
+            payload["manifest_candidate"]["object_refs"].__setitem__(
+                object_key,
+                f"{object_key}/cycle_other/ref",
+            ),
+        )
+    )
+
+    with pytest.raises(ManifestPublishError, match="requested cycle_id"):
         build_dashboard_snapshot("cycle_l8", bundle)
 
 

--- a/tests/l8_publish/test_report.py
+++ b/tests/l8_publish/test_report.py
@@ -43,6 +43,7 @@ def test_build_formal_report_rejects_missing_ref() -> None:
     bundle = _mutated_bundle(
         lambda payload: (
             payload["formal_objects"][RECOMMENDATION_SNAPSHOT_KEY].pop("ref"),
+            payload["manifest_candidate"].pop("manifest_ref"),
             payload["manifest_candidate"].pop("object_refs"),
         )
     )

--- a/tests/l8_publish/test_report.py
+++ b/tests/l8_publish/test_report.py
@@ -36,13 +36,15 @@ def test_build_formal_report_happy_path() -> None:
         "alpha_result_ref": "alpha_result_snapshot/cycle_l8/ref",
         "recommendation_ref": "recommendation_snapshot/cycle_l8/ref",
         "manifest_ref": "manifest/cycle_l8",
-        "audit_payload_ref": "audit_payload/cycle_l8",
     }
 
 
 def test_build_formal_report_rejects_missing_ref() -> None:
     bundle = _mutated_bundle(
-        lambda payload: payload["formal_objects"][RECOMMENDATION_SNAPSHOT_KEY].pop("ref")
+        lambda payload: (
+            payload["formal_objects"][RECOMMENDATION_SNAPSHOT_KEY].pop("ref"),
+            payload["manifest_candidate"].pop("object_refs"),
+        )
     )
 
     with pytest.raises(ManifestPublishError, match="ref"):
@@ -51,16 +53,37 @@ def test_build_formal_report_rejects_missing_ref() -> None:
 
 def test_build_formal_report_rejects_missing_manifest_ref() -> None:
     bundle = _mutated_bundle(
-        lambda payload: payload["manifest_candidate"].pop("manifest_ref")
+        lambda payload: (
+            payload["manifest_candidate"].pop("manifest_ref"),
+            payload["manifest_candidate"].pop("object_refs"),
+        )
     )
 
     with pytest.raises(ManifestPublishError, match="manifest_ref"):
         build_formal_report("cycle_l8", bundle)
 
 
+def test_build_formal_report_allows_opaque_manifest_ref() -> None:
+    bundle = _mutated_bundle(
+        lambda payload: payload["manifest_candidate"].__setitem__(
+            "manifest_ref",
+            "pg://cycle_publish_manifest/42",
+        )
+    )
+
+    report = build_formal_report("cycle_l8", bundle)
+
+    assert report.appendix_refs["manifest_ref"] == "pg://cycle_publish_manifest/42"
+
+
 def test_build_formal_report_rejects_cycle_mismatch() -> None:
     bundle = _mutated_bundle(
-        lambda payload: payload.__setitem__("cycle_id", "cycle_other")
+        lambda payload: (
+            payload.__setitem__("cycle_id", "cycle_other"),
+            payload["manifest_candidate"].__setitem__("cycle_id", "cycle_other"),
+            payload["audit_payload"].__setitem__("cycle_id", "cycle_other"),
+            payload["retrospective_seed"].__setitem__("cycle_id", "cycle_other"),
+        )
     )
 
     with pytest.raises(ManifestPublishError, match="cycle_id"):

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -106,4 +106,4 @@ def test_multi_agent_analyzer_returns_multi_agent_result() -> None:
     result = analyzer.analyze(ENTITY_ID, _analysis_context())
 
     assert result.analyzer_type == MULTI_AGENT_ANALYZER
-    assert result.status == "ok"
+    assert result.status == "inconclusive"

--- a/tests/protocols/test_graph_engine_contract.py
+++ b/tests/protocols/test_graph_engine_contract.py
@@ -54,9 +54,20 @@ def test_l3_graph_exports_are_compatibility_aliases() -> None:
 
 def test_l3_adapter_only_exports_adapter_helpers() -> None:
     assert set(l3_graph_adapter.__all__) == {
+        "GraphEnginePort",
+        "GraphImpactRecord",
+        "GraphRegimeContext",
+        "GraphSnapshotError",
         "load_graph_features",
         "merge_graph_features",
     }
+
+
+def test_l3_adapter_keeps_runtime_compatibility_aliases() -> None:
+    assert l3_graph_adapter.GraphEnginePort is GraphEnginePort
+    assert l3_graph_adapter.GraphImpactRecord is GraphImpactRecord
+    assert l3_graph_adapter.GraphRegimeContext is GraphRegimeContext
+    assert l3_graph_adapter.GraphSnapshotError is GraphSnapshotError
 
 
 def test_graph_engine_port_is_runtime_checkable_and_read_only() -> None:

--- a/tests/schemas/test_alpha.py
+++ b/tests/schemas/test_alpha.py
@@ -69,3 +69,21 @@ def test_alpha_result_rejects_inconclusive_with_score() -> None:
 
     with pytest.raises(ValidationError, match="score=None"):
         AlphaResultSnapshot(**payload)
+
+
+@pytest.mark.parametrize("score", [float("nan"), float("inf")])
+def test_alpha_result_rejects_non_finite_score(score: float) -> None:
+    payload = _alpha_payload()
+    payload["score"] = score
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)
+
+
+@pytest.mark.parametrize("confidence", [float("nan"), float("inf")])
+def test_alpha_result_rejects_non_finite_confidence(confidence: float) -> None:
+    payload = _alpha_payload()
+    payload["confidence"] = confidence
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -81,6 +82,70 @@ def test_feature_signal_bundle_rejects_non_finite_feature_values(
 
     with pytest.raises(ValidationError):
         FeatureSignalBundle(**payload)
+
+
+@pytest.mark.parametrize(
+    "bad_number",
+    [float("nan"), float("inf"), Decimal("NaN"), Decimal("Infinity")],
+)
+@pytest.mark.parametrize(
+    ("factory", "field_name"),
+    [
+        (
+            lambda bad_number: FeatureSignalBundle(
+                **{**_bundle_payload(), "signal_values": {"nested": bad_number}}
+            ),
+            "signal_values",
+        ),
+        (
+            lambda bad_number: FeatureSignalBundle(
+                **{**_bundle_payload(), "graph_features": {"nested": bad_number}}
+            ),
+            "graph_features",
+        ),
+        (
+            lambda bad_number: AlphaResultSnapshot(
+                cycle_id="cycle_001",
+                entity_id="ENT_001",
+                analyzer_type="multi_agent_v1",
+                score=0.72,
+                confidence=0.81,
+                rationale="quality and momentum are aligned",
+                similar_cases=[],
+                status="ok",
+                diagnostics={"role": {"score": bad_number}},
+            ),
+            "diagnostics",
+        ),
+        (
+            lambda bad_number: PublishBundle(
+                cycle_id="cycle_001",
+                formal_objects={"world_state": {"ref": "world_state_snapshot/cycle_001"}},
+                manifest_candidate={"snapshot_id": "snap_001"},
+                audit_payload={"quality": {"score": bad_number}},
+                retrospective_seed={"window": "1d"},
+            ),
+            "audit_payload",
+        ),
+        (
+            lambda bad_number: PublishBundle(
+                cycle_id="cycle_001",
+                formal_objects={"world_state": {"ref": "world_state_snapshot/cycle_001"}},
+                manifest_candidate={"snapshot_id": "snap_001"},
+                audit_payload={"actor": "system"},
+                retrospective_seed={"quality": {"score": bad_number}},
+            ),
+            "retrospective_seed",
+        ),
+    ],
+)
+def test_schema_any_payloads_reject_non_finite_numbers(
+    factory: Callable[[Any], FormalObjectBase],
+    field_name: str,
+    bad_number: Any,
+) -> None:
+    with pytest.raises(ValidationError, match=field_name):
+        factory(bad_number)
 
 
 def test_feature_signal_bundle_deep_freezes_nested_payload_containers() -> None:

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -21,6 +21,7 @@ from main_core.common.schemas import (
     RecommendationSnapshot,
     WorldStateSnapshot,
 )
+from main_core.l8_publish import CommittedFormalObject, ManifestWriteResult
 
 
 def _bundle_payload() -> dict[str, object]:
@@ -67,7 +68,18 @@ def test_feature_signal_bundle_rejects_non_positive_or_non_finite_multiplier(
     payload = _bundle_payload()
     payload["feature_weight_multiplier"] = {"momentum": multiplier}
 
-    with pytest.raises(ValidationError, match="finite and > 0"):
+    with pytest.raises(ValidationError):
+        FeatureSignalBundle(**payload)
+
+
+@pytest.mark.parametrize("feature_value", [float("nan"), float("inf")])
+def test_feature_signal_bundle_rejects_non_finite_feature_values(
+    feature_value: float,
+) -> None:
+    payload = _bundle_payload()
+    payload["feature_values"] = {"momentum": feature_value}
+
+    with pytest.raises(ValidationError):
         FeatureSignalBundle(**payload)
 
 
@@ -215,3 +227,132 @@ def test_all_schema_models_inherit_frozen_forbid_strict_base() -> None:
         assert model.model_config["frozen"] is True
         assert model.model_config["extra"] == "forbid"
         assert model.model_config["strict"] is True
+        assert model.model_config["allow_inf_nan"] is False
+
+
+def test_schema_contract_builds_one_valid_cycle_across_formal_objects() -> None:
+    cycle_id = "cycle_contract"
+    feature_bundle = FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id="ENT_001",
+        feature_values={"momentum": 0.42},
+        signal_values={},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+    world_state = WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="contract fixture",
+        actual_model_used="static",
+        actual_provider="local",
+        fallback_path=[],
+    )
+    pool = OfficialAlphaPool(
+        cycle_id=cycle_id,
+        observation_pool_size=1,
+        official_alpha_pool_capacity=1,
+        selected_entities=["ENT_001"],
+        added_entities=["ENT_001"],
+        removed_entities=[],
+        freeze_reason_map={},
+    )
+    alpha = AlphaResultSnapshot(
+        cycle_id=cycle_id,
+        entity_id="ENT_001",
+        analyzer_type="single_prompt_v1",
+        score=0.72,
+        confidence=0.81,
+        rationale="quality and momentum are aligned",
+        similar_cases=[],
+        status="ok",
+    )
+    recommendation = RecommendationSnapshot(
+        cycle_id=cycle_id,
+        entity_id="ENT_001",
+        action_type="buy",
+        rating="A",
+        confidence=0.81,
+        triggered_by="system",
+        override_applied=False,
+        constraints_applied={},
+    )
+    committed = (
+        CommittedFormalObject(
+            object_key="world_state_snapshot",
+            ref=f"world_state_snapshot/{cycle_id}/ref",
+            snapshot_id="world-snapshot",
+            payload_hash="world-hash",
+            row_count=1,
+        ),
+        CommittedFormalObject(
+            object_key="official_alpha_pool",
+            ref=f"official_alpha_pool/{cycle_id}/ref",
+            snapshot_id="pool-snapshot",
+            payload_hash="pool-hash",
+            row_count=1,
+        ),
+        CommittedFormalObject(
+            object_key="alpha_result_snapshot",
+            ref=f"alpha_result_snapshot/{cycle_id}/ref",
+            snapshot_id="alpha-snapshot",
+            payload_hash="alpha-hash",
+            row_count=1,
+        ),
+        CommittedFormalObject(
+            object_key="recommendation_snapshot",
+            ref=f"recommendation_snapshot/{cycle_id}/ref",
+            snapshot_id="recommendation-snapshot",
+            payload_hash="recommendation-hash",
+            row_count=1,
+        ),
+    )
+    manifest = ManifestWriteResult(
+        manifest_ref="pg://cycle_publish_manifest/42",
+        manifest_version="v1",
+        table_snapshots={
+            committed_object.object_key: committed_object.snapshot_id
+            for committed_object in committed
+        },
+    )
+
+    bundle = PublishBundle(
+        cycle_id=cycle_id,
+        formal_objects={
+            "world_state_snapshot": {
+                "ref": committed[0].ref,
+                "payload": world_state.model_dump(mode="json"),
+                "count": 1,
+            },
+            "official_alpha_pool": {
+                "ref": committed[1].ref,
+                "payload": pool.model_dump(mode="json"),
+                "count": 1,
+            },
+            "alpha_result_snapshot": {
+                "ref": committed[2].ref,
+                "payload": [alpha.model_dump(mode="json")],
+                "count": 1,
+            },
+            "recommendation_snapshot": {
+                "ref": committed[3].ref,
+                "payload": [recommendation.model_dump(mode="json")],
+                "count": 1,
+            },
+        },
+        manifest_candidate={
+            "cycle_id": cycle_id,
+            "manifest_ref": manifest.manifest_ref,
+            "object_refs": {
+                committed_object.object_key: committed_object.ref
+                for committed_object in committed
+            },
+        },
+        audit_payload={"cycle_id": cycle_id},
+        retrospective_seed={"cycle_id": cycle_id},
+    )
+
+    assert feature_bundle.cycle_id == bundle.cycle_id
+    assert bundle.manifest_candidate["manifest_ref"] == "pg://cycle_publish_manifest/42"

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -42,6 +42,22 @@ def test_official_alpha_pool_rejects_selected_entities_over_capacity() -> None:
         OfficialAlphaPool(**payload)
 
 
+def test_official_alpha_pool_rejects_negative_observation_pool_size() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = -1
+
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(**payload)
+
+
+def test_official_alpha_pool_rejects_selection_larger_than_observation_pool() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = 1
+
+    with pytest.raises(ValidationError, match="observation_pool_size"):
+        OfficialAlphaPool(**payload)
+
+
 def test_official_alpha_pool_selected_entities_cannot_mutate_past_capacity() -> None:
     payload = _pool_payload()
     payload["official_alpha_pool_capacity"] = 1

--- a/tests/schemas/test_publish.py
+++ b/tests/schemas/test_publish.py
@@ -82,6 +82,37 @@ def test_publish_bundle_rejects_missing_manifest_anchor_when_refs_are_present() 
         PublishBundle(**payload)
 
 
+def test_publish_bundle_rejects_manifest_anchor_without_object_refs() -> None:
+    payload = _publish_payload()
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "manifest_ref": "pg://cycle_publish_manifest/42",
+    }
+
+    with pytest.raises(ValidationError, match="object_refs"):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_object_refs_without_manifest_cycle() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = {
+        "recommendation_snapshot": {
+            "ref": "recommendation_snapshot/cycle_001/ref",
+            "payload": [],
+            "count": 0,
+        }
+    }
+    payload["manifest_candidate"] = {
+        "manifest_ref": "pg://cycle_publish_manifest/42",
+        "object_refs": {
+            "recommendation_snapshot": "recommendation_snapshot/cycle_001/ref",
+        },
+    }
+
+    with pytest.raises(ValidationError, match="manifest_candidate.cycle_id"):
+        PublishBundle(**payload)
+
+
 def test_publish_bundle_rejects_stale_recommendation_reference() -> None:
     payload = _publish_payload()
     payload["formal_objects"] = {

--- a/tests/schemas/test_publish.py
+++ b/tests/schemas/test_publish.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
-from main_core.common.schemas import OverrideRecord, PublishBundle
+from main_core.common.schemas import ManifestReference, OverrideRecord, PublishBundle
 
 
 def _publish_payload() -> dict[str, object]:
@@ -50,6 +50,56 @@ def test_publish_bundle_rejects_wrong_formal_objects_type() -> None:
     payload["formal_objects"] = []
 
     with pytest.raises(ValidationError):
+        PublishBundle(**payload)
+
+
+def test_manifest_reference_requires_manifest_anchor() -> None:
+    with pytest.raises(ValidationError, match="manifest_ref"):
+        ManifestReference(
+            cycle_id="cycle_001",
+            manifest_ref="",
+            object_refs={"recommendation_snapshot": "recommendation_snapshot/cycle_001/ref"},
+        )
+
+
+def test_publish_bundle_rejects_missing_manifest_anchor_when_refs_are_present() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = {
+        "recommendation_snapshot": {
+            "ref": "recommendation_snapshot/cycle_001/ref",
+            "payload": [],
+            "count": 0,
+        }
+    }
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "object_refs": {
+            "recommendation_snapshot": "recommendation_snapshot/cycle_001/ref",
+        },
+    }
+
+    with pytest.raises(ValidationError, match="manifest_ref"):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_stale_recommendation_reference() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = {
+        "recommendation_snapshot": {
+            "ref": "recommendation_snapshot/cycle_old/ref",
+            "payload": [],
+            "count": 0,
+        }
+    }
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "manifest_ref": "pg://cycle_publish_manifest/42",
+        "object_refs": {
+            "recommendation_snapshot": "recommendation_snapshot/cycle_001/ref",
+        },
+    }
+
+    with pytest.raises(ValidationError, match="recommendation_snapshot.ref"):
         PublishBundle(**payload)
 
 

--- a/tests/schemas/test_recommendation.py
+++ b/tests/schemas/test_recommendation.py
@@ -50,3 +50,12 @@ def test_recommendation_rejects_inconclusive_with_confidence() -> None:
 
     with pytest.raises(ValidationError, match="confidence=None"):
         RecommendationSnapshot(**payload)
+
+
+@pytest.mark.parametrize("confidence", [float("nan"), float("inf")])
+def test_recommendation_rejects_non_finite_confidence(confidence: float) -> None:
+    payload = _recommendation_payload()
+    payload["confidence"] = confidence
+
+    with pytest.raises(ValidationError):
+        RecommendationSnapshot(**payload)


### PR DESCRIPTION
Closes #51

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/pool.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/candidate_signals.py`, `src/main_core/l3_features/feature_math.py`, `src/main_core/l3_features/graph_adapter.py`, `src/main_core/l6_alpha/ab_runner.py`, `src/main_core/l6_alpha/fallback.py`


---
## P1 Backlog Cleanup (33 findings across 18 files)

Consolidated cleanup of P1 findings accumulated from milestone reviews. 
These are non-blocking improvements identified during code review.

**Fix all (or as many as feasible) in a single PR.** Items are grouped by file:


### `cross-cutting` (5 items)


- **L1** (conf=0.74, from PR #-92625): Multiplier store validation is split across multiple layers
  - Recommendation: Extract a single L3 multiplier validation helper and use it in the write API, store implementations, and builder read path. Add tests with a deliberately invalid custom store so the public builder always raises the same L3 error class.

- **L1** (conf=0.9, from PR #-36312): Milestone lacks cross-layer integration coverage
  - Recommendation: Add a minimal pure-market closed-loop test that derives world state, selects a pool, builds L6 contexts from the selected entities, generates recommendations, and verifies override plus constraint behavior. Include one task-level L6 inconclusive case and one stale-freeze case.

- **L1** (conf=0.86, from PR #-36682): Bundle parsing and object ordering logic is duplicated across L8 modules
  - Recommendation: Extract shared L8 utilities for ordered formal object keys and typed PublishBundle entry parsing. Keep dashboard/report-specific summarization separate, but make ref/payload/count validation a single public helper used by all L8 builders.

- **L1** (conf=0.84, from PR #-96178): Adapter merge and serialization rules are duplicated and inconsistent
  - Recommendation: Extract a shared JSON-like normalization helper and define explicit merge policies for external payloads. Prefer namespaced payloads such as graph_impact and candidate_signals, and make overwrite behavior either impossible or explicitly audited.

- **L1** (conf=0.78, from PR #-4093): Role-level evidence is discarded from formal and A/B outputs
  - Recommendation: Define a structured role diagnostics payload for multi_agent_v1, either as an Alpha