### PR TITLE
feat(#51): P1 backlog cleanup (33 findings, 18 files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "project-ult-main-core"
 version = "0.1.0"
 description = "Scaffold workspace for main-core."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [project.optional-dependencies]
@@ -28,3 +28,6 @@ where = ["src"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"

--- a/src/main_core/common/contexts.py
+++ b/src/main_core/common/contexts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from main_core.common.schemas import (
     FeatureSignalBundle,
@@ -23,6 +23,18 @@ class AlphaAnalysisContext(BaseModel):
     feature_bundle: FeatureSignalBundle
     world_state: WorldStateSnapshot
     similar_cases: list[dict[str, Any]] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_cycle_and_entity_consistency(self) -> AlphaAnalysisContext:
+        """Keep L6 analyzer context anchored to one cycle and entity."""
+
+        if self.feature_bundle.cycle_id != self.cycle_id:
+            raise ValueError("feature_bundle.cycle_id must match context.cycle_id")
+        if self.world_state.cycle_id != self.cycle_id:
+            raise ValueError("world_state.cycle_id must match context.cycle_id")
+        if self.feature_bundle.entity_id != self.entity_id:
+            raise ValueError("feature_bundle.entity_id must match context.entity_id")
+        return self
 
 
 class WorldStateInputs(BaseModel):

--- a/src/main_core/common/json_like.py
+++ b/src/main_core/common/json_like.py
@@ -1,0 +1,24 @@
+"""Shared JSON-like payload normalization helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def to_plain_json_like(value: Any) -> Any:
+    """Return a recursively plain JSON-like value for schema/report payloads."""
+
+    if isinstance(value, Mapping):
+        return {
+            str(key): to_plain_json_like(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, tuple | list):
+        return [to_plain_json_like(item) for item in value]
+    if isinstance(value, frozenset | set):
+        return sorted(to_plain_json_like(item) for item in value)
+    return value
+
+
+__all__ = ["to_plain_json_like"]

--- a/src/main_core/common/schemas/alpha.py
+++ b/src/main_core/common/schemas/alpha.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId, EntityId
@@ -24,6 +24,7 @@ class AlphaResultSnapshot(FormalObjectBase):
     rationale: str
     similar_cases: list[dict[str, Any]]
     status: AlphaStatus
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_inconclusive_score(self) -> AlphaResultSnapshot:

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from copy import deepcopy
+from decimal import Decimal
+from math import isfinite
 from types import MappingProxyType
 from typing import Any, Self
 
@@ -60,6 +62,20 @@ def _thaw_value(value: Any) -> Any:
     return value
 
 
+def _reject_non_finite_numbers(value: Any, path: str = "payload") -> None:
+    if isinstance(value, float) and not isfinite(value):
+        raise ValueError(f"{path} contains non-finite numeric value")
+    if isinstance(value, Decimal) and not value.is_finite():
+        raise ValueError(f"{path} contains non-finite numeric value")
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            _reject_non_finite_numbers(item, f"{path}.{key}")
+        return
+    if isinstance(value, (list, tuple, set, frozenset)):
+        for index, item in enumerate(value):
+            _reject_non_finite_numbers(item, f"{path}[{index}]")
+
+
 class FormalObjectBase(BaseModel):
     """Frozen schema base for formal and runtime contract objects."""
 
@@ -70,7 +86,9 @@ class FormalObjectBase(BaseModel):
         """Recursively freeze validated container fields before sharing objects."""
 
         for field_name in type(self).model_fields:
-            object.__setattr__(self, field_name, _freeze_value(getattr(self, field_name)))
+            field_value = getattr(self, field_name)
+            _reject_non_finite_numbers(field_value, field_name)
+            object.__setattr__(self, field_name, _freeze_value(field_value))
         return self
 
     @model_serializer(mode="plain")

--- a/src/main_core/common/schemas/pool.py
+++ b/src/main_core/common/schemas/pool.py
@@ -12,7 +12,7 @@ class OfficialAlphaPool(FormalObjectBase):
     """Formal L5 official alpha pool described in §9.3."""
 
     cycle_id: CycleId
-    observation_pool_size: int
+    observation_pool_size: int = Field(ge=0)
     official_alpha_pool_capacity: int = Field(default=100, ge=1, le=100)
     selected_entities: list[EntityId]
     added_entities: list[EntityId]
@@ -25,6 +25,8 @@ class OfficialAlphaPool(FormalObjectBase):
 
         if len(self.selected_entities) > self.official_alpha_pool_capacity:
             raise ValueError("selected_entities length must be <= official_alpha_pool_capacity")
+        if len(self.selected_entities) > self.observation_pool_size:
+            raise ValueError("selected_entities length must be <= observation_pool_size")
         return self
 
 

--- a/src/main_core/common/schemas/publish.py
+++ b/src/main_core/common/schemas/publish.py
@@ -2,10 +2,42 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
+from pydantic import Field, model_validator
+
+from main_core.common.json_like import to_plain_json_like
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId
+
+
+class ManifestReference(FormalObjectBase):
+    """Typed manifest anchor embedded in final publish bundles."""
+
+    cycle_id: CycleId
+    object_refs: dict[str, str]
+    manifest_ref: str
+    committed_objects: list[dict[str, Any]] = Field(default_factory=list)
+    manifest_version: str | None = None
+    table_snapshots: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_manifest_reference(self) -> ManifestReference:
+        """Require non-empty manifest and object refs."""
+
+        if not self.manifest_ref.strip():
+            raise ValueError("manifest_ref must be non-empty")
+        if not self.object_refs:
+            raise ValueError("object_refs must be non-empty when manifest_ref is present")
+        blank_object_keys = [
+            object_key
+            for object_key, object_ref in self.object_refs.items()
+            if not object_key.strip() or not object_ref.strip()
+        ]
+        if blank_object_keys:
+            raise ValueError("object_refs keys and values must be non-empty")
+        return self
 
 
 class PublishBundle(FormalObjectBase):
@@ -17,5 +49,35 @@ class PublishBundle(FormalObjectBase):
     audit_payload: dict[str, Any]
     retrospective_seed: dict[str, Any]
 
+    @model_validator(mode="after")
+    def validate_final_manifest_anchor(self) -> PublishBundle:
+        """Require final bundles to anchor each formal object in the manifest."""
 
-__all__ = ["PublishBundle"]
+        if "manifest_ref" not in self.manifest_candidate:
+            return self
+
+        manifest = ManifestReference.model_validate(
+            to_plain_json_like(self.manifest_candidate)
+        )
+        if manifest.cycle_id != self.cycle_id:
+            raise ValueError("manifest_candidate.cycle_id must match bundle cycle_id")
+        object_refs = dict(manifest.object_refs)
+        formal_object_keys = set(self.formal_objects)
+        manifest_object_keys = set(object_refs)
+        if manifest_object_keys != formal_object_keys:
+            raise ValueError(
+                "manifest_candidate.object_refs must exactly match formal_objects"
+            )
+
+        for object_key, entry in self.formal_objects.items():
+            if not isinstance(entry, Mapping):
+                raise ValueError(f"{object_key} formal object entry must be a mapping")
+            entry_ref = entry.get("ref")
+            if not isinstance(entry_ref, str) or not entry_ref.strip():
+                raise ValueError(f"{object_key}.ref must be a non-empty string")
+            if entry_ref != object_refs[object_key]:
+                raise ValueError(f"{object_key}.ref must match manifest object_refs")
+
+        return self
+
+__all__ = ["ManifestReference", "PublishBundle"]

--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -18,6 +18,7 @@ from main_core.l3_features.candidate_signals import (
 from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
 from main_core.l3_features.graph_adapter import load_graph_features, merge_graph_features
 from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 from main_core.l3_features.weight_api import (
     apply_weight_multiplier,
     get_feature_weight_multiplier,
@@ -44,4 +45,5 @@ __all__ = [
     "merge_candidate_signals",
     "merge_graph_features",
     "normalize_candidate_signals",
+    "validate_multiplier_mapping",
 ]

--- a/src/main_core/l3_features/candidate_signals.py
+++ b/src/main_core/l3_features/candidate_signals.py
@@ -71,15 +71,15 @@ def normalize_candidate_signals(
                 "candidate signal records must match the requested cycle_id"
             )
 
+        if str(record.entity_id) != str(entity_id):
+            continue
+
         record_key = (str(record.entity_id), record.source, record.signal_name)
         if record_key in seen_record_keys:
             raise CandidateSignalError(
                 "candidate signal records contain duplicate entity/source/signal_name"
             )
         seen_record_keys.add(record_key)
-
-        if str(record.entity_id) != str(entity_id):
-            continue
 
         if record.signal_name in normalized:
             raise CandidateSignalError(

--- a/src/main_core/l3_features/feature_math.py
+++ b/src/main_core/l3_features/feature_math.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation, localcontext
 from math import isfinite
+from typing import Any
 
 from main_core.l1_l2_basis.models import MarketBar
 from main_core.l3_features.errors import InvalidMultiplierError
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 
 
 def market_bar_feature_values(market_bar: MarketBar) -> dict[str, float]:
@@ -27,19 +30,41 @@ def apply_feature_weight_multiplier(
 ) -> tuple[dict[str, float], dict[str, float]]:
     """Apply known feature multipliers and return weighted features plus effective weights."""
 
-    effective_multipliers = {
-        feature_name: float(multipliers.get(feature_name, 1.0))
-        for feature_name in feature_values
-    }
+    effective_multipliers = validate_multiplier_mapping(
+        {
+            feature_name: multipliers.get(feature_name, 1.0)
+            for feature_name in feature_values
+        }
+    )
     weighted_feature_values = {}
     for feature_name, feature_value in feature_values.items():
-        weighted_feature_value = feature_value * effective_multipliers[feature_name]
+        weighted_feature_value = _weighted_decimal_float(
+            feature_value,
+            effective_multipliers[feature_name],
+        )
         if not isfinite(weighted_feature_value):
             raise InvalidMultiplierError(
                 "weighted feature values must be finite after applying multipliers"
             )
         weighted_feature_values[feature_name] = weighted_feature_value
     return weighted_feature_values, effective_multipliers
+
+
+def _weighted_decimal_float(feature_value: Any, multiplier: float) -> float:
+    try:
+        with localcontext() as context:
+            context.prec = 28
+            weighted_value = Decimal(str(feature_value)) * Decimal(str(multiplier))
+    except (InvalidOperation, ValueError) as exc:
+        raise InvalidMultiplierError(
+            "feature values and multipliers must be finite numeric values"
+        ) from exc
+
+    if not weighted_value.is_finite():
+        raise InvalidMultiplierError(
+            "weighted feature values must be finite after applying multipliers"
+        )
+    return float(weighted_value)
 
 
 __all__ = ["apply_feature_weight_multiplier", "market_bar_feature_values"]

--- a/src/main_core/l3_features/graph_adapter.py
+++ b/src/main_core/l3_features/graph_adapter.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from main_core.common.protocols import GraphSnapshotError as _GraphSnapshotError
+from main_core.common.json_like import to_plain_json_like
+from main_core.common.protocols import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+)
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.types import CycleId, EntityId
-
-if TYPE_CHECKING:
-    from main_core.common.protocols import GraphEnginePort, GraphImpactRecord
 
 
 def load_graph_features(
@@ -27,7 +30,7 @@ def load_graph_features(
     matching_records: list[GraphImpactRecord] = []
     for record in records:
         if str(record.cycle_id) != str(cycle_id):
-            raise _GraphSnapshotError(
+            raise GraphSnapshotError(
                 "graph impact snapshot contains records from a different cycle"
             )
         if str(record.entity_id) == str(entity_id):
@@ -36,14 +39,14 @@ def load_graph_features(
     if not matching_records:
         return {}
     if len(matching_records) > 1:
-        raise _GraphSnapshotError(
+        raise GraphSnapshotError(
             "graph impact snapshot contains duplicate records for entity"
         )
 
     record = matching_records[0]
     return {
         "snapshot_id": record.snapshot_id,
-        "features": _to_plain_json_like(record.features),
+        "features": to_plain_json_like(record.features),
     }
 
 
@@ -54,19 +57,15 @@ def merge_graph_features(
     """Return a new feature bundle with graph features merged in."""
 
     return bundle.model_copy(
-        update={"graph_features": _to_plain_json_like(graph_features)}
+        update={"graph_features": to_plain_json_like(graph_features)}
     )
 
 
-def _to_plain_json_like(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _to_plain_json_like(item) for key, item in value.items()}
-    if isinstance(value, tuple | list):
-        return [_to_plain_json_like(item) for item in value]
-    return value
-
-
 __all__ = [
+    "GraphEnginePort",
+    "GraphImpactRecord",
+    "GraphRegimeContext",
+    "GraphSnapshotError",
     "load_graph_features",
     "merge_graph_features",
 ]

--- a/src/main_core/l3_features/multiplier_store.py
+++ b/src/main_core/l3_features/multiplier_store.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from math import isfinite
 from threading import Lock
 from typing import Protocol, runtime_checkable
 
 from main_core.common.types import CycleId
-from main_core.l3_features.errors import InvalidMultiplierError
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 
 
 @runtime_checkable
@@ -46,26 +45,12 @@ class InMemoryMultiplierStore:
     ) -> None:
         """Validate and store multiplier updates for the requested cycle."""
 
-        validated_updates = _validated_multiplier_copy(updates)
+        validated_updates = validate_multiplier_mapping(updates)
         cycle_key = str(cycle_id)
         with self._lock:
             current_multipliers = dict(self._multipliers_by_cycle.get(cycle_key, {}))
             current_multipliers.update(validated_updates)
             self._multipliers_by_cycle[cycle_key] = current_multipliers
-
-
-def _validated_multiplier_copy(updates: Mapping[str, float]) -> dict[str, float]:
-    invalid_keys = [
-        feature_name
-        for feature_name, multiplier in updates.items()
-        if not isinstance(multiplier, int | float)
-        or isinstance(multiplier, bool)
-        or not isfinite(multiplier)
-        or multiplier <= 0
-    ]
-    if invalid_keys:
-        raise InvalidMultiplierError("feature weight multipliers must be finite and > 0")
-    return {feature_name: float(multiplier) for feature_name, multiplier in updates.items()}
 
 
 __all__ = ["InMemoryMultiplierStore", "MultiplierStore"]

--- a/src/main_core/l3_features/multiplier_validation.py
+++ b/src/main_core/l3_features/multiplier_validation.py
@@ -12,27 +12,31 @@ from main_core.l3_features.errors import InvalidMultiplierError
 def validate_multiplier_mapping(updates: Mapping[str, object]) -> dict[str, float]:
     """Return a float copy after enforcing positive finite multipliers."""
 
-    invalid_keys = [
-        str(feature_name)
-        for feature_name, multiplier in updates.items()
-        if not _is_valid_multiplier(multiplier)
-    ]
+    validated_updates: dict[str, float] = {}
+    invalid_keys: list[str] = []
+    for feature_name, multiplier in updates.items():
+        converted_multiplier = _validated_multiplier(multiplier)
+        if converted_multiplier is None:
+            invalid_keys.append(str(feature_name))
+            continue
+        validated_updates[str(feature_name)] = converted_multiplier
     if invalid_keys:
         raise InvalidMultiplierError("feature weight multipliers must be finite and > 0")
-    return {
-        str(feature_name): float(multiplier)
-        for feature_name, multiplier in updates.items()
-    }
+    return validated_updates
 
 
-def _is_valid_multiplier(multiplier: object) -> bool:
+def _validated_multiplier(multiplier: object) -> float | None:
     if isinstance(multiplier, bool):
-        return False
-    if isinstance(multiplier, int | float):
-        return isfinite(multiplier) and multiplier > 0
-    if isinstance(multiplier, Decimal):
-        return multiplier.is_finite() and multiplier > 0
-    return False
+        return None
+    if isinstance(multiplier, int | float | Decimal):
+        try:
+            converted_multiplier = float(multiplier)
+        except (OverflowError, ValueError):
+            return None
+        if isfinite(converted_multiplier) and converted_multiplier > 0:
+            return converted_multiplier
+        return None
+    return None
 
 
 __all__ = ["validate_multiplier_mapping"]

--- a/src/main_core/l3_features/multiplier_validation.py
+++ b/src/main_core/l3_features/multiplier_validation.py
@@ -1,0 +1,38 @@
+"""Shared validation for L3 feature weight multipliers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+from math import isfinite
+
+from main_core.l3_features.errors import InvalidMultiplierError
+
+
+def validate_multiplier_mapping(updates: Mapping[str, object]) -> dict[str, float]:
+    """Return a float copy after enforcing positive finite multipliers."""
+
+    invalid_keys = [
+        str(feature_name)
+        for feature_name, multiplier in updates.items()
+        if not _is_valid_multiplier(multiplier)
+    ]
+    if invalid_keys:
+        raise InvalidMultiplierError("feature weight multipliers must be finite and > 0")
+    return {
+        str(feature_name): float(multiplier)
+        for feature_name, multiplier in updates.items()
+    }
+
+
+def _is_valid_multiplier(multiplier: object) -> bool:
+    if isinstance(multiplier, bool):
+        return False
+    if isinstance(multiplier, int | float):
+        return isfinite(multiplier) and multiplier > 0
+    if isinstance(multiplier, Decimal):
+        return multiplier.is_finite() and multiplier > 0
+    return False
+
+
+__all__ = ["validate_multiplier_mapping"]

--- a/src/main_core/l3_features/weight_api.py
+++ b/src/main_core/l3_features/weight_api.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 
 from main_core.common.types import CycleId
 from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 
 _DEFAULT_MULTIPLIER_STORE = InMemoryMultiplierStore()
 
@@ -18,7 +19,8 @@ def apply_weight_multiplier(
 ) -> None:
     """Apply feature weight multiplier updates for a cycle."""
 
-    _resolve_store(store).put_multipliers(cycle_id, updates)
+    validated_updates = validate_multiplier_mapping(updates)
+    _resolve_store(store).put_multipliers(cycle_id, validated_updates)
 
 
 def get_feature_weight_multiplier(
@@ -28,7 +30,7 @@ def get_feature_weight_multiplier(
 ) -> dict[str, float]:
     """Return the currently visible feature weight multipliers for a cycle."""
 
-    return dict(_resolve_store(store).get_multipliers(cycle_id))
+    return validate_multiplier_mapping(_resolve_store(store).get_multipliers(cycle_id))
 
 
 def _resolve_store(store: MultiplierStore | None) -> MultiplierStore:

--- a/src/main_core/l6_alpha/__init__.py
+++ b/src/main_core/l6_alpha/__init__.py
@@ -1,6 +1,7 @@
 """L6 package: single-stock alpha analysis."""
 
 from main_core.l6_alpha.ab_runner import run_ab_evaluation, write_ab_report
+from main_core.l6_alpha.errors import AlphaAnalyzerError, AlphaReasonerError
 from main_core.l6_alpha.fallback import build_inconclusive_result
 from main_core.l6_alpha.multi_agent_analyzer import (
     AgentRoleConfig,
@@ -19,6 +20,8 @@ from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
 
 __all__ = [
     "AgentRoleConfig",
+    "AlphaAnalyzerError",
+    "AlphaReasonerError",
     "AlphaReasonerPort",
     "AlphaReasonerResponse",
     "MultiAgentAnalyzer",

--- a/src/main_core/l6_alpha/ab_runner.py
+++ b/src/main_core/l6_alpha/ab_runner.py
@@ -194,9 +194,10 @@ def format_ab_report_markdown(report: AbEvaluationReport) -> str:
             (
                 "| case_id | entity_id | baseline_analyzer_type | "
                 "challenger_analyzer_type | baseline_status | challenger_status | "
-                "score_delta | confidence_delta | status_matches |"
+                "score_delta | confidence_delta | status_matches | "
+                "baseline_error | challenger_error |"
             ),
-            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
     lines.extend(_case_markdown_row(case) for case in report.cases)
@@ -269,6 +270,8 @@ def _case_markdown_row(case: AbCaseResult) -> str:
         _format_value(case.score_delta),
         _format_value(case.confidence_delta),
         case.status_matches,
+        case.baseline_error,
+        case.challenger_error,
     ]
     return "| " + " | ".join(_escape_markdown(value) for value in values) + " |"
 

--- a/src/main_core/l6_alpha/ab_runner.py
+++ b/src/main_core/l6_alpha/ab_runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.protocols import AnalyzerInterface
+from main_core.common.schemas import AlphaResultSnapshot
 from main_core.common.types import EntityId
 
 
@@ -42,6 +43,10 @@ class AbCaseResult:
     score_delta: float | None
     confidence_delta: float
     status_matches: bool
+    baseline_error: str | None
+    challenger_error: str | None
+    baseline_diagnostics: dict[str, object]
+    challenger_diagnostics: dict[str, object]
 
 
 @dataclass(frozen=True)
@@ -57,6 +62,8 @@ class AbEvaluationReport:
     baseline_inconclusive_count: int
     challenger_inconclusive_count: int
     inconclusive_count_delta: int
+    baseline_failure_count: int
+    challenger_failure_count: int
     cases: tuple[AbCaseResult, ...]
 
 
@@ -68,16 +75,21 @@ def run_ab_evaluation(
 ) -> AbEvaluationReport:
     """Run baseline and challenger analyzers on the same supplied contexts."""
 
+    if not cases:
+        raise ValueError("A/B evaluation requires at least one case")
+
     case_results: list[AbCaseResult] = []
     score_abs_deltas: list[float] = []
     confidence_abs_deltas: list[float] = []
     status_match_count = 0
     baseline_inconclusive_count = 0
     challenger_inconclusive_count = 0
+    baseline_failure_count = 0
+    challenger_failure_count = 0
 
     for case in cases:
-        baseline_result = baseline.analyze(case.entity_id, case.context)
-        challenger_result = challenger.analyze(case.entity_id, case.context)
+        baseline_result, baseline_error = _safe_analyze(baseline, case)
+        challenger_result, challenger_error = _safe_analyze(challenger, case)
 
         status_matches = baseline_result.status == challenger_result.status
         if status_matches:
@@ -86,6 +98,10 @@ def run_ab_evaluation(
             baseline_inconclusive_count += 1
         if challenger_result.status == "inconclusive":
             challenger_inconclusive_count += 1
+        if baseline_error is not None:
+            baseline_failure_count += 1
+        if challenger_error is not None:
+            challenger_failure_count += 1
 
         score_delta: float | None = None
         if baseline_result.score is not None and challenger_result.score is not None:
@@ -111,6 +127,10 @@ def run_ab_evaluation(
                 score_delta=score_delta,
                 confidence_delta=confidence_delta,
                 status_matches=status_matches,
+                baseline_error=baseline_error,
+                challenger_error=challenger_error,
+                baseline_diagnostics=_result_diagnostics(baseline_result),
+                challenger_diagnostics=_result_diagnostics(challenger_result),
             )
         )
 
@@ -129,6 +149,8 @@ def run_ab_evaluation(
         inconclusive_count_delta=(
             challenger_inconclusive_count - baseline_inconclusive_count
         ),
+        baseline_failure_count=baseline_failure_count,
+        challenger_failure_count=challenger_failure_count,
         cases=tuple(case_results),
     )
 
@@ -152,6 +174,8 @@ def format_ab_report_markdown(report: AbEvaluationReport) -> str:
         ("baseline_inconclusive_count", report.baseline_inconclusive_count),
         ("challenger_inconclusive_count", report.challenger_inconclusive_count),
         ("inconclusive_count_delta", report.inconclusive_count_delta),
+        ("baseline_failure_count", report.baseline_failure_count),
+        ("challenger_failure_count", report.challenger_failure_count),
     ]
     lines = [
         "# L6 A/B Evaluation",
@@ -206,6 +230,8 @@ def _report_payload(report: AbEvaluationReport) -> dict[str, object]:
         "baseline_inconclusive_count": report.baseline_inconclusive_count,
         "challenger_inconclusive_count": report.challenger_inconclusive_count,
         "inconclusive_count_delta": report.inconclusive_count_delta,
+        "baseline_failure_count": report.baseline_failure_count,
+        "challenger_failure_count": report.challenger_failure_count,
         "cases": [_case_payload(case) for case in report.cases],
     }
 
@@ -225,6 +251,10 @@ def _case_payload(case: AbCaseResult) -> dict[str, object]:
         "score_delta": case.score_delta,
         "confidence_delta": case.confidence_delta,
         "status_matches": case.status_matches,
+        "baseline_error": case.baseline_error,
+        "challenger_error": case.challenger_error,
+        "baseline_diagnostics": case.baseline_diagnostics,
+        "challenger_diagnostics": case.challenger_diagnostics,
     }
 
 
@@ -247,6 +277,40 @@ def _mean(values: Sequence[float]) -> float | None:
     if not values:
         return None
     return sum(values) / len(values)
+
+
+def _safe_analyze(
+    analyzer: AnalyzerInterface,
+    case: AbEvaluationCase,
+) -> tuple[AlphaResultSnapshot, str | None]:
+    try:
+        return analyzer.analyze(case.entity_id, case.context), None
+    except Exception as exc:  # noqa: BLE001 - A/B reports record analyzer failures.
+        error = f"{type(exc).__name__}: {exc}"
+        return (
+            AlphaResultSnapshot(
+                cycle_id=case.context.cycle_id,
+                entity_id=case.entity_id,
+                analyzer_type=analyzer.analyzer_type,
+                score=None,
+                confidence=0.0,
+                rationale=f"inconclusive: analyzer failure: {error}",
+                similar_cases=[],
+                status="inconclusive",
+                diagnostics={
+                    "error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc),
+                    },
+                },
+            ),
+            error,
+        )
+
+
+def _result_diagnostics(result: AlphaResultSnapshot) -> dict[str, object]:
+    diagnostics = result.model_dump(mode="json").get("diagnostics", {})
+    return diagnostics if isinstance(diagnostics, dict) else {}
 
 
 def _format_value(value: object) -> str:

--- a/src/main_core/l6_alpha/errors.py
+++ b/src/main_core/l6_alpha/errors.py
@@ -1,0 +1,16 @@
+"""Shared L6 analyzer error types."""
+
+from __future__ import annotations
+
+from main_core.common.errors import MainCoreError
+
+
+class AlphaAnalyzerError(MainCoreError):
+    """Raised when an L6 analyzer contract is violated before provider work."""
+
+
+class AlphaReasonerError(MainCoreError):
+    """Raised when an L6 reasoner provider returns malformed infrastructure output."""
+
+
+__all__ = ["AlphaAnalyzerError", "AlphaReasonerError"]

--- a/src/main_core/l6_alpha/fallback.py
+++ b/src/main_core/l6_alpha/fallback.py
@@ -9,7 +9,6 @@ from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError
 from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
 from main_core.common.types import EntityId
-from main_core.l6_alpha.reasoner_port import AlphaReasonerResponse
 
 
 def build_inconclusive_result(
@@ -36,9 +35,7 @@ def build_inconclusive_result(
 def is_task_level_failure(error: BaseException) -> bool:
     """Return whether an exception should be downgraded to inconclusive."""
 
-    return isinstance(error, InconclusiveError) or (
-        isinstance(error, AlphaReasonerResponse) and error.task_failed
-    )
+    return isinstance(error, InconclusiveError)
 
 
 __all__ = ["build_inconclusive_result", "is_task_level_failure"]

--- a/src/main_core/l6_alpha/multi_agent_analyzer.py
+++ b/src/main_core/l6_alpha/multi_agent_analyzer.py
@@ -10,10 +10,11 @@ from typing import Any, ClassVar, Protocol, runtime_checkable
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
+from main_core.common.json_like import to_plain_json_like
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot
 from main_core.common.types import EntityId
-from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
+from main_core.l6_alpha.errors import AlphaAnalyzerError
 
 DEFAULT_MULTI_AGENT_ROLES: tuple[str, ...] = ("fundamental", "technical", "risk")
 
@@ -86,7 +87,7 @@ class StaticMultiAgentReasonerPort:
         role: AgentRoleConfig,
         payload: Mapping[str, Any],
     ) -> MultiAgentRoleResult:
-        """Return a configured role result or a stable zero-score default."""
+        """Return a configured role result or an explicit inconclusive role failure."""
 
         self.calls.append((entity_id, context, role, payload))
         if role.name in self.role_results:
@@ -94,10 +95,12 @@ class StaticMultiAgentReasonerPort:
 
         return MultiAgentRoleResult(
             role=role.name,
-            score=0.0,
+            score=None,
             confidence=0.0,
-            rationale=f"static {role.name} alpha analysis",
+            rationale=f"static {role.name} alpha analysis is not configured",
             evidence={"role": role.name},
+            task_failed=True,
+            failure_reason="static multi-agent role result is not configured",
         )
 
 
@@ -110,14 +113,14 @@ def build_multi_agent_input_payload(
     return {
         "cycle_id": context.cycle_id,
         "entity_id": entity_id,
-        "feature_values": _plain_value(context.feature_bundle.feature_values),
-        "signal_values": _plain_value(context.feature_bundle.signal_values),
-        "graph_features": _plain_value(context.feature_bundle.graph_features),
+        "feature_values": to_plain_json_like(context.feature_bundle.feature_values),
+        "signal_values": to_plain_json_like(context.feature_bundle.signal_values),
+        "graph_features": to_plain_json_like(context.feature_bundle.graph_features),
         "world_state": {
             "final_regime": context.world_state.final_regime,
             "llm_delta": context.world_state.llm_delta,
         },
-        "similar_cases": _plain_value(context.similar_cases),
+        "similar_cases": to_plain_json_like(context.similar_cases),
     }
 
 
@@ -149,6 +152,7 @@ def aggregate_role_results(
                 "confidence": 0.0,
                 "rationale": _all_failed_rationale(failed_results, roles),
                 "status": "inconclusive",
+                "diagnostics": _role_diagnostics(result_map.values()),
             },
         )
 
@@ -170,6 +174,7 @@ def aggregate_role_results(
             "confidence": weighted_confidence,
             "rationale": _aggregate_rationale(healthy_results, failed_results),
             "status": "ok",
+            "diagnostics": _role_diagnostics(result_map.values()),
         },
     )
 
@@ -224,6 +229,10 @@ class MultiAgentAnalyzer(AnalyzerBase):
                 )
             except MainCoreError:
                 raise
+            if result.role != role.name:
+                raise AlphaAnalyzerError(
+                    f"role result identity mismatch: expected {role.name}, got {result.role}"
+                )
             role_results.append(result)
 
         return aggregate_role_results(
@@ -248,6 +257,7 @@ def _multi_agent_result(
         rationale=fields["rationale"],
         similar_cases=[dict(case) for case in context.similar_cases],
         status=fields["status"],
+        diagnostics=fields.get("diagnostics", {}),
     )
 
 
@@ -274,6 +284,10 @@ def _role_result_map(
         if result.role in result_map:
             raise AlphaAnalyzerError(f"duplicate role result: {result.role}")
         result_map[result.role] = result
+    missing_roles = set(role_weight_map) - set(result_map)
+    if missing_roles:
+        missing = ", ".join(sorted(missing_roles))
+        raise AlphaAnalyzerError(f"missing role results: {missing}")
     return result_map
 
 
@@ -310,14 +324,28 @@ def _all_failed_rationale(
     return f"inconclusive: all multi-agent roles failed: {failures}"
 
 
-def _plain_value(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {key: _plain_value(item) for key, item in value.items()}
-    if isinstance(value, tuple | list):
-        return [_plain_value(item) for item in value]
-    if isinstance(value, frozenset | set):
-        return sorted(_plain_value(item) for item in value)
-    return value
+def _role_diagnostics(
+    role_results: Sequence[MultiAgentRoleResult],
+) -> dict[str, Any]:
+    sorted_results = sorted(role_results, key=lambda result: result.role)
+    return {
+        "roles": [
+            {
+                "role": result.role,
+                "score": result.score,
+                "confidence": result.confidence,
+                "task_failed": result.task_failed,
+                "failure_reason": result.failure_reason,
+                "evidence": to_plain_json_like(result.evidence),
+            }
+            for result in sorted_results
+        ],
+        "failed_roles": [
+            result.role
+            for result in sorted_results
+            if result.task_failed
+        ],
+    }
 
 
 __all__ = [

--- a/src/main_core/l6_alpha/single_prompt_analyzer.py
+++ b/src/main_core/l6_alpha/single_prompt_analyzer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from math import isfinite
 from typing import ClassVar
 
 from main_core.common.contexts import AlphaAnalysisContext
@@ -9,18 +11,16 @@ from main_core.common.errors import MainCoreError
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
 from main_core.common.types import EntityId
+from main_core.l6_alpha.errors import AlphaAnalyzerError, AlphaReasonerError
 from main_core.l6_alpha.fallback import (
     build_inconclusive_result,
     is_task_level_failure,
 )
 from main_core.l6_alpha.reasoner_port import (
     AlphaReasonerPort,
+    AlphaReasonerResponse,
     StaticAlphaReasonerPort,
 )
-
-
-class AlphaAnalyzerError(MainCoreError):
-    """Raised when the L6 analyzer contract is violated before provider work."""
 
 
 class SinglePromptAnalyzer(AnalyzerBase):
@@ -42,11 +42,15 @@ class SinglePromptAnalyzer(AnalyzerBase):
             raise AlphaAnalyzerError("entity_id must match context.entity_id")
 
         try:
-            response = self._reasoner_port.analyze_alpha(entity_id, context)
+            raw_response = self._reasoner_port.analyze_alpha(entity_id, context)
         except Exception as exc:
             if is_task_level_failure(exc):
                 return build_inconclusive_result(entity_id, context, str(exc))
-            raise
+            if isinstance(exc, MainCoreError):
+                raise
+            raise AlphaReasonerError("alpha reasoner provider failed") from exc
+
+        response = _coerce_reasoner_response(raw_response)
 
         if response.task_failed:
             reason = response.failure_reason or response.rationale or "alpha task failed"
@@ -57,6 +61,7 @@ class SinglePromptAnalyzer(AnalyzerBase):
                 similar_cases=response.similar_cases,
             )
 
+        _validate_successful_response(response)
         return single_prompt_result(
             cycle_id=context.cycle_id,
             entity_id=entity_id,
@@ -68,4 +73,30 @@ class SinglePromptAnalyzer(AnalyzerBase):
         )
 
 
-__all__ = ["AlphaAnalyzerError", "SinglePromptAnalyzer"]
+def _coerce_reasoner_response(raw_response: object) -> AlphaReasonerResponse:
+    if isinstance(raw_response, AlphaReasonerResponse):
+        return raw_response
+    raise AlphaReasonerError("alpha reasoner must return AlphaReasonerResponse")
+
+
+def _validate_successful_response(response: AlphaReasonerResponse) -> None:
+    if response.score is None or not isfinite(response.score):
+        raise AlphaReasonerError("successful alpha response score must be finite")
+    if not isfinite(response.confidence) or not 0.0 <= response.confidence <= 1.0:
+        raise AlphaReasonerError(
+            "successful alpha response confidence must be finite within 0.0..1.0"
+        )
+    if not isinstance(response.rationale, str) or not response.rationale.strip():
+        raise AlphaReasonerError("successful alpha response rationale must be non-empty")
+    if not isinstance(response.similar_cases, Sequence) or isinstance(
+        response.similar_cases,
+        (str, bytes),
+    ):
+        raise AlphaReasonerError("successful alpha response similar_cases must be a list")
+    if any(not isinstance(case, Mapping) for case in response.similar_cases):
+        raise AlphaReasonerError(
+            "successful alpha response similar_cases items must be mappings"
+        )
+
+
+__all__ = ["AlphaAnalyzerError", "AlphaReasonerError", "SinglePromptAnalyzer"]

--- a/src/main_core/l7_recommendation/__init__.py
+++ b/src/main_core/l7_recommendation/__init__.py
@@ -8,14 +8,17 @@ from main_core.l7_recommendation.override import (
     find_override,
     submit_override,
 )
+from main_core.l7_recommendation.rules import action_for_score, rating_for_action
 from main_core.l7_recommendation.service import generate_recommendations
 
 __all__ = [
     "DefaultConstraintProvider",
     "InMemoryOverrideStore",
     "OverrideStore",
+    "action_for_score",
     "apply_override",
     "find_override",
     "generate_recommendations",
+    "rating_for_action",
     "submit_override",
 ]

--- a/src/main_core/l7_recommendation/override.py
+++ b/src/main_core/l7_recommendation/override.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 from main_core.common.errors import MainCoreError
 from main_core.common.schemas import OverrideRecord, RecommendationSnapshot
 from main_core.common.types import CycleId, EntityId
+from main_core.l7_recommendation.rules import rating_for_action
 
 
 class OverrideStore(Protocol):
@@ -56,7 +57,7 @@ def submit_override(
     """Validate, store, and return a human override record."""
 
     override = _coerce_override(override_input)
-    active_store = store or _DEFAULT_OVERRIDE_STORE
+    active_store = store if store is not None else _DEFAULT_OVERRIDE_STORE
     return active_store.save(override)
 
 
@@ -65,9 +66,9 @@ def find_override(
     cycle_id: CycleId,
     entity_id: EntityId,
 ) -> OverrideRecord | None:
-    """Return the first override matching a cycle/entity pair."""
+    """Return the latest override matching a cycle/entity pair."""
 
-    for override in overrides:
+    for override in reversed(tuple(overrides)):
         if override.cycle_id == cycle_id and override.entity_id == entity_id:
             return override
     return None
@@ -94,7 +95,7 @@ def apply_override(
         updates["rating"] = None
         updates["confidence"] = None
     else:
-        updates["rating"] = _rating_for_action(override.action_type)
+        updates["rating"] = rating_for_action(override.action_type)
 
     return candidate.model_copy(update=updates)
 
@@ -103,15 +104,6 @@ def _coerce_override(override_input: OverrideRecord | Mapping[str, Any]) -> Over
     if isinstance(override_input, OverrideRecord):
         return override_input.model_copy()
     return OverrideRecord.model_validate(dict(override_input))
-
-
-def _rating_for_action(action_type: str) -> str:
-    ratings = {
-        "buy": "A",
-        "hold": "B",
-        "reduce": "C",
-    }
-    return ratings[action_type]
 
 
 __all__ = [

--- a/src/main_core/l7_recommendation/rules.py
+++ b/src/main_core/l7_recommendation/rules.py
@@ -1,0 +1,36 @@
+"""Shared deterministic L7 recommendation rules."""
+
+from __future__ import annotations
+
+BUY_SCORE_THRESHOLD = 0.65
+REDUCE_SCORE_THRESHOLD = 0.35
+
+_RATING_BY_ACTION = {
+    "buy": "A",
+    "hold": "B",
+    "reduce": "C",
+}
+
+
+def action_for_score(score: float) -> str:
+    """Map an alpha score to the deterministic recommendation action."""
+
+    if score >= BUY_SCORE_THRESHOLD:
+        return "buy"
+    if score <= REDUCE_SCORE_THRESHOLD:
+        return "reduce"
+    return "hold"
+
+
+def rating_for_action(action_type: str) -> str:
+    """Map a non-inconclusive action to the formal rating value."""
+
+    return _RATING_BY_ACTION[action_type]
+
+
+__all__ = [
+    "BUY_SCORE_THRESHOLD",
+    "REDUCE_SCORE_THRESHOLD",
+    "action_for_score",
+    "rating_for_action",
+]

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -23,9 +23,12 @@ from main_core.l7_recommendation.override import (
     apply_override,
     find_override,
 )
-
-BUY_SCORE_THRESHOLD = 0.65
-REDUCE_SCORE_THRESHOLD = 0.35
+from main_core.l7_recommendation.rules import (
+    BUY_SCORE_THRESHOLD,
+    REDUCE_SCORE_THRESHOLD,
+    action_for_score,
+    rating_for_action,
+)
 
 
 def generate_recommendations(  # noqa: PLR0913
@@ -164,12 +167,12 @@ def _candidate_from_analysis(analysis: AlphaResultSnapshot) -> RecommendationSna
     if not math.isfinite(analysis.confidence):
         raise MainCoreError("ok analysis confidence must be finite")
 
-    action_type = _action_for_score(analysis.score)
+    action_type = action_for_score(analysis.score)
     return RecommendationSnapshot(
         cycle_id=analysis.cycle_id,
         entity_id=analysis.entity_id,
         action_type=action_type,
-        rating=_rating_for_action(action_type),
+        rating=rating_for_action(action_type),
         confidence=analysis.confidence,
         triggered_by="system",
         override_applied=False,
@@ -202,23 +205,6 @@ def _validate_gated_identity(
         raise MainCoreError("constraint gate must preserve recommendation cycle_id")
     if candidate.entity_id != entity_id:
         raise MainCoreError("constraint gate must preserve recommendation entity_id")
-
-
-def _action_for_score(score: float) -> str:
-    if score >= BUY_SCORE_THRESHOLD:
-        return "buy"
-    if score <= REDUCE_SCORE_THRESHOLD:
-        return "reduce"
-    return "hold"
-
-
-def _rating_for_action(action_type: str) -> str:
-    ratings = {
-        "buy": "A",
-        "hold": "B",
-        "reduce": "C",
-    }
-    return ratings[action_type]
 
 
 __all__ = [

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -18,6 +18,7 @@ from main_core.l8_publish.audit_payload import (
     build_audit_payload,
     build_retrospective_seed,
 )
+from main_core.l8_publish.bundle_utils import ordered_formal_object_keys
 from main_core.l8_publish.manifest import (
     build_manifest_candidate,
     commit_formal_objects,
@@ -32,7 +33,6 @@ from main_core.l8_publish.publish_port import (
 )
 from main_core.l8_publish.refs import (
     ALPHA_RESULT_SNAPSHOT_KEY,
-    CANONICAL_FORMAL_OBJECT_KEYS,
     OFFICIAL_ALPHA_POOL_KEY,
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
@@ -320,7 +320,7 @@ def _build_bundle_formal_objects(
         for committed in committed_objects
     }
     bundle_formal_objects: dict[str, dict[str, Any]] = {}
-    for object_key in _ordered_object_keys(formal_objects):
+    for object_key in ordered_formal_object_keys(formal_objects):
         committed_object = committed_by_key.get(object_key)
         if committed_object is None:
             raise ManifestPublishError(f"missing commit result for {object_key}")
@@ -350,20 +350,6 @@ def _bundle_payload(value: FormalObjectValue) -> dict[str, Any] | list[dict[str,
         item.model_dump(mode="json")
         for item in value
     ]
-
-
-def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
-    canonical_keys = [
-        object_key
-        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
-        if object_key in formal_objects
-    ]
-    derived_keys = [
-        object_key
-        for object_key in formal_objects
-        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
-    ]
-    return (*canonical_keys, *derived_keys)
 
 
 __all__ = ["collect_formal_objects", "prepare_publish_bundle"]

--- a/src/main_core/l8_publish/audit_payload.py
+++ b/src/main_core/l8_publish/audit_payload.py
@@ -28,6 +28,16 @@ def build_audit_payload(
 
     alpha_results = _payload_list(formal_objects, ALPHA_RESULT_SNAPSHOT_KEY)
     recommendations = _payload_list(formal_objects, RECOMMENDATION_SNAPSHOT_KEY)
+    alpha_inconclusive_count = sum(
+        1
+        for alpha_result in alpha_results
+        if alpha_result.get("status") == "inconclusive"
+    )
+    recommendation_inconclusive_count = sum(
+        1
+        for recommendation in recommendations
+        if recommendation.get("action_type") == "inconclusive"
+    )
 
     return {
         "cycle_id": str(cycle_id),
@@ -35,11 +45,9 @@ def build_audit_payload(
         "commit_refs": _commit_refs(committed_objects),
         "manifest_ref": manifest.manifest_ref,
         "manifest_version": manifest.manifest_version,
-        "inconclusive_count": sum(
-            1
-            for alpha_result in alpha_results
-            if alpha_result.get("status") == "inconclusive"
-        ),
+        "inconclusive_count": recommendation_inconclusive_count,
+        "alpha_inconclusive_count": alpha_inconclusive_count,
+        "recommendation_inconclusive_count": recommendation_inconclusive_count,
         "override_applied_count": sum(
             1
             for recommendation in recommendations

--- a/src/main_core/l8_publish/bundle_utils.py
+++ b/src/main_core/l8_publish/bundle_utils.py
@@ -1,0 +1,139 @@
+"""Shared L8 publish-bundle parsing utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from main_core.common.errors import ManifestPublishError
+from main_core.common.schemas import PublishBundle
+from main_core.common.types import CycleId
+from main_core.l8_publish.publish_port import FormalObjectValue
+from main_core.l8_publish.refs import CANONICAL_FORMAL_OBJECT_KEYS, formal_object_ref
+
+MIN_CANONICAL_REF_PARTS = 3
+
+
+@dataclass(frozen=True)
+class FormalObjectEntry:
+    """Typed publish-bundle entry after ref, payload, and count validation."""
+
+    ref: str
+    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...]
+    count: int
+
+
+def ordered_formal_object_keys(
+    formal_objects: Mapping[str, FormalObjectValue],
+) -> tuple[str, ...]:
+    """Return canonical formal object keys before derived object keys."""
+
+    canonical_keys = [
+        object_key
+        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
+        if object_key in formal_objects
+    ]
+    derived_keys = [
+        object_key
+        for object_key in formal_objects
+        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
+    ]
+    return (*canonical_keys, *derived_keys)
+
+
+def parse_publish_bundle_entry(
+    bundle: PublishBundle,
+    object_key: str,
+    cycle_id: CycleId,
+    *,
+    payload_shape: Literal["mapping", "list"],
+) -> FormalObjectEntry:
+    """Validate and parse one typed formal object entry from a publish bundle."""
+
+    entry = _entry_mapping(bundle, object_key)
+    ref = formal_object_ref(bundle, object_key)
+    ensure_formal_object_ref_matches_cycle(object_key, ref, cycle_id)
+    payload = entry.get("payload", _MISSING)
+    if payload_shape == "mapping":
+        if not isinstance(payload, Mapping):
+            raise ManifestPublishError(f"{object_key}.payload must be a mapping")
+        count = _entry_count(entry, object_key)
+        if count != 1:
+            raise ManifestPublishError(f"{object_key}.count must be 1")
+        _ensure_payload_cycle(object_key, payload, cycle_id)
+        return FormalObjectEntry(ref=ref, payload=dict(payload), count=count)
+
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
+        raise ManifestPublishError(f"{object_key}.payload must be a list")
+
+    payload_items: list[Mapping[str, Any]] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, Mapping):
+            raise ManifestPublishError(
+                f"{object_key}.payload[{index}] must be a mapping"
+            )
+        _ensure_payload_cycle(object_key, item, cycle_id)
+        payload_items.append(dict(item))
+
+    count = _entry_count(entry, object_key)
+    if count != len(payload_items):
+        raise ManifestPublishError(f"{object_key}.count must match payload length")
+    return FormalObjectEntry(ref=ref, payload=tuple(payload_items), count=count)
+
+
+def ensure_formal_object_ref_matches_cycle(
+    object_key: str,
+    ref: str,
+    cycle_id: CycleId,
+) -> None:
+    """Validate the canonical object_key/cycle_id/ref shape exactly."""
+
+    parts = ref.split("/")
+    if (
+        len(parts) < MIN_CANONICAL_REF_PARTS
+        or parts[0] != object_key
+        or parts[1] != str(cycle_id)
+    ):
+        raise ManifestPublishError(f"{object_key}.ref must point to requested cycle_id")
+
+
+_MISSING = object()
+
+
+def _entry_mapping(bundle: PublishBundle, object_key: str) -> Mapping[str, Any]:
+    try:
+        entry = bundle.formal_objects[object_key]
+    except KeyError as exc:
+        raise ManifestPublishError(f"missing formal object entry {object_key}") from exc
+    if not isinstance(entry, Mapping):
+        raise ManifestPublishError(f"{object_key} formal object entry must be a mapping")
+    return entry
+
+
+def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
+    count = entry.get("count", _MISSING)
+    if (
+        not isinstance(count, int)
+        or isinstance(count, bool)
+        or count < 0
+    ):
+        raise ManifestPublishError(f"{object_key}.count must be a non-negative integer")
+    return count
+
+
+def _ensure_payload_cycle(
+    object_key: str,
+    payload: Mapping[str, Any],
+    cycle_id: CycleId,
+) -> None:
+    if payload.get("cycle_id") != str(cycle_id):
+        raise ManifestPublishError(f"{object_key}.payload cycle_id must match")
+
+
+__all__ = [
+    "FormalObjectEntry",
+    "ensure_formal_object_ref_matches_cycle",
+    "ordered_formal_object_keys",
+    "parse_publish_bundle_entry",
+]

--- a/src/main_core/l8_publish/dashboard.py
+++ b/src/main_core/l8_publish/dashboard.py
@@ -9,33 +9,25 @@ from typing import Any
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import DashboardSnapshot, PublishBundle
 from main_core.common.types import CycleId
+from main_core.l8_publish.bundle_utils import FormalObjectEntry, parse_publish_bundle_entry
 from main_core.l8_publish.refs import (
     ALPHA_RESULT_SNAPSHOT_KEY,
     OFFICIAL_ALPHA_POOL_KEY,
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
-    formal_object_ref,
 )
 
 DASHBOARD_SNAPSHOT_KEY = "dashboard_snapshot"
 
 _ACTION_TYPES = ("buy", "hold", "reduce", "inconclusive")
-_MISSING = object()
-
-
-@dataclass(frozen=True)
-class _FormalObjectEntry:
-    ref: str
-    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...]
-    count: int
 
 
 @dataclass(frozen=True)
 class _RequiredFormalObjects:
-    world_state: _FormalObjectEntry
-    pool: _FormalObjectEntry
-    alpha_results: _FormalObjectEntry
-    recommendations: _FormalObjectEntry
+    world_state: FormalObjectEntry
+    pool: FormalObjectEntry
+    alpha_results: FormalObjectEntry
+    recommendations: FormalObjectEntry
 
 
 def build_dashboard_snapshot(
@@ -65,10 +57,30 @@ def _extract_required_formal_objects(
         raise ManifestPublishError("publish bundle cycle_id must match requested cycle_id")
 
     return _RequiredFormalObjects(
-        world_state=_mapping_entry(bundle, WORLD_STATE_SNAPSHOT_KEY, cycle_id),
-        pool=_mapping_entry(bundle, OFFICIAL_ALPHA_POOL_KEY, cycle_id),
-        alpha_results=_list_entry(bundle, ALPHA_RESULT_SNAPSHOT_KEY, cycle_id),
-        recommendations=_list_entry(bundle, RECOMMENDATION_SNAPSHOT_KEY, cycle_id),
+        world_state=parse_publish_bundle_entry(
+            bundle,
+            WORLD_STATE_SNAPSHOT_KEY,
+            cycle_id,
+            payload_shape="mapping",
+        ),
+        pool=parse_publish_bundle_entry(
+            bundle,
+            OFFICIAL_ALPHA_POOL_KEY,
+            cycle_id,
+            payload_shape="mapping",
+        ),
+        alpha_results=parse_publish_bundle_entry(
+            bundle,
+            ALPHA_RESULT_SNAPSHOT_KEY,
+            cycle_id,
+            payload_shape="list",
+        ),
+        recommendations=parse_publish_bundle_entry(
+            bundle,
+            RECOMMENDATION_SNAPSHOT_KEY,
+            cycle_id,
+            payload_shape="list",
+        ),
     )
 
 
@@ -136,80 +148,6 @@ def _build_summary_cards(objects: _RequiredFormalObjects) -> dict[str, Any]:
             "entity_ids": override_entity_ids,
         },
     }
-
-
-def _mapping_entry(
-    bundle: PublishBundle,
-    object_key: str,
-    cycle_id: CycleId,
-) -> _FormalObjectEntry:
-    entry = _entry_mapping(bundle, object_key)
-    ref = formal_object_ref(bundle, object_key)
-    payload = entry.get("payload", _MISSING)
-    if not isinstance(payload, Mapping):
-        raise ManifestPublishError(f"{object_key}.payload must be a mapping")
-
-    count = _entry_count(entry, object_key)
-    if count != 1:
-        raise ManifestPublishError(f"{object_key}.count must be 1")
-    _ensure_payload_cycle(object_key, payload, cycle_id)
-    return _FormalObjectEntry(ref=ref, payload=dict(payload), count=count)
-
-
-def _list_entry(
-    bundle: PublishBundle,
-    object_key: str,
-    cycle_id: CycleId,
-) -> _FormalObjectEntry:
-    entry = _entry_mapping(bundle, object_key)
-    ref = formal_object_ref(bundle, object_key)
-    payload = entry.get("payload", _MISSING)
-    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
-        raise ManifestPublishError(f"{object_key}.payload must be a list")
-
-    payload_items: list[Mapping[str, Any]] = []
-    for index, item in enumerate(payload):
-        if not isinstance(item, Mapping):
-            raise ManifestPublishError(
-                f"{object_key}.payload[{index}] must be a mapping"
-            )
-        _ensure_payload_cycle(object_key, item, cycle_id)
-        payload_items.append(dict(item))
-
-    count = _entry_count(entry, object_key)
-    if count != len(payload_items):
-        raise ManifestPublishError(f"{object_key}.count must match payload length")
-    return _FormalObjectEntry(ref=ref, payload=tuple(payload_items), count=count)
-
-
-def _entry_mapping(bundle: PublishBundle, object_key: str) -> Mapping[str, Any]:
-    try:
-        entry = bundle.formal_objects[object_key]
-    except KeyError as exc:
-        raise ManifestPublishError(f"missing formal object entry {object_key}") from exc
-    if not isinstance(entry, Mapping):
-        raise ManifestPublishError(f"{object_key} formal object entry must be a mapping")
-    return entry
-
-
-def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
-    count = entry.get("count", _MISSING)
-    if (
-        not isinstance(count, int)
-        or isinstance(count, bool)
-        or count < 0
-    ):
-        raise ManifestPublishError(f"{object_key}.count must be a non-negative integer")
-    return count
-
-
-def _ensure_payload_cycle(
-    object_key: str,
-    payload: Mapping[str, Any],
-    cycle_id: CycleId,
-) -> None:
-    if payload.get("cycle_id") != str(cycle_id):
-        raise ManifestPublishError(f"{object_key}.payload cycle_id must match")
 
 
 def _as_mapping(

--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -8,13 +8,13 @@ from typing import Any
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import FormalObjectBase
 from main_core.common.types import CycleId
+from main_core.l8_publish.bundle_utils import ordered_formal_object_keys
 from main_core.l8_publish.publish_port import (
     CommittedFormalObject,
     DataPlatformPublishPort,
     FormalObjectValue,
     ManifestWriteResult,
 )
-from main_core.l8_publish.refs import CANONICAL_FORMAL_OBJECT_KEYS
 
 
 def commit_formal_objects(
@@ -25,7 +25,7 @@ def commit_formal_objects(
     """Commit formal object classes in stable order before manifest publication."""
 
     committed_objects: list[CommittedFormalObject] = []
-    for object_key in _ordered_object_keys(formal_objects):
+    for object_key in ordered_formal_object_keys(formal_objects):
         formal_object = formal_objects[object_key]
         payload = _commit_payload(formal_object)
         expected_row_count = _expected_row_count(formal_object)
@@ -116,20 +116,6 @@ def build_manifest_candidate(
             }
         )
     return candidate
-
-
-def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
-    canonical_keys = [
-        object_key
-        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
-        if object_key in formal_objects
-    ]
-    derived_keys = [
-        object_key
-        for object_key in formal_objects
-        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
-    ]
-    return (*canonical_keys, *derived_keys)
 
 
 def _commit_payload(value: FormalObjectValue) -> Mapping[str, Any]:

--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -8,7 +8,10 @@ from typing import Any
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import FormalObjectBase
 from main_core.common.types import CycleId
-from main_core.l8_publish.bundle_utils import ordered_formal_object_keys
+from main_core.l8_publish.bundle_utils import (
+    ensure_formal_object_ref_matches_cycle,
+    ordered_formal_object_keys,
+)
 from main_core.l8_publish.publish_port import (
     CommittedFormalObject,
     DataPlatformPublishPort,
@@ -62,6 +65,7 @@ def write_manifest_after_commits(
     """Write the cycle manifest only after all formal object commits succeed."""
 
     committed_tuple = tuple(committed_objects)
+    _validate_committed_formal_object_refs(cycle_id, committed_tuple)
     try:
         manifest = publish_port.write_cycle_manifest(
             cycle_id=cycle_id,
@@ -211,6 +215,30 @@ def _validate_manifest_write_result(
             raise ManifestPublishError(
                 f"manifest table_snapshots snapshot_id mismatch for {object_key}",
             )
+
+
+def _validate_committed_formal_object_refs(
+    cycle_id: CycleId,
+    committed_objects: Sequence[CommittedFormalObject],
+) -> None:
+    for committed_object in committed_objects:
+        if not isinstance(committed_object, CommittedFormalObject):
+            raise ManifestPublishError(
+                "manifest committed objects must be CommittedFormalObject",
+            )
+        if not _non_empty_string(committed_object.object_key):
+            raise ManifestPublishError(
+                "manifest committed object_key must be non-empty",
+            )
+        if not _non_empty_string(committed_object.ref):
+            raise ManifestPublishError(
+                f"{committed_object.object_key}.ref must be non-empty",
+            )
+        ensure_formal_object_ref_matches_cycle(
+            committed_object.object_key,
+            committed_object.ref,
+            cycle_id,
+        )
 
 
 def _non_empty_string(value: object) -> bool:

--- a/src/main_core/l8_publish/report.py
+++ b/src/main_core/l8_publish/report.py
@@ -134,7 +134,6 @@ def _build_appendix_refs(
         "alpha_result_ref": objects.alpha_results.ref,
         "recommendation_ref": objects.recommendations.ref,
         "manifest_ref": _manifest_ref(cycle_id, bundle),
-        "audit_payload_ref": _audit_payload_ref(cycle_id, bundle),
     }
 
 
@@ -142,21 +141,10 @@ def _manifest_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
     _ensure_same_cycle("manifest_candidate", bundle.manifest_candidate, cycle_id)
     manifest_ref = bundle.manifest_candidate.get("manifest_ref")
     if isinstance(manifest_ref, str) and manifest_ref:
-        _ensure_ref_points_to_cycle("manifest_ref", manifest_ref, cycle_id)
         return manifest_ref
     raise ManifestPublishError(
         "manifest_candidate.manifest_ref must be reserved before formal report build",
     )
-
-
-def _audit_payload_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
-    _ensure_same_cycle("audit_payload", bundle.audit_payload, cycle_id)
-    for key in ("audit_payload_ref", "ref"):
-        value = bundle.audit_payload.get(key)
-        if isinstance(value, str) and value:
-            _ensure_ref_points_to_cycle(key, value, cycle_id)
-            return value
-    return f"audit_payload/{cycle_id}"
 
 
 def _ensure_same_cycle(
@@ -165,17 +153,8 @@ def _ensure_same_cycle(
     cycle_id: CycleId,
 ) -> None:
     payload_cycle_id = payload.get("cycle_id")
-    if payload_cycle_id is not None and payload_cycle_id != str(cycle_id):
+    if payload_cycle_id != str(cycle_id):
         raise ManifestPublishError(f"{payload_name}.cycle_id must match")
-
-
-def _ensure_ref_points_to_cycle(
-    ref_name: str,
-    ref: str,
-    cycle_id: CycleId,
-) -> None:
-    if str(cycle_id) not in ref:
-        raise ManifestPublishError(f"{ref_name} must point to requested cycle_id")
 
 
 def _entity_ids_by_action(

--- a/tests/integration/test_pure_market_closed_loop.py
+++ b/tests/integration/test_pure_market_closed_loop.py
@@ -1,0 +1,137 @@
+"""Cross-layer pure-market L3-L7 closed-loop coverage."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import FeatureSignalBundle, OfficialAlphaPool
+from main_core.l4_world_state import derive_world_state
+from main_core.l5_universe import select_official_alpha_pool
+from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer
+from main_core.l7_recommendation import (
+    InMemoryOverrideStore,
+    generate_recommendations,
+    submit_override,
+)
+
+
+class MappingReasonerPort:
+    def __init__(self, responses: dict[str, AlphaReasonerResponse]) -> None:
+        self.responses = responses
+
+    def analyze_alpha(
+        self,
+        entity_id: str,
+        context: AlphaAnalysisContext,
+    ) -> AlphaReasonerResponse:
+        return self.responses[str(entity_id)]
+
+
+def test_pure_market_closed_loop_with_override_constraint_and_inconclusive() -> None:
+    cycle_id = "cycle_market_closed_loop"
+    bundles = [
+        _bundle(cycle_id, "ENT_A", 3.0),
+        _bundle(cycle_id, "ENT_B", 2.0),
+    ]
+    world_state = derive_world_state(bundles[0])
+    pool = select_official_alpha_pool(world_state, bundles, capacity=2)
+    bundle_by_entity = {str(bundle.entity_id): bundle for bundle in bundles}
+    reasoner_port = MappingReasonerPort(
+        {
+            "ENT_A": AlphaReasonerResponse(
+                score=0.8,
+                confidence=0.9,
+                rationale="strong current-cycle alpha",
+                similar_cases=[],
+            ),
+            "ENT_B": AlphaReasonerResponse(
+                score=None,
+                confidence=0.0,
+                rationale="provider timeout",
+                similar_cases=[],
+                task_failed=True,
+                failure_reason="task-level timeout",
+            ),
+        }
+    )
+    analyzer = SinglePromptAnalyzer(reasoner_port)
+    analyses = [
+        analyzer.analyze(
+            entity_id,
+            AlphaAnalysisContext(
+                cycle_id=cycle_id,
+                entity_id=entity_id,
+                feature_bundle=bundle_by_entity[str(entity_id)],
+                world_state=world_state,
+                similar_cases=[],
+            ),
+        )
+        for entity_id in pool.selected_entities
+    ]
+    override_store = InMemoryOverrideStore()
+    submit_override(
+        {
+            "cycle_id": cycle_id,
+            "entity_id": "ENT_A",
+            "submitted_by": "analyst",
+            "action_type": "buy",
+            "rationale": "manual conviction check",
+            "submitted_at": datetime(2026, 4, 17, 9, 30, tzinfo=UTC),
+        },
+        store=override_store,
+    )
+
+    recommendations = generate_recommendations(
+        pool,
+        analyses,
+        world_state,
+        override_store=override_store,
+    )
+
+    by_entity = {
+        str(recommendation.entity_id): recommendation
+        for recommendation in recommendations
+    }
+    assert by_entity["ENT_A"].action_type == "hold"
+    assert by_entity["ENT_A"].triggered_by == "human_decision"
+    assert by_entity["ENT_A"].override_applied is True
+    assert by_entity["ENT_A"].constraints_applied["regime_gate"] == "risk_off_buy_to_hold"
+    assert by_entity["ENT_B"].action_type == "inconclusive"
+    assert by_entity["ENT_B"].confidence is None
+
+
+def test_pure_market_closed_loop_rejects_stale_previous_freeze() -> None:
+    cycle_id = "cycle_market_closed_loop"
+    previous_pool = OfficialAlphaPool(
+        cycle_id=cycle_id,
+        observation_pool_size=1,
+        official_alpha_pool_capacity=2,
+        selected_entities=["ENT_STALE"],
+        added_entities=[],
+        removed_entities=[],
+        freeze_reason_map={"ENT_STALE": "stale freeze"},
+    )
+    world_state = derive_world_state(_bundle(cycle_id, "ENT_A", 3.0))
+
+    with pytest.raises(MainCoreError, match="frozen entities must be present"):
+        select_official_alpha_pool(
+            world_state,
+            [_bundle(cycle_id, "ENT_A", 3.0)],
+            previous_pool=previous_pool,
+            capacity=2,
+        )
+
+
+def _bundle(cycle_id: str, entity_id: str, momentum: float) -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_values={"momentum": momentum},
+        signal_values={"baseline_regime": "risk_off"},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )

--- a/tests/l3_features/test_builder.py
+++ b/tests/l3_features/test_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date
+from decimal import Decimal
 from sys import float_info
 from types import ModuleType
 
@@ -78,6 +79,16 @@ def test_feature_math_derives_market_features_and_applies_known_multipliers(
         "volume": 1.0,
         "return_1d": 1.0,
     }
+
+
+def test_feature_math_uses_decimal_arithmetic_before_schema_boundary() -> None:
+    weighted_features, effective_multipliers = apply_feature_weight_multiplier(
+        {"close_price": Decimal("0.1")},
+        {"close_price": Decimal("0.2")},
+    )
+
+    assert weighted_features == {"close_price": 0.02}
+    assert effective_multipliers == {"close_price": 0.2}
 
 
 def test_feature_math_omits_missing_return_1d(cycle_id: CycleId) -> None:
@@ -307,6 +318,35 @@ def test_default_multiplier_store_update_is_visible_to_same_cycle_build() -> Non
 
     assert bundles[0].feature_values["close_price"] == UPDATED_CLOSE_PRICE
     assert bundles[0].feature_weight_multiplier["close_price"] == UPDATED_CLOSE_MULTIPLIER
+
+
+def test_build_feature_signal_bundle_rejects_invalid_custom_multiplier_store(
+    cycle_id: CycleId,
+    active_entity: EntityMasterRow,
+    market_bar: MarketBar,
+) -> None:
+    class InvalidCustomMultiplierStore:
+        def get_multipliers(self, requested_cycle_id: CycleId | str) -> dict[str, float]:
+            return {"close_price": 0.0}
+
+        def put_multipliers(
+            self,
+            requested_cycle_id: CycleId | str,
+            updates: dict[str, float],
+        ) -> None:
+            raise AssertionError("builder should only read multipliers")
+
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(active_entity,),
+    )
+
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        build_feature_signal_bundle(
+            cycle_id,
+            data_port=port,
+            multiplier_store=InvalidCustomMultiplierStore(),
+        )
 
 
 def test_build_feature_signal_bundle_resolves_default_port_and_returns_single_bundle(

--- a/tests/l3_features/test_candidate_signals.py
+++ b/tests/l3_features/test_candidate_signals.py
@@ -23,6 +23,7 @@ from .conftest import FakeDataPlatformPort
 
 SCOPED_MULTIPLIER = 1.5
 UNSCOPED_MULTIPLIER = 0.75
+OTHER_ENTITY_DUPLICATE_IGNORED_VALUE = 3.0
 
 
 @dataclass
@@ -212,6 +213,41 @@ def test_normalize_candidate_signals_omits_other_entities() -> None:
         entity_id=EntityId("ENT_A"),
         multipliers={},
     ) == {}
+
+
+def test_normalize_candidate_signals_ignores_duplicate_records_for_other_entities() -> None:
+    cycle_id = CycleId("cycle-layer-b")
+
+    normalized = normalize_candidate_signals(
+        (
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_B"),
+                signal_name="layer_b_score",
+                value=1.0,
+            ),
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_B"),
+                signal_name="layer_b_score",
+                value=2.0,
+            ),
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_A"),
+                signal_name="layer_b_score",
+                value=3.0,
+            ),
+        ),
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_A"),
+        multipliers={},
+    )
+
+    assert (
+        normalized["layer_b_score"]["adjusted_value"]
+        == OTHER_ENTITY_DUPLICATE_IGNORED_VALUE
+    )
 
 
 def test_merge_candidate_signals_preserves_bundle_payload_without_mutating() -> None:

--- a/tests/l3_features/test_graph_adapter.py
+++ b/tests/l3_features/test_graph_adapter.py
@@ -20,6 +20,7 @@ from main_core.l3_features import (
     load_graph_features,
     merge_graph_features,
 )
+from main_core.l3_features.graph_adapter import GraphEnginePort as RuntimeGraphEnginePort
 
 from .conftest import FakeDataPlatformPort
 
@@ -70,6 +71,7 @@ def test_graph_engine_port_is_runtime_checkable_and_read_only() -> None:
         for name in dir(port)
         if name.startswith(("write_", "commit_", "mutate_"))
     }
+    assert RuntimeGraphEnginePort is GraphEnginePort
 
 
 def test_load_graph_features_returns_empty_without_port_or_matching_record() -> None:

--- a/tests/l3_features/test_multiplier_store.py
+++ b/tests/l3_features/test_multiplier_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
 from threading import Barrier
 
 import pytest
@@ -87,3 +88,8 @@ def test_in_memory_multiplier_store_rejects_invalid_values(
 def test_shared_multiplier_validator_rejects_invalid_values() -> None:
     with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
         validate_multiplier_mapping({"close_price": 0.0})
+
+
+def test_shared_multiplier_validator_rejects_decimal_float_overflow() -> None:
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        validate_multiplier_mapping({"close_price": Decimal("1e10000")})

--- a/tests/l3_features/test_multiplier_store.py
+++ b/tests/l3_features/test_multiplier_store.py
@@ -8,7 +8,11 @@ from threading import Barrier
 import pytest
 
 from main_core.common.types import CycleId
-from main_core.l3_features import InMemoryMultiplierStore, InvalidMultiplierError
+from main_core.l3_features import (
+    InMemoryMultiplierStore,
+    InvalidMultiplierError,
+    validate_multiplier_mapping,
+)
 
 
 def test_in_memory_multiplier_store_is_cycle_scoped() -> None:
@@ -78,3 +82,8 @@ def test_in_memory_multiplier_store_rejects_invalid_values(
         store.put_multipliers("cycle-001", {"close_price": invalid_multiplier})
 
     assert store.get_multipliers("cycle-001") == {}
+
+
+def test_shared_multiplier_validator_rejects_invalid_values() -> None:
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        validate_multiplier_mapping({"close_price": 0.0})

--- a/tests/l6_alpha/test_ab_runner.py
+++ b/tests/l6_alpha/test_ab_runner.py
@@ -154,6 +154,22 @@ def test_run_ab_evaluation_records_analyzer_failures() -> None:
     assert report.cases[0].baseline_diagnostics["error"]["type"] == "RuntimeError"
 
 
+def test_ab_report_markdown_includes_analyzer_failure_causes() -> None:
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=FailingAnalyzer(),
+        challenger=RecordingAnalyzer(
+            "multi_agent_v1",
+            {"ENT_A": _alpha_result("ENT_A", "multi_agent_v1", 0.6, 0.8, "ok")},
+        ),
+    )
+
+    markdown = format_ab_report_markdown(report)
+
+    assert "baseline_error | challenger_error" in markdown
+    assert "RuntimeError: provider exploded" in markdown
+
+
 def test_ab_report_json_serializes_multi_agent_role_diagnostics() -> None:
     context = _context("ENT_A")
     report = run_ab_evaluation(

--- a/tests/l6_alpha/test_ab_runner.py
+++ b/tests/l6_alpha/test_ab_runner.py
@@ -15,6 +15,12 @@ from main_core.l6_alpha.ab_runner import (
     run_ab_evaluation,
     write_ab_report,
 )
+from main_core.l6_alpha.multi_agent_analyzer import (
+    AgentRoleConfig,
+    MultiAgentAnalyzer,
+    MultiAgentRoleResult,
+    StaticMultiAgentReasonerPort,
+)
 
 EXPECTED_CONFIDENCE_MAE = 0.25
 EXPECTED_OK_SCORE_MAE = 0.3
@@ -39,6 +45,17 @@ class RecordingAnalyzer:
     ) -> AlphaResultSnapshot:
         self.calls.append((entity_id, context))
         return self.results[entity_id]
+
+
+class FailingAnalyzer:
+    analyzer_type = "single_prompt_v1"
+
+    def analyze(
+        self,
+        entity_id: str,
+        context: AlphaAnalysisContext,
+    ) -> AlphaResultSnapshot:
+        raise RuntimeError("provider exploded")
 
 
 def test_run_ab_evaluation_computes_metrics_from_same_contexts(monkeypatch) -> None:
@@ -84,6 +101,8 @@ def test_run_ab_evaluation_computes_metrics_from_same_contexts(monkeypatch) -> N
     assert report.baseline_inconclusive_count == 1
     assert report.challenger_inconclusive_count == 0
     assert report.inconclusive_count_delta == -1
+    assert report.baseline_failure_count == 0
+    assert report.challenger_failure_count == 0
     assert report.cases[0].score_delta == pytest.approx(EXPECTED_OK_SCORE_MAE)
     assert report.cases[1].score_delta is None
 
@@ -108,6 +127,61 @@ def test_ab_report_json_is_parseable_and_excludes_context_models() -> None:
     assert payload["cases"][0]["case_id"] == "case-a"
     assert "context" not in payload["cases"][0]
     assert "feature_bundle" not in json.dumps(payload)
+
+
+def test_run_ab_evaluation_requires_cases() -> None:
+    with pytest.raises(ValueError, match="at least one case"):
+        run_ab_evaluation(
+            [],
+            baseline=RecordingAnalyzer("single_prompt_v1", {}),
+            challenger=RecordingAnalyzer("multi_agent_v1", {}),
+        )
+
+
+def test_run_ab_evaluation_records_analyzer_failures() -> None:
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=FailingAnalyzer(),
+        challenger=RecordingAnalyzer(
+            "multi_agent_v1",
+            {"ENT_A": _alpha_result("ENT_A", "multi_agent_v1", 0.6, 0.8, "ok")},
+        ),
+    )
+
+    assert report.baseline_failure_count == 1
+    assert report.cases[0].baseline_status == "inconclusive"
+    assert report.cases[0].baseline_error == "RuntimeError: provider exploded"
+    assert report.cases[0].baseline_diagnostics["error"]["type"] == "RuntimeError"
+
+
+def test_ab_report_json_serializes_multi_agent_role_diagnostics() -> None:
+    context = _context("ENT_A")
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", context)],
+        baseline=RecordingAnalyzer(
+            "single_prompt_v1",
+            {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+        ),
+        challenger=MultiAgentAnalyzer(
+            StaticMultiAgentReasonerPort(
+                {
+                    "fundamental": MultiAgentRoleResult(
+                        "fundamental",
+                        0.8,
+                        0.9,
+                        "fundamental evidence",
+                        evidence={"drivers": ("quality", "growth")},
+                    ),
+                }
+            ),
+            roles=(AgentRoleConfig("fundamental"),),
+        ),
+    )
+
+    payload = json.loads(format_ab_report_json(report))
+
+    diagnostics = payload["cases"][0]["challenger_diagnostics"]
+    assert diagnostics["roles"][0]["evidence"] == {"drivers": ["quality", "growth"]}
 
 
 def test_ab_report_markdown_uses_stable_summary_and_case_tables() -> None:

--- a/tests/l6_alpha/test_fallback.py
+++ b/tests/l6_alpha/test_fallback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
-from main_core.l6_alpha import AlphaReasonerResponse, build_inconclusive_result
+from main_core.l6_alpha import build_inconclusive_result
 from main_core.l6_alpha.fallback import is_task_level_failure
 
 
@@ -42,14 +42,5 @@ def test_build_inconclusive_result_accepts_explicit_similar_cases(
 
 def test_is_task_level_failure_only_accepts_inconclusive_errors() -> None:
     assert is_task_level_failure(InconclusiveError("single stock task failed"))
-    assert is_task_level_failure(
-        AlphaReasonerResponse(
-            score=None,
-            confidence=0.0,
-            rationale="provider task failed",
-            similar_cases=[],
-            task_failed=True,
-        ),
-    )
     assert not is_task_level_failure(MainCoreError("infrastructure failed"))
     assert not is_task_level_failure(RuntimeError("unknown failure"))

--- a/tests/l6_alpha/test_multi_agent_analyzer.py
+++ b/tests/l6_alpha/test_multi_agent_analyzer.py
@@ -110,6 +110,9 @@ def test_multi_agent_analyzer_happy_path_returns_formal_result(
     assert result.confidence == pytest.approx(EXPECTED_WEIGHTED_CONFIDENCE)
     assert "fundamental case is strong" in result.rationale
     assert "technical case is mixed" in result.rationale
+    assert result.diagnostics["roles"][0]["role"] == "fundamental"
+    assert result.diagnostics["roles"][0]["evidence"] == {"metric": "quality"}
+    assert result.diagnostics["failed_roles"] == ()
     assert [call[2].name for call in port.calls] == ["fundamental", "technical"]
 
 
@@ -180,6 +183,7 @@ def test_single_role_task_failure_keeps_ok_result_and_records_reason(
     assert result.status == "ok"
     assert result.score == HEALTHY_ONLY_SCORE
     assert "risk failed: risk provider timeout" in result.rationale
+    assert result.diagnostics["failed_roles"] == ("risk",)
 
 
 def test_inconclusive_role_error_is_downgraded_to_role_failure(
@@ -233,6 +237,40 @@ def test_all_role_task_failures_return_multi_agent_inconclusive(
     assert result.confidence == 0.0
     assert "fundamental: no data" in result.rationale
     assert "risk: timeout" in result.rationale
+    assert result.diagnostics["failed_roles"] == ("fundamental", "risk")
+
+
+def test_aggregate_role_results_rejects_missing_configured_role(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    with pytest.raises(AlphaAnalyzerError, match="missing role results"):
+        aggregate_role_results(
+            "ENT_A",
+            analysis_context,
+            (MultiAgentRoleResult("fundamental", 0.7, 0.8, "fundamental"),),
+            roles=(AgentRoleConfig("fundamental"), AgentRoleConfig("technical")),
+        )
+
+
+def test_multi_agent_analyzer_rejects_permuted_role_identity(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = MultiAgentAnalyzer(
+        RecordingMultiAgentPort(
+            {
+                "fundamental": MultiAgentRoleResult(
+                    "technical",
+                    0.7,
+                    0.8,
+                    "wrong role",
+                ),
+            }
+        ),
+        roles=(AgentRoleConfig("fundamental"),),
+    )
+
+    with pytest.raises(AlphaAnalyzerError, match="identity mismatch"):
+        analyzer.analyze("ENT_A", analysis_context)
 
 
 def test_main_core_error_from_role_hard_stops_without_fallback(

--- a/tests/l6_alpha/test_single_prompt_analyzer.py
+++ b/tests/l6_alpha/test_single_prompt_analyzer.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
 from main_core.common.schemas import AlphaResultSnapshot
-from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer
+from main_core.l6_alpha import AlphaReasonerError, AlphaReasonerResponse, SinglePromptAnalyzer
 from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
 
 EXPECTED_FEATURE_MOMENTUM = 4.2
@@ -39,6 +40,18 @@ class RecordingReasonerPort:
         self.calls.append((entity_id, context))
         if self.error is not None:
             raise self.error
+        return self.response
+
+
+class MalformedReasonerPort:
+    def __init__(self, response: object) -> None:
+        self.response = response
+
+    def analyze_alpha(
+        self,
+        entity_id: object,
+        context: AlphaAnalysisContext,
+    ) -> object:
         return self.response
 
 
@@ -76,6 +89,39 @@ def test_single_prompt_analyzer_rejects_entity_mismatch_without_calling_reasoner
         analyzer.analyze("ENT_OTHER", analysis_context)
 
     assert port.calls == []
+
+
+@pytest.mark.parametrize(
+    "context_update",
+    [
+        {"cycle_id": "cycle_other"},
+        {
+            "feature_bundle": lambda context: context.feature_bundle.model_copy(
+                update={"cycle_id": "cycle_other"}
+            )
+        },
+        {
+            "world_state": lambda context: context.world_state.model_copy(
+                update={"cycle_id": "cycle_other"}
+            )
+        },
+        {
+            "feature_bundle": lambda context: context.feature_bundle.model_copy(
+                update={"entity_id": "ENT_OTHER"}
+            )
+        },
+    ],
+)
+def test_alpha_analysis_context_rejects_upstream_consistency_mismatch(
+    analysis_context: AlphaAnalysisContext,
+    context_update: dict[str, object],
+) -> None:
+    payload = analysis_context.model_dump(mode="python")
+    for key, value in context_update.items():
+        payload[key] = value(analysis_context) if callable(value) else value
+
+    with pytest.raises(ValidationError, match="must match context"):
+        AlphaAnalysisContext(**payload)
 
 
 def test_single_prompt_analyzer_converts_task_failed_response_to_inconclusive(
@@ -126,6 +172,56 @@ def test_single_prompt_analyzer_propagates_main_core_infrastructure_errors(
     )
 
     with pytest.raises(MainCoreError, match="reasoner unavailable"):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"score": 0.5, "confidence": 0.6, "rationale": "dict payload"},
+        object(),
+    ],
+)
+def test_single_prompt_analyzer_rejects_malformed_reasoner_return_values(
+    analysis_context: AlphaAnalysisContext,
+    response: object,
+) -> None:
+    analyzer = SinglePromptAnalyzer(MalformedReasonerPort(response))
+
+    with pytest.raises(AlphaReasonerError, match="AlphaReasonerResponse"):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        AlphaReasonerResponse(
+            score=None,
+            confidence=0.6,
+            rationale="missing score",
+            similar_cases=[],
+        ),
+        AlphaReasonerResponse(
+            score=0.5,
+            confidence=1.5,
+            rationale="bad confidence",
+            similar_cases=[],
+        ),
+        AlphaReasonerResponse(
+            score=0.5,
+            confidence=0.6,
+            rationale=" ",
+            similar_cases=[],
+        ),
+    ],
+)
+def test_single_prompt_analyzer_rejects_malformed_successful_responses(
+    analysis_context: AlphaAnalysisContext,
+    response: AlphaReasonerResponse,
+) -> None:
+    analyzer = SinglePromptAnalyzer(RecordingReasonerPort(response))
+
+    with pytest.raises(AlphaReasonerError):
         analyzer.analyze("ENT_A", analysis_context)
 
 

--- a/tests/l7_recommendation/test_override.py
+++ b/tests/l7_recommendation/test_override.py
@@ -68,12 +68,31 @@ def test_submit_override_accepts_existing_record() -> None:
     assert store.records == (stored_override,)
 
 
+def test_submit_override_honors_falsey_custom_store() -> None:
+    class FalseyOverrideStore(InMemoryOverrideStore):
+        def __len__(self) -> int:
+            return 0
+
+    store = FalseyOverrideStore()
+
+    override = submit_override(_override_payload(action_type="reduce"), store=store)
+
+    assert store.records == (override,)
+
+
 def test_find_override_returns_matching_cycle_entity_record() -> None:
     first = OverrideRecord(**_override_payload(entity_id="ENT_B", action_type="reduce"))
     second = OverrideRecord(**_override_payload())
 
     assert find_override([first, second], "cycle_l7", "ENT_A") == second
     assert find_override([first, second], "cycle_l7", "ENT_Z") is None
+
+
+def test_find_override_returns_latest_matching_record() -> None:
+    older = OverrideRecord(**_override_payload(action_type="buy"))
+    newer = OverrideRecord(**_override_payload(action_type="reduce"))
+
+    assert find_override([older, newer], "cycle_l7", "ENT_A") == newer
 
 
 def test_apply_override_sets_human_audit_fields_and_keeps_constraints() -> None:

--- a/tests/l7_recommendation/test_service.py
+++ b/tests/l7_recommendation/test_service.py
@@ -22,6 +22,7 @@ from main_core.l7_recommendation import (
     generate_recommendations,
     submit_override,
 )
+from main_core.l7_recommendation.rules import action_for_score, rating_for_action
 from main_core.l7_recommendation.service import (
     BUY_SCORE_THRESHOLD,
     REDUCE_SCORE_THRESHOLD,
@@ -128,6 +129,12 @@ def test_generate_recommendations_maps_scores_in_pool_order() -> None:
         "reduce",
     ]
     assert [recommendation.rating for recommendation in recommendations] == ["B", "A", "C"]
+
+
+def test_shared_action_rating_rules_cover_thresholds() -> None:
+    assert action_for_score(BUY_SCORE_THRESHOLD) == "buy"
+    assert action_for_score(REDUCE_SCORE_THRESHOLD) == "reduce"
+    assert rating_for_action("hold") == "B"
 
 
 def test_generate_recommendations_passes_inconclusive_through_explicitly() -> None:
@@ -316,6 +323,27 @@ def test_generate_recommendations_honors_explicit_falsey_override_store(
     assert recommendation.action_type == "hold"
     assert recommendation.triggered_by == "system"
     assert recommendation.override_applied is False
+
+
+def test_submit_override_falsey_store_feeds_recommendation_generation() -> None:
+    class FalseyOverrideStore(InMemoryOverrideStore):
+        def __len__(self) -> int:
+            return 0
+
+    store = FalseyOverrideStore()
+    submit_override(_override("ENT_A", "reduce"), store=store)
+    pool = _pool(("ENT_A",))
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.8)],
+        _world_state(),
+        override_store=store,
+    )
+
+    assert recommendation.action_type == "reduce"
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
 
 
 def test_generate_recommendations_force_inconclusive_passes_schema_validation() -> None:

--- a/tests/l8_publish/test_assembler.py
+++ b/tests/l8_publish/test_assembler.py
@@ -91,6 +91,11 @@ def test_prepare_publish_bundle_returns_canonical_formal_object_entries() -> Non
         FORMAL_REPORT_KEY: SINGLE_OBJECT_COUNT,
     }
     assert bundle_payload["audit_payload"]["inconclusive_count"] == SINGLE_OBJECT_COUNT
+    assert (
+        bundle_payload["audit_payload"]["recommendation_inconclusive_count"]
+        == SINGLE_OBJECT_COUNT
+    )
+    assert bundle_payload["audit_payload"]["alpha_inconclusive_count"] == SINGLE_OBJECT_COUNT
     assert bundle_payload["audit_payload"]["override_applied_count"] == SINGLE_OBJECT_COUNT
     assert bundle_payload["retrospective_seed"]["selected_entity_ids"] == [
         "ENT_A",
@@ -231,3 +236,23 @@ def test_formal_object_ref_rejects_missing_entry() -> None:
 
     with pytest.raises(ManifestPublishError, match="missing formal object"):
         formal_object_ref(bundle, "backtest_result")
+
+
+def test_audit_payload_counts_recommendation_inconclusive_separately() -> None:
+    source = FakeFormalObjectSource(
+        loaded_pool=pool(("ENT_A",)),
+        loaded_alpha_results=[alpha_result("ENT_A", score=0.8, status="ok")],
+        loaded_recommendations=[recommendation("ENT_A", action_type="inconclusive")],
+    )
+
+    bundle = prepare_publish_bundle(
+        "cycle_l8",
+        source=source,
+        publish_port=RecordingPublishPort(),
+        derived_builders=(),
+    )
+
+    audit_payload = bundle.model_dump(mode="json")["audit_payload"]
+    assert audit_payload["alpha_inconclusive_count"] == 0
+    assert audit_payload["recommendation_inconclusive_count"] == 1
+    assert audit_payload["inconclusive_count"] == 1

--- a/tests/l8_publish/test_dashboard.py
+++ b/tests/l8_publish/test_dashboard.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import PublishBundle
@@ -41,12 +42,10 @@ def test_build_dashboard_snapshot_happy_path() -> None:
 
 
 def test_build_dashboard_snapshot_rejects_missing_ref() -> None:
-    bundle = _mutated_bundle(
-        lambda payload: payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY].pop("ref")
-    )
-
-    with pytest.raises(ManifestPublishError, match="ref"):
-        build_dashboard_snapshot("cycle_l8", bundle)
+    with pytest.raises(ValidationError, match="ref"):
+        _mutated_bundle(
+            lambda payload: payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY].pop("ref")
+        )
 
 
 def test_build_dashboard_snapshot_rejects_cycle_mismatch() -> None:
@@ -57,6 +56,29 @@ def test_build_dashboard_snapshot_rejects_cycle_mismatch() -> None:
     )
 
     with pytest.raises(ManifestPublishError, match="cycle_id"):
+        build_dashboard_snapshot("cycle_l8", bundle)
+
+
+@pytest.mark.parametrize(
+    "object_key",
+    [
+        WORLD_STATE_SNAPSHOT_KEY,
+        "official_alpha_pool",
+        "alpha_result_snapshot",
+        "recommendation_snapshot",
+    ],
+)
+def test_build_dashboard_snapshot_rejects_stale_formal_object_refs(
+    object_key: str,
+) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        stale_ref = f"{object_key}/cycle_other/ref"
+        payload["formal_objects"][object_key]["ref"] = stale_ref
+        payload["manifest_candidate"]["object_refs"][object_key] = stale_ref
+
+    bundle = _mutated_bundle(mutate)
+
+    with pytest.raises(ManifestPublishError, match="requested cycle_id"):
         build_dashboard_snapshot("cycle_l8", bundle)
 
 

--- a/tests/l8_publish/test_dashboard_report_publish_integration.py
+++ b/tests/l8_publish/test_dashboard_report_publish_integration.py
@@ -107,7 +107,11 @@ def test_formal_report_uses_reserved_manifest_ref_in_committed_payload() -> None
     assert payload["formal_objects"][FORMAL_REPORT_KEY]["payload"]["appendix_refs"][
         "manifest_ref"
     ] == manifest_ref
+    assert "audit_payload_ref" not in payload["formal_objects"][FORMAL_REPORT_KEY][
+        "payload"
+    ]["appendix_refs"]
     assert report_commit_payload["appendix_refs"]["manifest_ref"] == manifest_ref
+    assert "audit_payload_ref" not in report_commit_payload["appendix_refs"]
 
 
 def test_manifest_ref_mismatch_fails_before_visible_manifest_write() -> None:

--- a/tests/l8_publish/test_manifest.py
+++ b/tests/l8_publish/test_manifest.py
@@ -196,6 +196,26 @@ def test_prepare_publish_bundle_raises_when_manifest_write_fails() -> None:
     assert publish_port.manifest_calls == []
 
 
+def test_prepare_publish_bundle_rejects_stale_committed_ref_before_manifest_write() -> None:
+    publish_port = StaleRecommendationRefPublishPort()
+
+    with pytest.raises(ManifestPublishError, match="recommendation_snapshot.ref"):
+        prepare_publish_bundle(
+            "cycle_l8",
+            source=FakeFormalObjectSource(),
+            publish_port=publish_port,
+            derived_builders=(),
+        )
+
+    assert [call[1] for call in publish_port.commit_calls] == [
+        WORLD_STATE_SNAPSHOT_KEY,
+        OFFICIAL_ALPHA_POOL_KEY,
+        ALPHA_RESULT_SNAPSHOT_KEY,
+        RECOMMENDATION_SNAPSHOT_KEY,
+    ]
+    assert publish_port.manifest_calls == []
+
+
 class InvalidCommitResultPublishPort(RecordingPublishPort):
     def __init__(self, *, override: Mapping[str, Any]) -> None:
         super().__init__()
@@ -219,6 +239,30 @@ class InvalidCommitResultPublishPort(RecordingPublishPort):
             snapshot_id=self.override.get("snapshot_id", committed.snapshot_id),
             payload_hash=self.override.get("payload_hash", committed.payload_hash),
             row_count=self.override.get("row_count", committed.row_count),
+        )
+
+
+class StaleRecommendationRefPublishPort(RecordingPublishPort):
+    def commit_formal_object(
+        self,
+        *,
+        cycle_id: CycleId,
+        object_key: str,
+        payload: Mapping[str, Any],
+    ) -> CommittedFormalObject:
+        committed = super().commit_formal_object(
+            cycle_id=cycle_id,
+            object_key=object_key,
+            payload=payload,
+        )
+        if object_key != RECOMMENDATION_SNAPSHOT_KEY:
+            return committed
+        return CommittedFormalObject(
+            object_key=committed.object_key,
+            ref=f"{RECOMMENDATION_SNAPSHOT_KEY}/cycle_old/ref",
+            snapshot_id=committed.snapshot_id,
+            payload_hash=committed.payload_hash,
+            row_count=committed.row_count,
         )
 
 

--- a/tests/l8_publish/test_report.py
+++ b/tests/l8_publish/test_report.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import PublishBundle
@@ -36,17 +37,16 @@ def test_build_formal_report_happy_path() -> None:
         "alpha_result_ref": "alpha_result_snapshot/cycle_l8/ref",
         "recommendation_ref": "recommendation_snapshot/cycle_l8/ref",
         "manifest_ref": "manifest/cycle_l8",
-        "audit_payload_ref": "audit_payload/cycle_l8",
     }
 
 
 def test_build_formal_report_rejects_missing_ref() -> None:
-    bundle = _mutated_bundle(
-        lambda payload: payload["formal_objects"][RECOMMENDATION_SNAPSHOT_KEY].pop("ref")
-    )
-
-    with pytest.raises(ManifestPublishError, match="ref"):
-        build_formal_report("cycle_l8", bundle)
+    with pytest.raises(ValidationError, match="ref"):
+        _mutated_bundle(
+            lambda payload: payload["formal_objects"][RECOMMENDATION_SNAPSHOT_KEY].pop(
+                "ref"
+            )
+        )
 
 
 def test_build_formal_report_rejects_missing_manifest_ref() -> None:
@@ -59,12 +59,24 @@ def test_build_formal_report_rejects_missing_manifest_ref() -> None:
 
 
 def test_build_formal_report_rejects_cycle_mismatch() -> None:
+    with pytest.raises(ValidationError, match="cycle_id"):
+        _mutated_bundle(
+            lambda payload: payload.__setitem__("cycle_id", "cycle_other")
+        )
+
+
+def test_build_formal_report_accepts_opaque_manifest_ref() -> None:
     bundle = _mutated_bundle(
-        lambda payload: payload.__setitem__("cycle_id", "cycle_other")
+        lambda payload: payload["manifest_candidate"].__setitem__(
+            "manifest_ref",
+            "pg://cycle_publish_manifest/42",
+        )
     )
 
-    with pytest.raises(ManifestPublishError, match="cycle_id"):
-        build_formal_report("cycle_l8", bundle)
+    report = build_formal_report("cycle_l8", bundle)
+
+    assert report.appendix_refs["manifest_ref"] == "pg://cycle_publish_manifest/42"
+    assert "audit_payload_ref" not in report.appendix_refs
 
 
 def test_build_formal_report_keeps_inconclusive_outcomes_visible() -> None:

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -106,4 +106,4 @@ def test_multi_agent_analyzer_returns_multi_agent_result() -> None:
     result = analyzer.analyze(ENTITY_ID, _analysis_context())
 
     assert result.analyzer_type == MULTI_AGENT_ANALYZER
-    assert result.status == "ok"
+    assert result.status == "inconclusive"

--- a/tests/protocols/test_graph_engine_contract.py
+++ b/tests/protocols/test_graph_engine_contract.py
@@ -52,11 +52,19 @@ def test_l3_graph_exports_are_compatibility_aliases() -> None:
     assert l3_features.GraphSnapshotError is GraphSnapshotError
 
 
-def test_l3_adapter_only_exports_adapter_helpers() -> None:
+def test_l3_adapter_exports_runtime_compatibility_aliases() -> None:
     assert set(l3_graph_adapter.__all__) == {
+        "GraphEnginePort",
+        "GraphImpactRecord",
+        "GraphRegimeContext",
+        "GraphSnapshotError",
         "load_graph_features",
         "merge_graph_features",
     }
+    assert l3_graph_adapter.GraphEnginePort is GraphEnginePort
+    assert l3_graph_adapter.GraphImpactRecord is GraphImpactRecord
+    assert l3_graph_adapter.GraphRegimeContext is GraphRegimeContext
+    assert l3_graph_adapter.GraphSnapshotError is GraphSnapshotError
 
 
 def test_graph_engine_port_is_runtime_checkable_and_read_only() -> None:

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -84,6 +85,64 @@ def test_feature_signal_bundle_deep_freezes_nested_payload_containers() -> None:
         bundle.graph_features["node"]["centrality"] = 0.9
 
     assert bundle.to_json() == before_json
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("feature_values", {"momentum": float("nan")}),
+        ("signal_values", {"candidate": {"score": float("inf")}}),
+        ("graph_features", {"centrality": Decimal("NaN")}),
+    ],
+)
+def test_feature_signal_bundle_rejects_non_finite_payload_values(
+    field_name: str,
+    field_value: object,
+) -> None:
+    payload = _bundle_payload()
+    payload[field_name] = field_value
+
+    with pytest.raises(ValidationError, match="non-finite numeric value"):
+        FeatureSignalBundle(**payload)
+
+
+def test_alpha_result_rejects_non_finite_diagnostics() -> None:
+    with pytest.raises(ValidationError, match="non-finite numeric value"):
+        AlphaResultSnapshot(
+            cycle_id="cycle_001",
+            entity_id="ENT_001",
+            analyzer_type="multi_agent_v1",
+            score=0.72,
+            confidence=0.81,
+            rationale="quality and momentum are aligned",
+            similar_cases=[],
+            status="ok",
+            diagnostics={"role": {"confidence": float("nan")}},
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("audit_payload", {"latency": float("inf")}),
+        ("retrospective_seed", {"score": Decimal("NaN")}),
+    ],
+)
+def test_publish_bundle_rejects_non_finite_any_payload_values(
+    field_name: str,
+    field_value: object,
+) -> None:
+    payload = {
+        "cycle_id": "cycle_001",
+        "formal_objects": {"world_state": {"ref": "world_state_snapshot/cycle_001"}},
+        "manifest_candidate": {"snapshot_id": "snap_001"},
+        "audit_payload": {"actor": "system"},
+        "retrospective_seed": {"window": "1d"},
+    }
+    payload[field_name] = field_value
+
+    with pytest.raises(ValidationError, match="non-finite numeric value"):
+        PublishBundle(**payload)
 
 
 @pytest.mark.parametrize(
@@ -215,3 +274,100 @@ def test_all_schema_models_inherit_frozen_forbid_strict_base() -> None:
         assert model.model_config["frozen"] is True
         assert model.model_config["extra"] == "forbid"
         assert model.model_config["strict"] is True
+
+
+def test_schema_contract_cycle_builds_publish_bundle_with_manifest_anchor() -> None:
+    cycle_id = "cycle_contract"
+    bundle = FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id="ENT_001",
+        feature_values={"momentum": 0.42},
+        signal_values={},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+    world_state = WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="baseline unchanged",
+        actual_model_used="reasoner-stub",
+        actual_provider="local",
+        fallback_path=[],
+    )
+    pool = OfficialAlphaPool(
+        cycle_id=cycle_id,
+        observation_pool_size=1,
+        official_alpha_pool_capacity=1,
+        selected_entities=["ENT_001"],
+        added_entities=["ENT_001"],
+        removed_entities=[],
+        freeze_reason_map={},
+    )
+    alpha = AlphaResultSnapshot(
+        cycle_id=cycle_id,
+        entity_id="ENT_001",
+        analyzer_type="single_prompt_v1",
+        score=0.72,
+        confidence=0.81,
+        rationale="quality and momentum are aligned",
+        similar_cases=[],
+        status="ok",
+    )
+    recommendation = RecommendationSnapshot(
+        cycle_id=cycle_id,
+        entity_id="ENT_001",
+        action_type="buy",
+        rating="A",
+        confidence=0.77,
+        triggered_by="system",
+        override_applied=False,
+        constraints_applied={},
+    )
+    formal_objects = {
+        "feature_signal_bundle": {
+            "ref": f"feature_signal_bundle/{cycle_id}/ref",
+            "payload": bundle.model_dump(mode="json"),
+            "count": 1,
+        },
+        "world_state_snapshot": {
+            "ref": f"world_state_snapshot/{cycle_id}/ref",
+            "payload": world_state.model_dump(mode="json"),
+            "count": 1,
+        },
+        "official_alpha_pool": {
+            "ref": f"official_alpha_pool/{cycle_id}/ref",
+            "payload": pool.model_dump(mode="json"),
+            "count": 1,
+        },
+        "alpha_result_snapshot": {
+            "ref": f"alpha_result_snapshot/{cycle_id}/ref",
+            "payload": [alpha.model_dump(mode="json")],
+            "count": 1,
+        },
+        "recommendation_snapshot": {
+            "ref": f"recommendation_snapshot/{cycle_id}/ref",
+            "payload": [recommendation.model_dump(mode="json")],
+            "count": 1,
+        },
+    }
+
+    publish_bundle = PublishBundle(
+        cycle_id=cycle_id,
+        formal_objects=formal_objects,
+        manifest_candidate={
+            "cycle_id": cycle_id,
+            "manifest_ref": "pg://cycle_publish_manifest/contract-1",
+            "object_refs": {
+                object_key: entry["ref"]
+                for object_key, entry in formal_objects.items()
+            },
+        },
+        audit_payload={"cycle_id": cycle_id},
+        retrospective_seed={"cycle_id": cycle_id},
+    )
+
+    assert publish_bundle.manifest_candidate["manifest_ref"] == (
+        "pg://cycle_publish_manifest/contract-1"
+    )

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -42,6 +42,22 @@ def test_official_alpha_pool_rejects_selected_entities_over_capacity() -> None:
         OfficialAlphaPool(**payload)
 
 
+def test_official_alpha_pool_rejects_negative_observation_pool_size() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = -1
+
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(**payload)
+
+
+def test_official_alpha_pool_rejects_selected_entities_over_observation_size() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = 1
+
+    with pytest.raises(ValidationError, match="observation_pool_size"):
+        OfficialAlphaPool(**payload)
+
+
 def test_official_alpha_pool_selected_entities_cannot_mutate_past_capacity() -> None:
     payload = _pool_payload()
     payload["official_alpha_pool_capacity"] = 1

--- a/tests/schemas/test_publish.py
+++ b/tests/schemas/test_publish.py
@@ -53,6 +53,62 @@ def test_publish_bundle_rejects_wrong_formal_objects_type() -> None:
         PublishBundle(**payload)
 
 
+def test_publish_bundle_rejects_manifest_ref_without_object_refs() -> None:
+    payload = _publish_payload()
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "manifest_ref": "pg://cycle_publish_manifest/42",
+    }
+
+    with pytest.raises(ValidationError, match="object_refs"):
+        PublishBundle(**payload)
+
+
+@pytest.mark.parametrize(
+    "manifest_candidate",
+    [
+        {
+            "cycle_id": "cycle_001",
+            "manifest_ref": "manifest/cycle_001",
+            "object_refs": {},
+        },
+        {
+            "cycle_id": "cycle_001",
+            "manifest_ref": "manifest/cycle_001",
+            "object_refs": {"world_state": " "},
+        },
+        {
+            "cycle_id": "cycle_001",
+            "manifest_ref": "manifest/cycle_001",
+            "object_refs": {
+                "world_state": "world_state_snapshot/cycle_001",
+                "extra": "extra/cycle_001",
+            },
+        },
+    ],
+)
+def test_publish_bundle_rejects_invalid_manifest_object_refs(
+    manifest_candidate: dict[str, object],
+) -> None:
+    payload = _publish_payload()
+    payload["manifest_candidate"] = manifest_candidate
+
+    with pytest.raises(ValidationError):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_formal_object_ref_mismatch() -> None:
+    payload = _publish_payload()
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "manifest_ref": "manifest/cycle_001",
+        "object_refs": {"world_state": "world_state_snapshot/cycle_001/other"},
+    }
+
+    with pytest.raises(ValidationError, match="must match manifest"):
+        PublishBundle(**payload)
+
+
 def test_override_record_happy_path_round_trips_json() -> None:
     override = OverrideRecord(**_override_payload())
 


### PR DESCRIPTION
Closes #51

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/publish.py`, `src/main_core/l6_alpha/__init__.py`, `src/main_core/l6_alpha/ab_runner.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `unknown`


---
## P1 Backlog Cleanup (33 findings across 18 files)

Consolidated cleanup of P1 findings accumulated from milestone reviews. 
These are non-blocking improvements identified during code review.

**Fix all (or as many as feasible) in a single PR.** Items are grouped by file:


### `cross-cutting` (5 items)


- **L1** (conf=0.74, from PR #-92625): Multiplier store validation is split across multiple layers
  - Recommendation: Extract a single L3 multiplier validation helper and use it in the write API, store implementations, and builder read path. Add tests with a deliberately invalid custom store so the public builder always raises the same L3 error class.

- **L1** (conf=0.9, from PR #-36312): Milestone lacks cross-layer integration coverage
  - Recommendation: Add a minimal pure-market closed-loop test that derives world state, selects a pool, builds L6 contexts from the selected entities, generates recommendations, and verifies override plus constraint behavior. Include one task-level L6 inconclusive case and one stale-freeze case.

- **L1** (conf=0.86, from PR #-36682): Bundle parsing and object ordering logic is duplicated across L8 modules
  - Recommendation: Extract shared L8 utilities for ordered formal object keys and typed PublishBundle entry parsing. Keep dashboard/report-specific summarization separate, but make ref/payload/count validation a single public helper used by all L8 builders.

- **L1** (conf=0.84, from PR #-96178): Adapter merge and serialization rules are duplicated and inconsistent
  - Recommendation: Extract a shared JSON-like normalization helper and define explicit merge policies for external payloads. Prefer namespaced payloads such as graph_impact and candidate_signals, and make overwrite behavior either impossible or explicitly audited.

- **L1** (conf=0.78, from PR #-4093): Role-level evidence is discarded from formal and A/B outputs
  - Recommendation: Define a structured role diagnostics payload for multi_agent_v1, either as an Alpha