### PR TITLE
feat(#51): P1 backlog cleanup (33 findings, 18 files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "project-ult-main-core"
 version = "0.1.0"
 description = "Scaffold workspace for main-core."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [project.optional-dependencies]
@@ -28,3 +28,6 @@ where = ["src"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"

--- a/src/main_core/common/contexts.py
+++ b/src/main_core/common/contexts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from main_core.common.schemas import (
     FeatureSignalBundle,
@@ -23,6 +23,18 @@ class AlphaAnalysisContext(BaseModel):
     feature_bundle: FeatureSignalBundle
     world_state: WorldStateSnapshot
     similar_cases: list[dict[str, Any]] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_context_consistency(self) -> AlphaAnalysisContext:
+        """Require L6 runtime context fields to describe the same cycle and entity."""
+
+        if self.feature_bundle.cycle_id != self.cycle_id:
+            raise ValueError("feature_bundle.cycle_id must match context.cycle_id")
+        if self.world_state.cycle_id != self.cycle_id:
+            raise ValueError("world_state.cycle_id must match context.cycle_id")
+        if self.feature_bundle.entity_id != self.entity_id:
+            raise ValueError("feature_bundle.entity_id must match context.entity_id")
+        return self
 
 
 class WorldStateInputs(BaseModel):

--- a/src/main_core/common/schemas/alpha.py
+++ b/src/main_core/common/schemas/alpha.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId, EntityId
@@ -24,6 +24,7 @@ class AlphaResultSnapshot(FormalObjectBase):
     rationale: str
     similar_cases: list[dict[str, Any]]
     status: AlphaStatus
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_inconclusive_score(self) -> AlphaResultSnapshot:

--- a/src/main_core/common/schemas/base.py
+++ b/src/main_core/common/schemas/base.py
@@ -63,7 +63,12 @@ def _thaw_value(value: Any) -> Any:
 class FormalObjectBase(BaseModel):
     """Frozen schema base for formal and runtime contract objects."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    model_config = ConfigDict(
+        allow_inf_nan=False,
+        extra="forbid",
+        frozen=True,
+        strict=True,
+    )
 
     @model_validator(mode="after")
     def freeze_nested_containers(self) -> Self:

--- a/src/main_core/common/schemas/pool.py
+++ b/src/main_core/common/schemas/pool.py
@@ -12,7 +12,7 @@ class OfficialAlphaPool(FormalObjectBase):
     """Formal L5 official alpha pool described in §9.3."""
 
     cycle_id: CycleId
-    observation_pool_size: int
+    observation_pool_size: int = Field(ge=0)
     official_alpha_pool_capacity: int = Field(default=100, ge=1, le=100)
     selected_entities: list[EntityId]
     added_entities: list[EntityId]
@@ -25,6 +25,8 @@ class OfficialAlphaPool(FormalObjectBase):
 
         if len(self.selected_entities) > self.official_alpha_pool_capacity:
             raise ValueError("selected_entities length must be <= official_alpha_pool_capacity")
+        if len(self.selected_entities) > self.observation_pool_size:
+            raise ValueError("selected_entities length must be <= observation_pool_size")
         return self
 
 

--- a/src/main_core/common/schemas/publish.py
+++ b/src/main_core/common/schemas/publish.py
@@ -10,6 +10,8 @@ from pydantic import model_validator
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId
 
+_MISSING = object()
+
 
 class PublishBundle(FormalObjectBase):
     """Runtime Phase 3 publish bundle described in §9.3."""
@@ -46,17 +48,19 @@ def _formal_refs_by_key(
 ) -> dict[str, tuple[str, ...]]:
     formal_refs_by_key: dict[str, tuple[str, ...]] = {}
     for object_key, entry in formal_objects.items():
-        if not isinstance(entry, Mapping):
-            continue
-
         key = str(object_key)
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"{key} formal object entry must be a mapping")
+
         refs = _entry_refs(key, entry)
-        if refs:
-            formal_refs_by_key[key] = refs
+        formal_refs_by_key[key] = refs
         for ref in refs:
             _ensure_ref_has_cycle_segment(f"{key}.ref", ref, cycle_id)
 
-        _ensure_payload_cycles(key, entry.get("payload"), cycle_id)
+        payload = _entry_payload(entry, key)
+        count = _entry_count(entry, key)
+        _ensure_count_matches_payload(key, count, payload)
+        _ensure_payload_cycles(key, payload, cycle_id)
     return formal_refs_by_key
 
 
@@ -66,9 +70,17 @@ def _validate_manifest_object_refs(
     cycle_id: str,
 ) -> None:
     if object_refs is None:
-        return
+        raise ValueError("manifest_candidate.object_refs must be a mapping")
     if not isinstance(object_refs, Mapping):
         raise ValueError("manifest_candidate.object_refs must be a mapping")
+
+    formal_object_keys = set(formal_refs_by_key)
+    manifest_object_keys = {str(object_key) for object_key in object_refs}
+    if manifest_object_keys != formal_object_keys:
+        raise ValueError(
+            "manifest_candidate.object_refs keys must match formal_objects keys"
+        )
+
     for object_key, ref in object_refs.items():
         if not isinstance(ref, str) or not ref:
             raise ValueError("manifest object_ref values must be non-empty strings")
@@ -127,12 +139,38 @@ def _entry_refs(object_key: str, entry: Mapping[str, Any]) -> tuple[str, ...]:
             raise ValueError(f"{object_key}.refs must contain non-empty strings")
         return tuple(refs)
 
-    ref = entry.get("ref")
-    if ref is None:
-        return ()
+    ref = entry.get("ref", _MISSING)
+    if ref is _MISSING:
+        raise ValueError(f"{object_key}.ref or {object_key}.refs is required")
     if not isinstance(ref, str) or not ref:
         raise ValueError(f"{object_key}.ref must be a non-empty string")
     return (ref,)
+
+
+def _entry_payload(entry: Mapping[str, Any], object_key: str) -> Any:
+    payload = entry.get("payload", _MISSING)
+    if payload is _MISSING:
+        raise ValueError(f"{object_key}.payload is required")
+    if isinstance(payload, Mapping):
+        return payload
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        return payload
+    raise ValueError(f"{object_key}.payload must be a mapping or list")
+
+
+def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
+    count = entry.get("count", _MISSING)
+    if count is _MISSING:
+        raise ValueError(f"{object_key}.count is required")
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        raise ValueError(f"{object_key}.count must be a non-negative integer")
+    return count
+
+
+def _ensure_count_matches_payload(object_key: str, count: int, payload: Any) -> None:
+    expected_count = len(payload) if isinstance(payload, Sequence) else 1
+    if count != expected_count:
+        raise ValueError(f"{object_key}.count must match payload")
 
 
 def _ensure_optional_payload_cycle(

--- a/src/main_core/common/schemas/publish.py
+++ b/src/main_core/common/schemas/publish.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Any
+
+from pydantic import model_validator
 
 from main_core.common.schemas.base import FormalObjectBase
 from main_core.common.types import CycleId
@@ -16,6 +19,151 @@ class PublishBundle(FormalObjectBase):
     manifest_candidate: dict[str, Any]
     audit_payload: dict[str, Any]
     retrospective_seed: dict[str, Any]
+
+    @model_validator(mode="after")
+    def validate_cycle_refs(self) -> PublishBundle:
+        """Reject stale formal object and manifest object refs inside the bundle."""
+
+        cycle_id = str(self.cycle_id)
+        _ensure_optional_payload_cycle("manifest_candidate", self.manifest_candidate, cycle_id)
+
+        formal_refs_by_key = _formal_refs_by_key(self.formal_objects, cycle_id)
+        _validate_manifest_object_refs(
+            self.manifest_candidate.get("object_refs"),
+            formal_refs_by_key,
+            cycle_id,
+        )
+        _validate_committed_object_refs(
+            self.manifest_candidate.get("committed_objects"),
+            cycle_id,
+        )
+        return self
+
+
+def _formal_refs_by_key(
+    formal_objects: Mapping[str, Any],
+    cycle_id: str,
+) -> dict[str, tuple[str, ...]]:
+    formal_refs_by_key: dict[str, tuple[str, ...]] = {}
+    for object_key, entry in formal_objects.items():
+        if not isinstance(entry, Mapping):
+            continue
+
+        key = str(object_key)
+        refs = _entry_refs(key, entry)
+        if refs:
+            formal_refs_by_key[key] = refs
+        for ref in refs:
+            _ensure_ref_has_cycle_segment(f"{key}.ref", ref, cycle_id)
+
+        _ensure_payload_cycles(key, entry.get("payload"), cycle_id)
+    return formal_refs_by_key
+
+
+def _validate_manifest_object_refs(
+    object_refs: Any,
+    formal_refs_by_key: Mapping[str, tuple[str, ...]],
+    cycle_id: str,
+) -> None:
+    if object_refs is None:
+        return
+    if not isinstance(object_refs, Mapping):
+        raise ValueError("manifest_candidate.object_refs must be a mapping")
+    for object_key, ref in object_refs.items():
+        if not isinstance(ref, str) or not ref:
+            raise ValueError("manifest object_ref values must be non-empty strings")
+        key = str(object_key)
+        _ensure_ref_has_cycle_segment(
+            f"manifest_candidate.object_refs.{key}",
+            ref,
+            cycle_id,
+        )
+        matching_refs = formal_refs_by_key.get(key)
+        if matching_refs is not None and ref not in matching_refs:
+            raise ValueError(
+                "manifest object_ref must match the formal_objects entry ref"
+            )
+
+
+def _validate_committed_object_refs(committed_objects: Any, cycle_id: str) -> None:
+    if committed_objects is None:
+        return
+    if not isinstance(committed_objects, Sequence) or isinstance(
+        committed_objects,
+        (str, bytes),
+    ):
+        raise ValueError("manifest_candidate.committed_objects must be a list")
+    for index, committed_object in enumerate(committed_objects):
+        _validate_committed_object_ref(index, committed_object, cycle_id)
+
+
+def _validate_committed_object_ref(
+    index: int,
+    committed_object: Any,
+    cycle_id: str,
+) -> None:
+    if not isinstance(committed_object, Mapping):
+        raise ValueError(
+            f"manifest_candidate.committed_objects[{index}] must be a mapping"
+        )
+    ref = committed_object.get("ref")
+    if ref is None:
+        return
+    if not isinstance(ref, str) or not ref:
+        raise ValueError("committed object ref must be a non-empty string")
+    _ensure_ref_has_cycle_segment(
+        f"manifest_candidate.committed_objects[{index}].ref",
+        ref,
+        cycle_id,
+    )
+
+
+def _entry_refs(object_key: str, entry: Mapping[str, Any]) -> tuple[str, ...]:
+    if "refs" in entry:
+        refs = entry["refs"]
+        if not isinstance(refs, Sequence) or isinstance(refs, (str, bytes)):
+            raise ValueError(f"{object_key}.refs must be a sequence of strings")
+        if not all(isinstance(ref, str) and ref for ref in refs):
+            raise ValueError(f"{object_key}.refs must contain non-empty strings")
+        return tuple(refs)
+
+    ref = entry.get("ref")
+    if ref is None:
+        return ()
+    if not isinstance(ref, str) or not ref:
+        raise ValueError(f"{object_key}.ref must be a non-empty string")
+    return (ref,)
+
+
+def _ensure_optional_payload_cycle(
+    payload_name: str,
+    payload: Mapping[str, Any],
+    cycle_id: str,
+) -> None:
+    payload_cycle_id = payload.get("cycle_id")
+    if payload_cycle_id is not None and payload_cycle_id != cycle_id:
+        raise ValueError(f"{payload_name}.cycle_id must match bundle.cycle_id")
+
+
+def _ensure_payload_cycles(object_key: str, payload: Any, cycle_id: str) -> None:
+    if isinstance(payload, Mapping):
+        _ensure_optional_payload_cycle(f"{object_key}.payload", payload, cycle_id)
+        return
+
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
+        return
+    for index, item in enumerate(payload):
+        if isinstance(item, Mapping):
+            _ensure_optional_payload_cycle(
+                f"{object_key}.payload[{index}]",
+                item,
+                cycle_id,
+            )
+
+
+def _ensure_ref_has_cycle_segment(ref_name: str, ref: str, cycle_id: str) -> None:
+    if cycle_id not in ref.split("/"):
+        raise ValueError(f"{ref_name} must point to bundle.cycle_id")
 
 
 __all__ = ["PublishBundle"]

--- a/src/main_core/l3_features/__init__.py
+++ b/src/main_core/l3_features/__init__.py
@@ -18,6 +18,7 @@ from main_core.l3_features.candidate_signals import (
 from main_core.l3_features.errors import InvalidMultiplierError, L3FeatureError
 from main_core.l3_features.graph_adapter import load_graph_features, merge_graph_features
 from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 from main_core.l3_features.weight_api import (
     apply_weight_multiplier,
     get_feature_weight_multiplier,
@@ -44,4 +45,5 @@ __all__ = [
     "merge_candidate_signals",
     "merge_graph_features",
     "normalize_candidate_signals",
+    "validate_multiplier_mapping",
 ]

--- a/src/main_core/l3_features/candidate_signals.py
+++ b/src/main_core/l3_features/candidate_signals.py
@@ -71,15 +71,15 @@ def normalize_candidate_signals(
                 "candidate signal records must match the requested cycle_id"
             )
 
+        if str(record.entity_id) != str(entity_id):
+            continue
+
         record_key = (str(record.entity_id), record.source, record.signal_name)
         if record_key in seen_record_keys:
             raise CandidateSignalError(
                 "candidate signal records contain duplicate entity/source/signal_name"
             )
         seen_record_keys.add(record_key)
-
-        if str(record.entity_id) != str(entity_id):
-            continue
 
         if record.signal_name in normalized:
             raise CandidateSignalError(

--- a/src/main_core/l3_features/feature_math.py
+++ b/src/main_core/l3_features/feature_math.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
 from math import isfinite
+from typing import Any
 
 from main_core.l1_l2_basis.models import MarketBar
 from main_core.l3_features.errors import InvalidMultiplierError
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 
 
 def market_bar_feature_values(market_bar: MarketBar) -> dict[str, float]:
@@ -27,19 +30,34 @@ def apply_feature_weight_multiplier(
 ) -> tuple[dict[str, float], dict[str, float]]:
     """Apply known feature multipliers and return weighted features plus effective weights."""
 
-    effective_multipliers = {
-        feature_name: float(multipliers.get(feature_name, 1.0))
-        for feature_name in feature_values
-    }
+    effective_multipliers = validate_multiplier_mapping(
+        {
+            feature_name: multipliers.get(feature_name, 1.0)
+            for feature_name in feature_values
+        }
+    )
     weighted_feature_values = {}
     for feature_name, feature_value in feature_values.items():
-        weighted_feature_value = feature_value * effective_multipliers[feature_name]
+        weighted_feature_value = _weighted_float(
+            feature_value,
+            effective_multipliers[feature_name],
+        )
         if not isfinite(weighted_feature_value):
             raise InvalidMultiplierError(
                 "weighted feature values must be finite after applying multipliers"
             )
         weighted_feature_values[feature_name] = weighted_feature_value
     return weighted_feature_values, effective_multipliers
+
+
+def _weighted_float(feature_value: Any, multiplier: float) -> float:
+    try:
+        weighted_value = Decimal(str(feature_value)) * Decimal(str(multiplier))
+        return float(weighted_value)
+    except (InvalidOperation, OverflowError, ValueError) as exc:
+        raise InvalidMultiplierError(
+            "weighted feature values must be finite after applying multipliers"
+        ) from exc
 
 
 __all__ = ["apply_feature_weight_multiplier", "market_bar_feature_values"]

--- a/src/main_core/l3_features/graph_adapter.py
+++ b/src/main_core/l3_features/graph_adapter.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from main_core.common.protocols import GraphSnapshotError as _GraphSnapshotError
+from main_core.common.protocols import (
+    GraphEnginePort,
+    GraphImpactRecord,
+    GraphRegimeContext,
+    GraphSnapshotError,
+)
 from main_core.common.schemas.feature_bundle import FeatureSignalBundle
 from main_core.common.types import CycleId, EntityId
-
-if TYPE_CHECKING:
-    from main_core.common.protocols import GraphEnginePort, GraphImpactRecord
 
 
 def load_graph_features(
@@ -27,7 +29,7 @@ def load_graph_features(
     matching_records: list[GraphImpactRecord] = []
     for record in records:
         if str(record.cycle_id) != str(cycle_id):
-            raise _GraphSnapshotError(
+            raise GraphSnapshotError(
                 "graph impact snapshot contains records from a different cycle"
             )
         if str(record.entity_id) == str(entity_id):
@@ -36,7 +38,7 @@ def load_graph_features(
     if not matching_records:
         return {}
     if len(matching_records) > 1:
-        raise _GraphSnapshotError(
+        raise GraphSnapshotError(
             "graph impact snapshot contains duplicate records for entity"
         )
 
@@ -67,6 +69,10 @@ def _to_plain_json_like(value: Any) -> Any:
 
 
 __all__ = [
+    "GraphEnginePort",
+    "GraphImpactRecord",
+    "GraphRegimeContext",
+    "GraphSnapshotError",
     "load_graph_features",
     "merge_graph_features",
 ]

--- a/src/main_core/l3_features/multiplier_store.py
+++ b/src/main_core/l3_features/multiplier_store.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from math import isfinite
 from threading import Lock
 from typing import Protocol, runtime_checkable
 
 from main_core.common.types import CycleId
-from main_core.l3_features.errors import InvalidMultiplierError
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 
 
 @runtime_checkable
@@ -46,26 +45,11 @@ class InMemoryMultiplierStore:
     ) -> None:
         """Validate and store multiplier updates for the requested cycle."""
 
-        validated_updates = _validated_multiplier_copy(updates)
+        validated_updates = validate_multiplier_mapping(updates)
         cycle_key = str(cycle_id)
         with self._lock:
             current_multipliers = dict(self._multipliers_by_cycle.get(cycle_key, {}))
             current_multipliers.update(validated_updates)
             self._multipliers_by_cycle[cycle_key] = current_multipliers
-
-
-def _validated_multiplier_copy(updates: Mapping[str, float]) -> dict[str, float]:
-    invalid_keys = [
-        feature_name
-        for feature_name, multiplier in updates.items()
-        if not isinstance(multiplier, int | float)
-        or isinstance(multiplier, bool)
-        or not isfinite(multiplier)
-        or multiplier <= 0
-    ]
-    if invalid_keys:
-        raise InvalidMultiplierError("feature weight multipliers must be finite and > 0")
-    return {feature_name: float(multiplier) for feature_name, multiplier in updates.items()}
-
 
 __all__ = ["InMemoryMultiplierStore", "MultiplierStore"]

--- a/src/main_core/l3_features/multiplier_validation.py
+++ b/src/main_core/l3_features/multiplier_validation.py
@@ -1,0 +1,38 @@
+"""Shared validation for L3 feature weight multipliers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import isfinite
+from typing import Any
+
+from main_core.l3_features.errors import InvalidMultiplierError
+
+
+def validate_multiplier_mapping(updates: Mapping[str, Any]) -> dict[str, float]:
+    """Return a finite positive float copy of a multiplier mapping."""
+
+    validated_updates: dict[str, float] = {}
+    for feature_name, multiplier in updates.items():
+        try:
+            converted_multiplier = _convert_multiplier(multiplier)
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise InvalidMultiplierError(
+                "feature weight multipliers must be finite and > 0"
+            ) from exc
+
+        if not isfinite(converted_multiplier) or converted_multiplier <= 0:
+            raise InvalidMultiplierError(
+                "feature weight multipliers must be finite and > 0"
+            )
+        validated_updates[feature_name] = converted_multiplier
+    return validated_updates
+
+
+def _convert_multiplier(multiplier: Any) -> float:
+    if isinstance(multiplier, bool):
+        raise TypeError("bool is not a valid feature weight multiplier")
+    return float(multiplier)
+
+
+__all__ = ["validate_multiplier_mapping"]

--- a/src/main_core/l3_features/weight_api.py
+++ b/src/main_core/l3_features/weight_api.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 
 from main_core.common.types import CycleId
 from main_core.l3_features.multiplier_store import InMemoryMultiplierStore, MultiplierStore
+from main_core.l3_features.multiplier_validation import validate_multiplier_mapping
 
 _DEFAULT_MULTIPLIER_STORE = InMemoryMultiplierStore()
 
@@ -18,7 +19,7 @@ def apply_weight_multiplier(
 ) -> None:
     """Apply feature weight multiplier updates for a cycle."""
 
-    _resolve_store(store).put_multipliers(cycle_id, updates)
+    _resolve_store(store).put_multipliers(cycle_id, validate_multiplier_mapping(updates))
 
 
 def get_feature_weight_multiplier(
@@ -28,7 +29,7 @@ def get_feature_weight_multiplier(
 ) -> dict[str, float]:
     """Return the currently visible feature weight multipliers for a cycle."""
 
-    return dict(_resolve_store(store).get_multipliers(cycle_id))
+    return validate_multiplier_mapping(_resolve_store(store).get_multipliers(cycle_id))
 
 
 def _resolve_store(store: MultiplierStore | None) -> MultiplierStore:

--- a/src/main_core/l5_universe/service.py
+++ b/src/main_core/l5_universe/service.py
@@ -52,7 +52,10 @@ def select_official_alpha_pool(  # noqa: PLR0913
 
     return OfficialAlphaPool(
         cycle_id=world_state.cycle_id,
-        observation_pool_size=len(observation_candidates),
+        observation_pool_size=_observation_pool_size(
+            observation_candidates,
+            freeze_reason_map,
+        ),
         official_alpha_pool_capacity=active_config.capacity,
         selected_entities=selected_entities,
         added_entities=added_entities,
@@ -123,6 +126,20 @@ def _select_entities(
         )
 
     return selected_entities
+
+
+def _observation_pool_size(
+    observation_candidates: Sequence[FeatureSignalBundle],
+    freeze_reason_map: Mapping[EntityId, str],
+) -> int:
+    """Count thresholded candidates plus frozen entities retained by policy."""
+
+    observed_entity_ids = {
+        str(bundle.entity_id)
+        for bundle in observation_candidates
+    }
+    observed_entity_ids.update(str(entity_id) for entity_id in freeze_reason_map)
+    return len(observed_entity_ids)
 
 
 def _append_if_room(

--- a/src/main_core/l6_alpha/__init__.py
+++ b/src/main_core/l6_alpha/__init__.py
@@ -1,6 +1,7 @@
 """L6 package: single-stock alpha analysis."""
 
 from main_core.l6_alpha.ab_runner import run_ab_evaluation, write_ab_report
+from main_core.l6_alpha.errors import AlphaAnalyzerError, AlphaReasonerError
 from main_core.l6_alpha.fallback import build_inconclusive_result
 from main_core.l6_alpha.multi_agent_analyzer import (
     AgentRoleConfig,
@@ -19,6 +20,8 @@ from main_core.l6_alpha.single_prompt_analyzer import SinglePromptAnalyzer
 
 __all__ = [
     "AgentRoleConfig",
+    "AlphaAnalyzerError",
+    "AlphaReasonerError",
     "AlphaReasonerPort",
     "AlphaReasonerResponse",
     "MultiAgentAnalyzer",

--- a/src/main_core/l6_alpha/ab_runner.py
+++ b/src/main_core/l6_alpha/ab_runner.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.protocols import AnalyzerInterface
+from main_core.common.schemas import AlphaResultSnapshot
 from main_core.common.types import EntityId
 
 
@@ -42,6 +44,10 @@ class AbCaseResult:
     score_delta: float | None
     confidence_delta: float
     status_matches: bool
+    baseline_error: str | None
+    challenger_error: str | None
+    baseline_diagnostics: Mapping[str, Any]
+    challenger_diagnostics: Mapping[str, Any]
 
 
 @dataclass(frozen=True)
@@ -57,6 +63,8 @@ class AbEvaluationReport:
     baseline_inconclusive_count: int
     challenger_inconclusive_count: int
     inconclusive_count_delta: int
+    baseline_failure_count: int
+    challenger_failure_count: int
     cases: tuple[AbCaseResult, ...]
 
 
@@ -68,16 +76,21 @@ def run_ab_evaluation(
 ) -> AbEvaluationReport:
     """Run baseline and challenger analyzers on the same supplied contexts."""
 
+    if not cases:
+        raise ValueError("cases must not be empty")
+
     case_results: list[AbCaseResult] = []
     score_abs_deltas: list[float] = []
     confidence_abs_deltas: list[float] = []
     status_match_count = 0
     baseline_inconclusive_count = 0
     challenger_inconclusive_count = 0
+    baseline_failure_count = 0
+    challenger_failure_count = 0
 
     for case in cases:
-        baseline_result = baseline.analyze(case.entity_id, case.context)
-        challenger_result = challenger.analyze(case.entity_id, case.context)
+        baseline_result = _run_analyzer(baseline, case)
+        challenger_result = _run_analyzer(challenger, case)
 
         status_matches = baseline_result.status == challenger_result.status
         if status_matches:
@@ -86,6 +99,10 @@ def run_ab_evaluation(
             baseline_inconclusive_count += 1
         if challenger_result.status == "inconclusive":
             challenger_inconclusive_count += 1
+        if baseline_result.error is not None:
+            baseline_failure_count += 1
+        if challenger_result.error is not None:
+            challenger_failure_count += 1
 
         score_delta: float | None = None
         if baseline_result.score is not None and challenger_result.score is not None:
@@ -111,6 +128,10 @@ def run_ab_evaluation(
                 score_delta=score_delta,
                 confidence_delta=confidence_delta,
                 status_matches=status_matches,
+                baseline_error=baseline_result.error,
+                challenger_error=challenger_result.error,
+                baseline_diagnostics=baseline_result.diagnostics,
+                challenger_diagnostics=challenger_result.diagnostics,
             )
         )
 
@@ -129,6 +150,8 @@ def run_ab_evaluation(
         inconclusive_count_delta=(
             challenger_inconclusive_count - baseline_inconclusive_count
         ),
+        baseline_failure_count=baseline_failure_count,
+        challenger_failure_count=challenger_failure_count,
         cases=tuple(case_results),
     )
 
@@ -152,6 +175,8 @@ def format_ab_report_markdown(report: AbEvaluationReport) -> str:
         ("baseline_inconclusive_count", report.baseline_inconclusive_count),
         ("challenger_inconclusive_count", report.challenger_inconclusive_count),
         ("inconclusive_count_delta", report.inconclusive_count_delta),
+        ("baseline_failure_count", report.baseline_failure_count),
+        ("challenger_failure_count", report.challenger_failure_count),
     ]
     lines = [
         "# L6 A/B Evaluation",
@@ -170,9 +195,10 @@ def format_ab_report_markdown(report: AbEvaluationReport) -> str:
             (
                 "| case_id | entity_id | baseline_analyzer_type | "
                 "challenger_analyzer_type | baseline_status | challenger_status | "
-                "score_delta | confidence_delta | status_matches |"
+                "score_delta | confidence_delta | status_matches | "
+                "baseline_error | challenger_error |"
             ),
-            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
     lines.extend(_case_markdown_row(case) for case in report.cases)
@@ -206,6 +232,8 @@ def _report_payload(report: AbEvaluationReport) -> dict[str, object]:
         "baseline_inconclusive_count": report.baseline_inconclusive_count,
         "challenger_inconclusive_count": report.challenger_inconclusive_count,
         "inconclusive_count_delta": report.inconclusive_count_delta,
+        "baseline_failure_count": report.baseline_failure_count,
+        "challenger_failure_count": report.challenger_failure_count,
         "cases": [_case_payload(case) for case in report.cases],
     }
 
@@ -225,6 +253,10 @@ def _case_payload(case: AbCaseResult) -> dict[str, object]:
         "score_delta": case.score_delta,
         "confidence_delta": case.confidence_delta,
         "status_matches": case.status_matches,
+        "baseline_error": case.baseline_error,
+        "challenger_error": case.challenger_error,
+        "baseline_diagnostics": case.baseline_diagnostics,
+        "challenger_diagnostics": case.challenger_diagnostics,
     }
 
 
@@ -239,8 +271,59 @@ def _case_markdown_row(case: AbCaseResult) -> str:
         _format_value(case.score_delta),
         _format_value(case.confidence_delta),
         case.status_matches,
+        case.baseline_error,
+        case.challenger_error,
     ]
     return "| " + " | ".join(_escape_markdown(value) for value in values) + " |"
+
+
+@dataclass(frozen=True)
+class _AnalyzerOutcome:
+    analyzer_type: str
+    status: str
+    score: float | None
+    confidence: float
+    error: str | None
+    diagnostics: Mapping[str, Any]
+
+
+def _run_analyzer(
+    analyzer: AnalyzerInterface,
+    case: AbEvaluationCase,
+) -> _AnalyzerOutcome:
+    try:
+        result = analyzer.analyze(case.entity_id, case.context)
+    except Exception as exc:  # noqa: BLE001 - A/B reports must capture analyzer failures.
+        return _AnalyzerOutcome(
+            analyzer_type=analyzer.analyzer_type,
+            status="inconclusive",
+            score=None,
+            confidence=0.0,
+            error=f"{type(exc).__name__}: {exc}",
+            diagnostics={},
+        )
+    return _outcome_from_result(result)
+
+
+def _outcome_from_result(result: AlphaResultSnapshot) -> _AnalyzerOutcome:
+    return _AnalyzerOutcome(
+        analyzer_type=result.analyzer_type,
+        status=result.status,
+        score=result.score,
+        confidence=result.confidence,
+        error=None,
+        diagnostics=_plain_json_like(result.diagnostics),
+    )
+
+
+def _plain_json_like(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_json_like(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_plain_json_like(item) for item in value]
+    if isinstance(value, frozenset | set):
+        return sorted(_plain_json_like(item) for item in value)
+    return value
 
 
 def _mean(values: Sequence[float]) -> float | None:

--- a/src/main_core/l6_alpha/errors.py
+++ b/src/main_core/l6_alpha/errors.py
@@ -1,0 +1,16 @@
+"""Shared L6 analyzer exception types."""
+
+from __future__ import annotations
+
+from main_core.common.errors import MainCoreError
+
+
+class AlphaAnalyzerError(MainCoreError):
+    """Raised when the L6 analyzer contract is violated before provider work."""
+
+
+class AlphaReasonerError(MainCoreError):
+    """Raised when the L6 reasoner provider returns unusable infrastructure output."""
+
+
+__all__ = ["AlphaAnalyzerError", "AlphaReasonerError"]

--- a/src/main_core/l6_alpha/fallback.py
+++ b/src/main_core/l6_alpha/fallback.py
@@ -9,7 +9,6 @@ from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError
 from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
 from main_core.common.types import EntityId
-from main_core.l6_alpha.reasoner_port import AlphaReasonerResponse
 
 
 def build_inconclusive_result(
@@ -36,9 +35,7 @@ def build_inconclusive_result(
 def is_task_level_failure(error: BaseException) -> bool:
     """Return whether an exception should be downgraded to inconclusive."""
 
-    return isinstance(error, InconclusiveError) or (
-        isinstance(error, AlphaReasonerResponse) and error.task_failed
-    )
+    return isinstance(error, InconclusiveError)
 
 
 __all__ = ["build_inconclusive_result", "is_task_level_failure"]

--- a/src/main_core/l6_alpha/multi_agent_analyzer.py
+++ b/src/main_core/l6_alpha/multi_agent_analyzer.py
@@ -13,7 +13,7 @@ from main_core.common.errors import InconclusiveError, MainCoreError
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot
 from main_core.common.types import EntityId
-from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
+from main_core.l6_alpha.errors import AlphaAnalyzerError
 
 DEFAULT_MULTI_AGENT_ROLES: tuple[str, ...] = ("fundamental", "technical", "risk")
 
@@ -86,7 +86,7 @@ class StaticMultiAgentReasonerPort:
         role: AgentRoleConfig,
         payload: Mapping[str, Any],
     ) -> MultiAgentRoleResult:
-        """Return a configured role result or a stable zero-score default."""
+        """Return a configured role result or an explicit unconfigured-role failure."""
 
         self.calls.append((entity_id, context, role, payload))
         if role.name in self.role_results:
@@ -94,10 +94,12 @@ class StaticMultiAgentReasonerPort:
 
         return MultiAgentRoleResult(
             role=role.name,
-            score=0.0,
+            score=None,
             confidence=0.0,
-            rationale=f"static {role.name} alpha analysis",
+            rationale=f"static {role.name} alpha analysis is not configured",
             evidence={"role": role.name},
+            task_failed=True,
+            failure_reason="static multi-agent role result is not configured",
         )
 
 
@@ -132,6 +134,7 @@ def aggregate_role_results(
 
     role_weight_map = _role_weight_map(roles)
     result_map = _role_result_map(role_results, role_weight_map)
+    _ensure_exact_role_coverage(result_map, role_weight_map)
     failed_results = tuple(result for result in result_map.values() if result.task_failed)
     healthy_results = tuple(
         sorted(
@@ -149,6 +152,7 @@ def aggregate_role_results(
                 "confidence": 0.0,
                 "rationale": _all_failed_rationale(failed_results, roles),
                 "status": "inconclusive",
+                "diagnostics": _role_diagnostics(failed_results),
             },
         )
 
@@ -170,6 +174,7 @@ def aggregate_role_results(
             "confidence": weighted_confidence,
             "rationale": _aggregate_rationale(healthy_results, failed_results),
             "status": "ok",
+            "diagnostics": _role_diagnostics((*healthy_results, *failed_results)),
         },
     )
 
@@ -224,6 +229,10 @@ class MultiAgentAnalyzer(AnalyzerBase):
                 )
             except MainCoreError:
                 raise
+            if result.role != role.name:
+                raise AlphaAnalyzerError(
+                    "role result role must match the configured role name"
+                )
             role_results.append(result)
 
         return aggregate_role_results(
@@ -248,6 +257,7 @@ def _multi_agent_result(
         rationale=fields["rationale"],
         similar_cases=[dict(case) for case in context.similar_cases],
         status=fields["status"],
+        diagnostics=dict(fields.get("diagnostics", {})),
     )
 
 
@@ -275,6 +285,17 @@ def _role_result_map(
             raise AlphaAnalyzerError(f"duplicate role result: {result.role}")
         result_map[result.role] = result
     return result_map
+
+
+def _ensure_exact_role_coverage(
+    result_map: Mapping[str, MultiAgentRoleResult],
+    role_weight_map: Mapping[str, float],
+) -> None:
+    missing_roles = sorted(set(role_weight_map) - set(result_map))
+    if missing_roles:
+        raise AlphaAnalyzerError(
+            "missing multi-agent role results: " + ", ".join(missing_roles)
+        )
 
 
 def _aggregate_rationale(
@@ -308,6 +329,31 @@ def _all_failed_rationale(
         role_names = ", ".join(sorted(role.name for role in roles))
         failures = f"no successful role results for roles: {role_names}"
     return f"inconclusive: all multi-agent roles failed: {failures}"
+
+
+def _role_diagnostics(
+    role_results: Sequence[MultiAgentRoleResult],
+) -> dict[str, Any]:
+    diagnostics = []
+    failed_roles = []
+    for result in sorted(role_results, key=lambda role_result: role_result.role):
+        if result.task_failed:
+            failed_roles.append(result.role)
+        diagnostics.append(
+            {
+                "role": result.role,
+                "status": "failed" if result.task_failed else "ok",
+                "score": result.score,
+                "confidence": result.confidence,
+                "rationale": result.rationale,
+                "failure_reason": result.failure_reason,
+                "evidence": _plain_value(result.evidence),
+            }
+        )
+    return {
+        "role_diagnostics": diagnostics,
+        "failed_roles": failed_roles,
+    }
 
 
 def _plain_value(value: Any) -> Any:

--- a/src/main_core/l6_alpha/single_prompt_analyzer.py
+++ b/src/main_core/l6_alpha/single_prompt_analyzer.py
@@ -2,25 +2,23 @@
 
 from __future__ import annotations
 
+from math import isfinite
 from typing import ClassVar
 
 from main_core.common.contexts import AlphaAnalysisContext
-from main_core.common.errors import MainCoreError
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
 from main_core.common.types import EntityId
+from main_core.l6_alpha.errors import AlphaAnalyzerError, AlphaReasonerError
 from main_core.l6_alpha.fallback import (
     build_inconclusive_result,
     is_task_level_failure,
 )
 from main_core.l6_alpha.reasoner_port import (
     AlphaReasonerPort,
+    AlphaReasonerResponse,
     StaticAlphaReasonerPort,
 )
-
-
-class AlphaAnalyzerError(MainCoreError):
-    """Raised when the L6 analyzer contract is violated before provider work."""
 
 
 class SinglePromptAnalyzer(AnalyzerBase):
@@ -38,15 +36,16 @@ class SinglePromptAnalyzer(AnalyzerBase):
     ) -> AlphaResultSnapshot:
         """Analyze one entity and downgrade only task-level failures."""
 
-        if entity_id != context.entity_id:
-            raise AlphaAnalyzerError("entity_id must match context.entity_id")
+        _validate_context(entity_id, context)
 
         try:
             response = self._reasoner_port.analyze_alpha(entity_id, context)
         except Exception as exc:
             if is_task_level_failure(exc):
                 return build_inconclusive_result(entity_id, context, str(exc))
-            raise
+            raise AlphaReasonerError(
+                f"alpha reasoner provider failed: {exc}"
+            ) from exc
 
         if response.task_failed:
             reason = response.failure_reason or response.rationale or "alpha task failed"
@@ -57,6 +56,7 @@ class SinglePromptAnalyzer(AnalyzerBase):
                 similar_cases=response.similar_cases,
             )
 
+        _validate_successful_response(response)
         return single_prompt_result(
             cycle_id=context.cycle_id,
             entity_id=entity_id,
@@ -66,6 +66,36 @@ class SinglePromptAnalyzer(AnalyzerBase):
             similar_cases=response.similar_cases,
             status="ok",
         )
+
+
+def _validate_context(entity_id: EntityId, context: AlphaAnalysisContext) -> None:
+    if entity_id != context.entity_id:
+        raise AlphaAnalyzerError("entity_id must match context.entity_id")
+    if context.feature_bundle.cycle_id != context.cycle_id:
+        raise AlphaAnalyzerError("feature_bundle.cycle_id must match context.cycle_id")
+    if context.world_state.cycle_id != context.cycle_id:
+        raise AlphaAnalyzerError("world_state.cycle_id must match context.cycle_id")
+    if context.feature_bundle.entity_id != context.entity_id:
+        raise AlphaAnalyzerError("feature_bundle.entity_id must match context.entity_id")
+
+
+def _validate_successful_response(response: AlphaReasonerResponse) -> None:
+    _finite_number(response.score, "score")
+    confidence = _finite_number(response.confidence, "confidence")
+    if not 0.0 <= confidence <= 1.0:
+        raise AlphaReasonerError("alpha reasoner confidence must be within 0.0..1.0")
+    if not isinstance(response.rationale, str) or not response.rationale.strip():
+        raise AlphaReasonerError("alpha reasoner rationale must be non-empty")
+
+
+def _finite_number(value: object, field_name: str) -> float:
+    if (
+        not isinstance(value, int | float)
+        or isinstance(value, bool)
+        or not isfinite(value)
+    ):
+        raise AlphaReasonerError(f"alpha reasoner {field_name} must be finite numeric")
+    return float(value)
 
 
 __all__ = ["AlphaAnalyzerError", "SinglePromptAnalyzer"]

--- a/src/main_core/l7_recommendation/__init__.py
+++ b/src/main_core/l7_recommendation/__init__.py
@@ -8,6 +8,7 @@ from main_core.l7_recommendation.override import (
     find_override,
     submit_override,
 )
+from main_core.l7_recommendation.rules import rating_for_action
 from main_core.l7_recommendation.service import generate_recommendations
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
     "apply_override",
     "find_override",
     "generate_recommendations",
+    "rating_for_action",
     "submit_override",
 ]

--- a/src/main_core/l7_recommendation/constraints.py
+++ b/src/main_core/l7_recommendation/constraints.py
@@ -7,6 +7,7 @@ from typing import Any
 from main_core.common.contexts import RecommendationConstraintInputs
 from main_core.common.protocols import RecommendationConstraintProviderBase
 from main_core.common.schemas import RecommendationSnapshot
+from main_core.l7_recommendation.rules import rating_for_action
 
 
 class DefaultConstraintProvider(RecommendationConstraintProviderBase):
@@ -35,7 +36,7 @@ class DefaultConstraintProvider(RecommendationConstraintProviderBase):
                 "regime_gate",
                 "risk_off_buy_to_hold",
                 action_type="hold",
-                rating="B",
+                rating=rating_for_action("hold"),
             )
 
         return candidate

--- a/src/main_core/l7_recommendation/override.py
+++ b/src/main_core/l7_recommendation/override.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 from main_core.common.errors import MainCoreError
 from main_core.common.schemas import OverrideRecord, RecommendationSnapshot
 from main_core.common.types import CycleId, EntityId
+from main_core.l7_recommendation.rules import rating_for_action
 
 
 class OverrideStore(Protocol):
@@ -56,7 +57,7 @@ def submit_override(
     """Validate, store, and return a human override record."""
 
     override = _coerce_override(override_input)
-    active_store = store or _DEFAULT_OVERRIDE_STORE
+    active_store = store if store is not None else _DEFAULT_OVERRIDE_STORE
     return active_store.save(override)
 
 
@@ -65,12 +66,24 @@ def find_override(
     cycle_id: CycleId,
     entity_id: EntityId,
 ) -> OverrideRecord | None:
-    """Return the first override matching a cycle/entity pair."""
+    """Return the latest override matching a cycle/entity pair."""
 
-    for override in overrides:
-        if override.cycle_id == cycle_id and override.entity_id == entity_id:
-            return override
-    return None
+    matching_overrides = [
+        (index, override)
+        for index, override in enumerate(overrides)
+        if override.cycle_id == cycle_id and override.entity_id == entity_id
+    ]
+    if not matching_overrides:
+        return None
+
+    _, latest_override = max(
+        matching_overrides,
+        key=lambda indexed_override: (
+            indexed_override[1].submitted_at,
+            indexed_override[0],
+        ),
+    )
+    return latest_override
 
 
 def apply_override(
@@ -94,7 +107,7 @@ def apply_override(
         updates["rating"] = None
         updates["confidence"] = None
     else:
-        updates["rating"] = _rating_for_action(override.action_type)
+        updates["rating"] = rating_for_action(override.action_type)
 
     return candidate.model_copy(update=updates)
 
@@ -103,16 +116,6 @@ def _coerce_override(override_input: OverrideRecord | Mapping[str, Any]) -> Over
     if isinstance(override_input, OverrideRecord):
         return override_input.model_copy()
     return OverrideRecord.model_validate(dict(override_input))
-
-
-def _rating_for_action(action_type: str) -> str:
-    ratings = {
-        "buy": "A",
-        "hold": "B",
-        "reduce": "C",
-    }
-    return ratings[action_type]
-
 
 __all__ = [
     "InMemoryOverrideStore",

--- a/src/main_core/l7_recommendation/rules.py
+++ b/src/main_core/l7_recommendation/rules.py
@@ -1,0 +1,20 @@
+"""Shared L7 recommendation rules."""
+
+from __future__ import annotations
+
+from main_core.common.schemas import ActionType
+
+ACTION_RATING_MAP: dict[str, str] = {
+    "buy": "A",
+    "hold": "B",
+    "reduce": "C",
+}
+
+
+def rating_for_action(action_type: ActionType | str) -> str:
+    """Map a conclusive recommendation action to its formal rating."""
+
+    return ACTION_RATING_MAP[str(action_type)]
+
+
+__all__ = ["ACTION_RATING_MAP", "rating_for_action"]

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -23,6 +23,7 @@ from main_core.l7_recommendation.override import (
     apply_override,
     find_override,
 )
+from main_core.l7_recommendation.rules import rating_for_action
 
 BUY_SCORE_THRESHOLD = 0.65
 REDUCE_SCORE_THRESHOLD = 0.35
@@ -169,7 +170,7 @@ def _candidate_from_analysis(analysis: AlphaResultSnapshot) -> RecommendationSna
         cycle_id=analysis.cycle_id,
         entity_id=analysis.entity_id,
         action_type=action_type,
-        rating=_rating_for_action(action_type),
+        rating=rating_for_action(action_type),
         confidence=analysis.confidence,
         triggered_by="system",
         override_applied=False,
@@ -210,16 +211,6 @@ def _action_for_score(score: float) -> str:
     if score <= REDUCE_SCORE_THRESHOLD:
         return "reduce"
     return "hold"
-
-
-def _rating_for_action(action_type: str) -> str:
-    ratings = {
-        "buy": "A",
-        "hold": "B",
-        "reduce": "C",
-    }
-    return ratings[action_type]
-
 
 __all__ = [
     "BUY_SCORE_THRESHOLD",

--- a/src/main_core/l7_recommendation/service.py
+++ b/src/main_core/l7_recommendation/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import Any
 
 from main_core.common.contexts import RecommendationConstraintInputs
@@ -102,10 +103,14 @@ def _resolve_overrides(
 def _latest_overrides_by_cycle_entity(
     overrides: Sequence[OverrideRecord],
 ) -> tuple[OverrideRecord, ...]:
-    latest_by_key: dict[tuple[str, str], OverrideRecord] = {}
-    for override in overrides:
-        latest_by_key[(str(override.cycle_id), str(override.entity_id))] = override
-    return tuple(latest_by_key.values())
+    latest_by_key: dict[tuple[str, str], tuple[datetime, int, OverrideRecord]] = {}
+    for index, override in enumerate(overrides):
+        key = (str(override.cycle_id), str(override.entity_id))
+        candidate = (override.submitted_at, index, override)
+        existing = latest_by_key.get(key)
+        if existing is None or candidate[:2] > existing[:2]:
+            latest_by_key[key] = candidate
+    return tuple(candidate[2] for candidate in latest_by_key.values())
 
 
 def _default_override_store() -> OverrideStore:

--- a/src/main_core/l8_publish/assembler.py
+++ b/src/main_core/l8_publish/assembler.py
@@ -32,10 +32,10 @@ from main_core.l8_publish.publish_port import (
 )
 from main_core.l8_publish.refs import (
     ALPHA_RESULT_SNAPSHOT_KEY,
-    CANONICAL_FORMAL_OBJECT_KEYS,
     OFFICIAL_ALPHA_POOL_KEY,
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
+    ordered_formal_object_keys,
 )
 from main_core.l8_publish.report import build_dashboard_and_report
 
@@ -320,7 +320,7 @@ def _build_bundle_formal_objects(
         for committed in committed_objects
     }
     bundle_formal_objects: dict[str, dict[str, Any]] = {}
-    for object_key in _ordered_object_keys(formal_objects):
+    for object_key in ordered_formal_object_keys(formal_objects):
         committed_object = committed_by_key.get(object_key)
         if committed_object is None:
             raise ManifestPublishError(f"missing commit result for {object_key}")
@@ -350,20 +350,5 @@ def _bundle_payload(value: FormalObjectValue) -> dict[str, Any] | list[dict[str,
         item.model_dump(mode="json")
         for item in value
     ]
-
-
-def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
-    canonical_keys = [
-        object_key
-        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
-        if object_key in formal_objects
-    ]
-    derived_keys = [
-        object_key
-        for object_key in formal_objects
-        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
-    ]
-    return (*canonical_keys, *derived_keys)
-
 
 __all__ = ["collect_formal_objects", "prepare_publish_bundle"]

--- a/src/main_core/l8_publish/audit_payload.py
+++ b/src/main_core/l8_publish/audit_payload.py
@@ -28,6 +28,16 @@ def build_audit_payload(
 
     alpha_results = _payload_list(formal_objects, ALPHA_RESULT_SNAPSHOT_KEY)
     recommendations = _payload_list(formal_objects, RECOMMENDATION_SNAPSHOT_KEY)
+    alpha_inconclusive_count = sum(
+        1
+        for alpha_result in alpha_results
+        if alpha_result.get("status") == "inconclusive"
+    )
+    recommendation_inconclusive_count = sum(
+        1
+        for recommendation in recommendations
+        if recommendation.get("action_type") == "inconclusive"
+    )
 
     return {
         "cycle_id": str(cycle_id),
@@ -35,11 +45,9 @@ def build_audit_payload(
         "commit_refs": _commit_refs(committed_objects),
         "manifest_ref": manifest.manifest_ref,
         "manifest_version": manifest.manifest_version,
-        "inconclusive_count": sum(
-            1
-            for alpha_result in alpha_results
-            if alpha_result.get("status") == "inconclusive"
-        ),
+        "inconclusive_count": recommendation_inconclusive_count,
+        "alpha_inconclusive_count": alpha_inconclusive_count,
+        "recommendation_inconclusive_count": recommendation_inconclusive_count,
         "override_applied_count": sum(
             1
             for recommendation in recommendations

--- a/src/main_core/l8_publish/dashboard.py
+++ b/src/main_core/l8_publish/dashboard.py
@@ -14,28 +14,22 @@ from main_core.l8_publish.refs import (
     OFFICIAL_ALPHA_POOL_KEY,
     RECOMMENDATION_SNAPSHOT_KEY,
     WORLD_STATE_SNAPSHOT_KEY,
-    formal_object_ref,
+    FormalObjectEntry,
+    list_formal_object_entry,
+    mapping_formal_object_entry,
 )
 
 DASHBOARD_SNAPSHOT_KEY = "dashboard_snapshot"
 
 _ACTION_TYPES = ("buy", "hold", "reduce", "inconclusive")
-_MISSING = object()
-
-
-@dataclass(frozen=True)
-class _FormalObjectEntry:
-    ref: str
-    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...]
-    count: int
 
 
 @dataclass(frozen=True)
 class _RequiredFormalObjects:
-    world_state: _FormalObjectEntry
-    pool: _FormalObjectEntry
-    alpha_results: _FormalObjectEntry
-    recommendations: _FormalObjectEntry
+    world_state: FormalObjectEntry
+    pool: FormalObjectEntry
+    alpha_results: FormalObjectEntry
+    recommendations: FormalObjectEntry
 
 
 def build_dashboard_snapshot(
@@ -65,10 +59,22 @@ def _extract_required_formal_objects(
         raise ManifestPublishError("publish bundle cycle_id must match requested cycle_id")
 
     return _RequiredFormalObjects(
-        world_state=_mapping_entry(bundle, WORLD_STATE_SNAPSHOT_KEY, cycle_id),
-        pool=_mapping_entry(bundle, OFFICIAL_ALPHA_POOL_KEY, cycle_id),
-        alpha_results=_list_entry(bundle, ALPHA_RESULT_SNAPSHOT_KEY, cycle_id),
-        recommendations=_list_entry(bundle, RECOMMENDATION_SNAPSHOT_KEY, cycle_id),
+        world_state=mapping_formal_object_entry(
+            bundle,
+            WORLD_STATE_SNAPSHOT_KEY,
+            cycle_id,
+        ),
+        pool=mapping_formal_object_entry(bundle, OFFICIAL_ALPHA_POOL_KEY, cycle_id),
+        alpha_results=list_formal_object_entry(
+            bundle,
+            ALPHA_RESULT_SNAPSHOT_KEY,
+            cycle_id,
+        ),
+        recommendations=list_formal_object_entry(
+            bundle,
+            RECOMMENDATION_SNAPSHOT_KEY,
+            cycle_id,
+        ),
     )
 
 
@@ -136,80 +142,6 @@ def _build_summary_cards(objects: _RequiredFormalObjects) -> dict[str, Any]:
             "entity_ids": override_entity_ids,
         },
     }
-
-
-def _mapping_entry(
-    bundle: PublishBundle,
-    object_key: str,
-    cycle_id: CycleId,
-) -> _FormalObjectEntry:
-    entry = _entry_mapping(bundle, object_key)
-    ref = formal_object_ref(bundle, object_key)
-    payload = entry.get("payload", _MISSING)
-    if not isinstance(payload, Mapping):
-        raise ManifestPublishError(f"{object_key}.payload must be a mapping")
-
-    count = _entry_count(entry, object_key)
-    if count != 1:
-        raise ManifestPublishError(f"{object_key}.count must be 1")
-    _ensure_payload_cycle(object_key, payload, cycle_id)
-    return _FormalObjectEntry(ref=ref, payload=dict(payload), count=count)
-
-
-def _list_entry(
-    bundle: PublishBundle,
-    object_key: str,
-    cycle_id: CycleId,
-) -> _FormalObjectEntry:
-    entry = _entry_mapping(bundle, object_key)
-    ref = formal_object_ref(bundle, object_key)
-    payload = entry.get("payload", _MISSING)
-    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
-        raise ManifestPublishError(f"{object_key}.payload must be a list")
-
-    payload_items: list[Mapping[str, Any]] = []
-    for index, item in enumerate(payload):
-        if not isinstance(item, Mapping):
-            raise ManifestPublishError(
-                f"{object_key}.payload[{index}] must be a mapping"
-            )
-        _ensure_payload_cycle(object_key, item, cycle_id)
-        payload_items.append(dict(item))
-
-    count = _entry_count(entry, object_key)
-    if count != len(payload_items):
-        raise ManifestPublishError(f"{object_key}.count must match payload length")
-    return _FormalObjectEntry(ref=ref, payload=tuple(payload_items), count=count)
-
-
-def _entry_mapping(bundle: PublishBundle, object_key: str) -> Mapping[str, Any]:
-    try:
-        entry = bundle.formal_objects[object_key]
-    except KeyError as exc:
-        raise ManifestPublishError(f"missing formal object entry {object_key}") from exc
-    if not isinstance(entry, Mapping):
-        raise ManifestPublishError(f"{object_key} formal object entry must be a mapping")
-    return entry
-
-
-def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
-    count = entry.get("count", _MISSING)
-    if (
-        not isinstance(count, int)
-        or isinstance(count, bool)
-        or count < 0
-    ):
-        raise ManifestPublishError(f"{object_key}.count must be a non-negative integer")
-    return count
-
-
-def _ensure_payload_cycle(
-    object_key: str,
-    payload: Mapping[str, Any],
-    cycle_id: CycleId,
-) -> None:
-    if payload.get("cycle_id") != str(cycle_id):
-        raise ManifestPublishError(f"{object_key}.payload cycle_id must match")
 
 
 def _as_mapping(

--- a/src/main_core/l8_publish/manifest.py
+++ b/src/main_core/l8_publish/manifest.py
@@ -14,7 +14,7 @@ from main_core.l8_publish.publish_port import (
     FormalObjectValue,
     ManifestWriteResult,
 )
-from main_core.l8_publish.refs import CANONICAL_FORMAL_OBJECT_KEYS
+from main_core.l8_publish.refs import ordered_formal_object_keys
 
 
 def commit_formal_objects(
@@ -25,7 +25,7 @@ def commit_formal_objects(
     """Commit formal object classes in stable order before manifest publication."""
 
     committed_objects: list[CommittedFormalObject] = []
-    for object_key in _ordered_object_keys(formal_objects):
+    for object_key in ordered_formal_object_keys(formal_objects):
         formal_object = formal_objects[object_key]
         payload = _commit_payload(formal_object)
         expected_row_count = _expected_row_count(formal_object)
@@ -116,21 +116,6 @@ def build_manifest_candidate(
             }
         )
     return candidate
-
-
-def _ordered_object_keys(formal_objects: Mapping[str, FormalObjectValue]) -> tuple[str, ...]:
-    canonical_keys = [
-        object_key
-        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
-        if object_key in formal_objects
-    ]
-    derived_keys = [
-        object_key
-        for object_key in formal_objects
-        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
-    ]
-    return (*canonical_keys, *derived_keys)
-
 
 def _commit_payload(value: FormalObjectValue) -> Mapping[str, Any]:
     if isinstance(value, FormalObjectBase):

--- a/src/main_core/l8_publish/refs.py
+++ b/src/main_core/l8_publish/refs.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from main_core.common.errors import ManifestPublishError
 from main_core.common.schemas import PublishBundle
+from main_core.common.types import CycleId
 
 WORLD_STATE_SNAPSHOT_KEY = "world_state_snapshot"
 OFFICIAL_ALPHA_POOL_KEY = "official_alpha_pool"
@@ -19,6 +21,17 @@ CANONICAL_FORMAL_OBJECT_KEYS: tuple[str, ...] = (
     ALPHA_RESULT_SNAPSHOT_KEY,
     RECOMMENDATION_SNAPSHOT_KEY,
 )
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class FormalObjectEntry:
+    """Validated PublishBundle entry for one committed formal object key."""
+
+    ref: str
+    payload: Mapping[str, Any] | tuple[Mapping[str, Any], ...]
+    count: int
 
 
 def formal_object_ref(bundle: PublishBundle, object_key: str) -> str:
@@ -34,12 +47,82 @@ def formal_object_refs(bundle: PublishBundle, object_key: str) -> tuple[str, ...
     """Return formal refs from a bundle entry using the canonical ref shape."""
 
     entry = _formal_object_entry(bundle, object_key)
+    return _entry_refs(object_key, entry)
+
+
+def mapping_formal_object_entry(
+    bundle: PublishBundle,
+    object_key: str,
+    cycle_id: CycleId,
+) -> FormalObjectEntry:
+    """Parse and validate a single-payload formal object bundle entry."""
+
+    entry = _formal_object_entry(bundle, object_key)
+    ref = formal_object_ref(bundle, object_key)
+    _ensure_ref_points_to_cycle(f"{object_key}.ref", ref, cycle_id)
+    payload = entry.get("payload", _MISSING)
+    if not isinstance(payload, Mapping):
+        raise ManifestPublishError(f"{object_key}.payload must be a mapping")
+
+    count = _entry_count(entry, object_key)
+    if count != 1:
+        raise ManifestPublishError(f"{object_key}.count must be 1")
+    _ensure_payload_cycle(object_key, payload, cycle_id)
+    return FormalObjectEntry(ref=ref, payload=dict(payload), count=count)
+
+
+def list_formal_object_entry(
+    bundle: PublishBundle,
+    object_key: str,
+    cycle_id: CycleId,
+) -> FormalObjectEntry:
+    """Parse and validate a list-payload formal object bundle entry."""
+
+    entry = _formal_object_entry(bundle, object_key)
+    ref = formal_object_ref(bundle, object_key)
+    _ensure_ref_points_to_cycle(f"{object_key}.ref", ref, cycle_id)
+    payload = entry.get("payload", _MISSING)
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)):
+        raise ManifestPublishError(f"{object_key}.payload must be a list")
+
+    payload_items: list[Mapping[str, Any]] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, Mapping):
+            raise ManifestPublishError(
+                f"{object_key}.payload[{index}] must be a mapping"
+            )
+        _ensure_payload_cycle(object_key, item, cycle_id)
+        payload_items.append(dict(item))
+
+    count = _entry_count(entry, object_key)
+    if count != len(payload_items):
+        raise ManifestPublishError(f"{object_key}.count must match payload length")
+    return FormalObjectEntry(ref=ref, payload=tuple(payload_items), count=count)
+
+
+def ordered_formal_object_keys(formal_objects: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return canonical L8 formal object keys followed by derived keys."""
+
+    canonical_keys = [
+        object_key
+        for object_key in CANONICAL_FORMAL_OBJECT_KEYS
+        if object_key in formal_objects
+    ]
+    derived_keys = [
+        object_key
+        for object_key in formal_objects
+        if object_key not in CANONICAL_FORMAL_OBJECT_KEYS
+    ]
+    return (*canonical_keys, *derived_keys)
+
+
+def _entry_refs(object_key: str, entry: Mapping[str, Any]) -> tuple[str, ...]:
     if "refs" in entry:
         refs = entry["refs"]
         if (
             isinstance(refs, Sequence)
             and not isinstance(refs, (str, bytes))
-            and all(isinstance(ref, str) for ref in refs)
+            and all(isinstance(ref, str) and ref for ref in refs)
         ):
             return tuple(refs)
         raise ManifestPublishError(f"{object_key}.refs must be a sequence of strings")
@@ -64,12 +147,45 @@ def _formal_object_entry(
     return entry
 
 
+def _entry_count(entry: Mapping[str, Any], object_key: str) -> int:
+    count = entry.get("count", _MISSING)
+    if (
+        not isinstance(count, int)
+        or isinstance(count, bool)
+        or count < 0
+    ):
+        raise ManifestPublishError(f"{object_key}.count must be a non-negative integer")
+    return count
+
+
+def _ensure_payload_cycle(
+    object_key: str,
+    payload: Mapping[str, Any],
+    cycle_id: CycleId,
+) -> None:
+    if payload.get("cycle_id") != str(cycle_id):
+        raise ManifestPublishError(f"{object_key}.payload cycle_id must match")
+
+
+def _ensure_ref_points_to_cycle(
+    ref_name: str,
+    ref: str,
+    cycle_id: CycleId,
+) -> None:
+    if str(cycle_id) not in ref.split("/"):
+        raise ManifestPublishError(f"{ref_name} must point to requested cycle_id")
+
+
 __all__ = [
     "ALPHA_RESULT_SNAPSHOT_KEY",
     "CANONICAL_FORMAL_OBJECT_KEYS",
+    "FormalObjectEntry",
     "OFFICIAL_ALPHA_POOL_KEY",
     "RECOMMENDATION_SNAPSHOT_KEY",
     "WORLD_STATE_SNAPSHOT_KEY",
     "formal_object_ref",
     "formal_object_refs",
+    "list_formal_object_entry",
+    "mapping_formal_object_entry",
+    "ordered_formal_object_keys",
 ]

--- a/src/main_core/l8_publish/report.py
+++ b/src/main_core/l8_publish/report.py
@@ -134,7 +134,6 @@ def _build_appendix_refs(
         "alpha_result_ref": objects.alpha_results.ref,
         "recommendation_ref": objects.recommendations.ref,
         "manifest_ref": _manifest_ref(cycle_id, bundle),
-        "audit_payload_ref": _audit_payload_ref(cycle_id, bundle),
     }
 
 
@@ -142,21 +141,10 @@ def _manifest_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
     _ensure_same_cycle("manifest_candidate", bundle.manifest_candidate, cycle_id)
     manifest_ref = bundle.manifest_candidate.get("manifest_ref")
     if isinstance(manifest_ref, str) and manifest_ref:
-        _ensure_ref_points_to_cycle("manifest_ref", manifest_ref, cycle_id)
         return manifest_ref
     raise ManifestPublishError(
         "manifest_candidate.manifest_ref must be reserved before formal report build",
     )
-
-
-def _audit_payload_ref(cycle_id: CycleId, bundle: PublishBundle) -> str:
-    _ensure_same_cycle("audit_payload", bundle.audit_payload, cycle_id)
-    for key in ("audit_payload_ref", "ref"):
-        value = bundle.audit_payload.get(key)
-        if isinstance(value, str) and value:
-            _ensure_ref_points_to_cycle(key, value, cycle_id)
-            return value
-    return f"audit_payload/{cycle_id}"
 
 
 def _ensure_same_cycle(
@@ -167,15 +155,6 @@ def _ensure_same_cycle(
     payload_cycle_id = payload.get("cycle_id")
     if payload_cycle_id is not None and payload_cycle_id != str(cycle_id):
         raise ManifestPublishError(f"{payload_name}.cycle_id must match")
-
-
-def _ensure_ref_points_to_cycle(
-    ref_name: str,
-    ref: str,
-    cycle_id: CycleId,
-) -> None:
-    if str(cycle_id) not in ref:
-        raise ManifestPublishError(f"{ref_name} must point to requested cycle_id")
 
 
 def _entity_ids_by_action(

--- a/tests/integration/test_pure_market_closed_loop.py
+++ b/tests/integration/test_pure_market_closed_loop.py
@@ -1,0 +1,183 @@
+"""Pure-market L1-L8 integration coverage for the minimal P2 path."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import OfficialAlphaPool
+from main_core.l1_l2_basis import EntityMasterRow, MarketBar
+from main_core.l3_features import build_feature_signal_bundles
+from main_core.l4_world_state import StaticWorldStateReasonerPort, derive_world_state
+from main_core.l4_world_state.reasoner_port import WorldStateDeltaDecision
+from main_core.l5_universe import select_official_alpha_pool
+from main_core.l6_alpha import (
+    AlphaReasonerResponse,
+    SinglePromptAnalyzer,
+    StaticAlphaReasonerPort,
+    analyze_stock,
+)
+from main_core.l7_recommendation import (
+    InMemoryOverrideStore,
+    generate_recommendations,
+    submit_override,
+)
+from main_core.l8_publish import prepare_publish_bundle
+from tests.l3_features.conftest import FakeDataPlatformPort
+from tests.l8_publish import FakeFormalObjectSource, RecordingPublishPort
+
+
+def test_pure_market_closed_loop_handles_override_constraint_and_inconclusive() -> None:
+    cycle_id = "cycle_market_closed_loop"
+    bundles = build_feature_signal_bundles(cycle_id, data_port=_market_port(cycle_id))
+    world_state = derive_world_state(
+        bundles[0],
+        reasoner_port=StaticWorldStateReasonerPort(
+            WorldStateDeltaDecision(
+                raw_delta=-1,
+                rationale="risk appetite faded",
+                actual_model_used="static",
+                actual_provider="local",
+                fallback_path=[],
+            ),
+        ),
+    )
+
+    with pytest.raises(MainCoreError, match="frozen entities must be present"):
+        select_official_alpha_pool(
+            world_state,
+            bundles,
+            previous_pool=OfficialAlphaPool(
+                cycle_id=cycle_id,
+                observation_pool_size=1,
+                official_alpha_pool_capacity=1,
+                selected_entities=["ENT_STALE"],
+                added_entities=[],
+                removed_entities=[],
+                freeze_reason_map={"ENT_STALE": "stale freeze"},
+            ),
+            capacity=2,
+        )
+
+    pool = select_official_alpha_pool(world_state, bundles, capacity=2)
+    bundle_by_entity = {str(bundle.entity_id): bundle for bundle in bundles}
+    alpha_results = [
+        analyze_stock(
+            entity_id,
+            AlphaAnalysisContext(
+                cycle_id=cycle_id,
+                entity_id=entity_id,
+                feature_bundle=bundle_by_entity[entity_id],
+                world_state=world_state,
+                similar_cases=[],
+            ),
+            analyzer=SinglePromptAnalyzer(
+                StaticAlphaReasonerPort(_alpha_response(entity_id))
+            ),
+        )
+        for entity_id in pool.selected_entities
+    ]
+    override_store = InMemoryOverrideStore()
+    submit_override(
+        {
+            "cycle_id": cycle_id,
+            "entity_id": "ENT_A",
+            "submitted_by": "analyst",
+            "action_type": "buy",
+            "rationale": "manual conviction review",
+            "submitted_at": datetime(2026, 4, 17, 9, 30, tzinfo=UTC),
+        },
+        store=override_store,
+    )
+
+    recommendations = generate_recommendations(
+        pool,
+        alpha_results,
+        world_state,
+        override_store=override_store,
+    )
+    recommendation_by_entity = {
+        str(recommendation.entity_id): recommendation
+        for recommendation in recommendations
+    }
+
+    assert recommendation_by_entity["ENT_A"].action_type == "hold"
+    assert recommendation_by_entity["ENT_A"].triggered_by == "human_decision"
+    assert recommendation_by_entity["ENT_A"].override_applied is True
+    assert (
+        recommendation_by_entity["ENT_A"].constraints_applied["regime_gate"]
+        == "risk_off_buy_to_hold"
+    )
+    assert recommendation_by_entity["ENT_B"].action_type == "inconclusive"
+
+    publish_bundle = prepare_publish_bundle(
+        cycle_id,
+        source=FakeFormalObjectSource(
+            loaded_world_state=world_state,
+            loaded_pool=pool,
+            loaded_alpha_results=alpha_results,
+            loaded_recommendations=recommendations,
+        ),
+        publish_port=RecordingPublishPort(),
+    )
+
+    assert publish_bundle.manifest_candidate["manifest_ref"] == f"manifest/{cycle_id}"
+    assert publish_bundle.audit_payload["recommendation_inconclusive_count"] == 1
+
+
+def _market_port(cycle_id: str) -> FakeDataPlatformPort:
+    return FakeDataPlatformPort(
+        entity_master=(
+            EntityMasterRow(
+                entity_id="ENT_A",
+                ticker="AAA",
+                name="Alpha A",
+                exchange="NASDAQ",
+            ),
+            EntityMasterRow(
+                entity_id="ENT_B",
+                ticker="BBB",
+                name="Beta B",
+                exchange="NYSE",
+            ),
+        ),
+        market_bars=(
+            MarketBar(
+                cycle_id=cycle_id,
+                entity_id="ENT_A",
+                as_of_date=date(2026, 4, 17),
+                close_price=100.0,
+                volume=1000.0,
+                return_1d=0.03,
+            ),
+            MarketBar(
+                cycle_id=cycle_id,
+                entity_id="ENT_B",
+                as_of_date=date(2026, 4, 17),
+                close_price=80.0,
+                volume=800.0,
+                return_1d=0.01,
+            ),
+        ),
+    )
+
+
+def _alpha_response(entity_id: str) -> AlphaReasonerResponse:
+    if entity_id == "ENT_B":
+        return AlphaReasonerResponse(
+            score=None,
+            confidence=0.0,
+            rationale="provider timeout",
+            similar_cases=[],
+            task_failed=True,
+            failure_reason="task-level timeout",
+        )
+    return AlphaReasonerResponse(
+        score=0.8,
+        confidence=0.7,
+        rationale="strong current-cycle market signal",
+        similar_cases=[],
+    )

--- a/tests/l3_features/test_builder.py
+++ b/tests/l3_features/test_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date
+from decimal import Decimal
 from sys import float_info
 from types import ModuleType
 
@@ -45,6 +46,18 @@ class FakeCandidateSignalPort:
         return self.records
 
 
+class InvalidReadMultiplierStore:
+    def get_multipliers(self, cycle_id: CycleId | str) -> dict[str, float]:
+        return {"close_price": float("inf")}
+
+    def put_multipliers(
+        self,
+        cycle_id: CycleId | str,
+        updates: dict[str, float],
+    ) -> None:
+        raise AssertionError("builder read path must not write multipliers")
+
+
 def test_feature_math_derives_market_features_and_applies_known_multipliers(
     cycle_id: CycleId,
 ) -> None:
@@ -78,6 +91,16 @@ def test_feature_math_derives_market_features_and_applies_known_multipliers(
         "volume": 1.0,
         "return_1d": 1.0,
     }
+
+
+def test_feature_math_uses_decimal_arithmetic_before_float_boundary() -> None:
+    weighted_features, effective_multipliers = apply_feature_weight_multiplier(
+        {"close_price": Decimal("0.1")},
+        {"close_price": Decimal("0.2")},
+    )
+
+    assert weighted_features == {"close_price": 0.02}
+    assert effective_multipliers == {"close_price": 0.2}
 
 
 def test_feature_math_omits_missing_return_1d(cycle_id: CycleId) -> None:
@@ -373,3 +396,21 @@ def test_build_feature_signal_bundle_rejects_ambiguous_multi_entity_cycle(
 
     bundles = build_feature_signal_bundles(cycle_id, data_port=port)
     assert [bundle.entity_id for bundle in bundles] == ["ENT_AAPL", "ENT_MSFT"]
+
+
+def test_build_feature_signal_bundle_validates_custom_multiplier_store_reads(
+    cycle_id: CycleId,
+    active_entity: EntityMasterRow,
+    market_bar: MarketBar,
+) -> None:
+    port = FakeDataPlatformPort(
+        market_bars=(market_bar,),
+        entity_master=(active_entity,),
+    )
+
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        build_feature_signal_bundles(
+            cycle_id,
+            data_port=port,
+            multiplier_store=InvalidReadMultiplierStore(),
+        )

--- a/tests/l3_features/test_candidate_signals.py
+++ b/tests/l3_features/test_candidate_signals.py
@@ -179,6 +179,32 @@ def test_normalize_candidate_signals_rejects_duplicate_signal_records() -> None:
         )
 
 
+def test_normalize_candidate_signals_ignores_duplicate_records_for_other_entities() -> None:
+    cycle_id = CycleId("cycle-layer-b")
+
+    normalized = normalize_candidate_signals(
+        (
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_Z"),
+                signal_name="layer_b_score",
+                value=1.0,
+            ),
+            CandidateSignalRecord(
+                cycle_id=cycle_id,
+                entity_id=EntityId("ENT_Z"),
+                signal_name="layer_b_score",
+                value=2.0,
+            ),
+        ),
+        cycle_id=cycle_id,
+        entity_id=EntityId("ENT_A"),
+        multipliers={},
+    )
+
+    assert normalized == {}
+
+
 def test_normalize_candidate_signals_rejects_cycle_mismatch() -> None:
     with pytest.raises(CandidateSignalError, match="cycle_id"):
         normalize_candidate_signals(

--- a/tests/l3_features/test_graph_adapter.py
+++ b/tests/l3_features/test_graph_adapter.py
@@ -17,6 +17,7 @@ from main_core.l3_features import (
     GraphRegimeContext,
     GraphSnapshotError,
     build_feature_signal_bundles,
+    graph_adapter,
     load_graph_features,
     merge_graph_features,
 )
@@ -70,6 +71,13 @@ def test_graph_engine_port_is_runtime_checkable_and_read_only() -> None:
         for name in dir(port)
         if name.startswith(("write_", "commit_", "mutate_"))
     }
+
+
+def test_graph_adapter_keeps_deprecated_runtime_protocol_aliases() -> None:
+    assert graph_adapter.GraphEnginePort is GraphEnginePort
+    assert graph_adapter.GraphImpactRecord is GraphImpactRecord
+    assert graph_adapter.GraphRegimeContext is GraphRegimeContext
+    assert graph_adapter.GraphSnapshotError is GraphSnapshotError
 
 
 def test_load_graph_features_returns_empty_without_port_or_matching_record() -> None:

--- a/tests/l3_features/test_multiplier_store.py
+++ b/tests/l3_features/test_multiplier_store.py
@@ -8,7 +8,11 @@ from threading import Barrier
 import pytest
 
 from main_core.common.types import CycleId
-from main_core.l3_features import InMemoryMultiplierStore, InvalidMultiplierError
+from main_core.l3_features import (
+    InMemoryMultiplierStore,
+    InvalidMultiplierError,
+    validate_multiplier_mapping,
+)
 
 
 def test_in_memory_multiplier_store_is_cycle_scoped() -> None:
@@ -78,3 +82,8 @@ def test_in_memory_multiplier_store_rejects_invalid_values(
         store.put_multipliers("cycle-001", {"close_price": invalid_multiplier})
 
     assert store.get_multipliers("cycle-001") == {}
+
+
+def test_multiplier_validation_rejects_overflowing_numeric_conversion() -> None:
+    with pytest.raises(InvalidMultiplierError, match="finite and > 0"):
+        validate_multiplier_mapping({"close_price": 10**10000})

--- a/tests/l5_universe/test_service.py
+++ b/tests/l5_universe/test_service.py
@@ -13,6 +13,7 @@ from main_core.l5_universe.types import MAX_OFFICIAL_ALPHA_POOL_CAPACITY
 
 DEFAULT_OBSERVATION_SIZE = 3
 THRESHOLDED_OBSERVATION_SIZE = 2
+FROZEN_THRESHOLD_OBSERVATION_SIZE = 3
 TWO_ENTITY_CAPACITY = 2
 
 
@@ -99,6 +100,27 @@ def test_select_official_alpha_pool_records_thresholded_observation_pool_size() 
 
     assert pool.observation_pool_size == THRESHOLDED_OBSERVATION_SIZE
     assert pool.selected_entities == ("ENT_A",)
+
+
+def test_select_official_alpha_pool_counts_frozen_entities_below_threshold() -> None:
+    previous_pool = _pool(
+        selected_entities=["ENT_C"],
+        freeze_reason_map={"ENT_C": "existing core freeze"},
+    )
+
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 3.0),
+            _bundle("ENT_B", 2.0),
+            _bundle("ENT_C", 0.5),
+        ],
+        previous_pool=previous_pool,
+        config=PoolSelectionConfig(capacity=2, min_candidate_score=1.0),
+    )
+
+    assert pool.observation_pool_size == FROZEN_THRESHOLD_OBSERVATION_SIZE
+    assert pool.selected_entities == ("ENT_C", "ENT_A")
 
 
 def test_select_official_alpha_pool_prioritizes_frozen_entities() -> None:

--- a/tests/l6_alpha/test_ab_runner.py
+++ b/tests/l6_alpha/test_ab_runner.py
@@ -110,6 +110,83 @@ def test_ab_report_json_is_parseable_and_excludes_context_models() -> None:
     assert "feature_bundle" not in json.dumps(payload)
 
 
+def test_ab_report_json_serializes_role_diagnostics() -> None:
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=RecordingAnalyzer(
+            "multi_agent_v1",
+            {
+                "ENT_A": _alpha_result("ENT_A", "multi_agent_v1", 0.5, 0.7, "ok")
+                .model_copy(
+                    update={
+                        "diagnostics": {
+                            "role_diagnostics": [
+                                {
+                                    "role": "risk",
+                                    "score": 0.5,
+                                    "evidence": {"metric": "volatility"},
+                                }
+                            ]
+                        }
+                    }
+                )
+            },
+        ),
+        challenger=RecordingAnalyzer(
+            "single_prompt_v1",
+            {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.6, 0.8, "ok")},
+        ),
+    )
+
+    payload = json.loads(format_ab_report_json(report))
+
+    assert payload["cases"][0]["baseline_diagnostics"]["role_diagnostics"] == [
+        {
+            "role": "risk",
+            "score": 0.5,
+            "evidence": {"metric": "volatility"},
+        }
+    ]
+
+
+def test_run_ab_evaluation_rejects_empty_cases() -> None:
+    with pytest.raises(ValueError, match="cases"):
+        run_ab_evaluation(
+            [],
+            baseline=RecordingAnalyzer("single_prompt_v1", {}),
+            challenger=RecordingAnalyzer("multi_agent_v1", {}),
+        )
+
+
+def test_run_ab_evaluation_records_analyzer_failures_instead_of_aborting() -> None:
+    class FailingAnalyzer:
+        analyzer_type = "multi_agent_v1"
+
+        def analyze(
+            self,
+            entity_id: str,
+            context: AlphaAnalysisContext,
+        ) -> AlphaResultSnapshot:
+            raise RuntimeError("role provider exploded")
+
+    report = run_ab_evaluation(
+        [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],
+        baseline=RecordingAnalyzer(
+            "single_prompt_v1",
+            {"ENT_A": _alpha_result("ENT_A", "single_prompt_v1", 0.5, 0.7, "ok")},
+        ),
+        challenger=FailingAnalyzer(),
+    )
+
+    assert report.total_cases == 1
+    assert report.challenger_failure_count == 1
+    assert report.challenger_inconclusive_count == 1
+    assert "role provider exploded" in report.cases[0].challenger_error
+    markdown = format_ab_report_markdown(report)
+    assert "challenger_error" in markdown
+    assert "role provider exploded" in markdown
+
+
 def test_ab_report_markdown_uses_stable_summary_and_case_tables() -> None:
     report = run_ab_evaluation(
         [AbEvaluationCase("case-a", "ENT_A", _context("ENT_A"))],

--- a/tests/l6_alpha/test_fallback.py
+++ b/tests/l6_alpha/test_fallback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
-from main_core.l6_alpha import AlphaReasonerResponse, build_inconclusive_result
+from main_core.l6_alpha import build_inconclusive_result
 from main_core.l6_alpha.fallback import is_task_level_failure
 
 
@@ -42,14 +42,5 @@ def test_build_inconclusive_result_accepts_explicit_similar_cases(
 
 def test_is_task_level_failure_only_accepts_inconclusive_errors() -> None:
     assert is_task_level_failure(InconclusiveError("single stock task failed"))
-    assert is_task_level_failure(
-        AlphaReasonerResponse(
-            score=None,
-            confidence=0.0,
-            rationale="provider task failed",
-            similar_cases=[],
-            task_failed=True,
-        ),
-    )
     assert not is_task_level_failure(MainCoreError("infrastructure failed"))
     assert not is_task_level_failure(RuntimeError("unknown failure"))

--- a/tests/l6_alpha/test_multi_agent_analyzer.py
+++ b/tests/l6_alpha/test_multi_agent_analyzer.py
@@ -110,6 +110,11 @@ def test_multi_agent_analyzer_happy_path_returns_formal_result(
     assert result.confidence == pytest.approx(EXPECTED_WEIGHTED_CONFIDENCE)
     assert "fundamental case is strong" in result.rationale
     assert "technical case is mixed" in result.rationale
+    assert result.diagnostics["failed_roles"] == ()
+    assert result.diagnostics["role_diagnostics"][0]["role"] == "fundamental"
+    assert result.diagnostics["role_diagnostics"][0]["evidence"] == {
+        "metric": "quality",
+    }
     assert [call[2].name for call in port.calls] == ["fundamental", "technical"]
 
 
@@ -180,6 +185,7 @@ def test_single_role_task_failure_keeps_ok_result_and_records_reason(
     assert result.status == "ok"
     assert result.score == HEALTHY_ONLY_SCORE
     assert "risk failed: risk provider timeout" in result.rationale
+    assert result.diagnostics["failed_roles"] == ("risk",)
 
 
 def test_inconclusive_role_error_is_downgraded_to_role_failure(
@@ -233,6 +239,52 @@ def test_all_role_task_failures_return_multi_agent_inconclusive(
     assert result.confidence == 0.0
     assert "fundamental: no data" in result.rationale
     assert "risk: timeout" in result.rationale
+    assert result.diagnostics["failed_roles"] == ("fundamental", "risk")
+
+
+def test_static_multi_agent_default_returns_visible_inconclusive(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = MultiAgentAnalyzer(roles=(AgentRoleConfig("fundamental"),))
+
+    result = analyzer.analyze("ENT_A", analysis_context)
+
+    assert result.status == "inconclusive"
+    assert result.score is None
+    assert result.diagnostics["failed_roles"] == ("fundamental",)
+
+
+def test_aggregate_role_results_rejects_missing_configured_role(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    with pytest.raises(AlphaAnalyzerError, match="missing multi-agent role"):
+        aggregate_role_results(
+            "ENT_A",
+            analysis_context,
+            [MultiAgentRoleResult("fundamental", 0.7, 0.8, "fundamental")],
+            roles=(AgentRoleConfig("fundamental"), AgentRoleConfig("risk")),
+        )
+
+
+def test_multi_agent_analyzer_rejects_permuted_role_identity(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = MultiAgentAnalyzer(
+        RecordingMultiAgentPort(
+            {
+                "fundamental": MultiAgentRoleResult(
+                    "risk",
+                    0.7,
+                    0.8,
+                    "wrong role identity",
+                ),
+            }
+        ),
+        roles=(AgentRoleConfig("fundamental"),),
+    )
+
+    with pytest.raises(AlphaAnalyzerError, match="configured role name"):
+        analyzer.analyze("ENT_A", analysis_context)
 
 
 def test_main_core_error_from_role_hard_stops_without_fallback(

--- a/tests/l6_alpha/test_single_prompt_analyzer.py
+++ b/tests/l6_alpha/test_single_prompt_analyzer.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from main_core.common.contexts import AlphaAnalysisContext
 from main_core.common.errors import InconclusiveError, MainCoreError
 from main_core.common.schemas import AlphaResultSnapshot
-from main_core.l6_alpha import AlphaReasonerResponse, SinglePromptAnalyzer
+from main_core.l6_alpha import AlphaReasonerError, AlphaReasonerResponse, SinglePromptAnalyzer
 from main_core.l6_alpha.single_prompt_analyzer import AlphaAnalyzerError
 
 EXPECTED_FEATURE_MOMENTUM = 4.2
@@ -127,6 +128,65 @@ def test_single_prompt_analyzer_propagates_main_core_infrastructure_errors(
 
     with pytest.raises(MainCoreError, match="reasoner unavailable"):
         analyzer.analyze("ENT_A", analysis_context)
+
+
+def test_single_prompt_analyzer_wraps_unknown_provider_errors(
+    analysis_context: AlphaAnalysisContext,
+) -> None:
+    analyzer = SinglePromptAnalyzer(
+        RecordingReasonerPort(error=RuntimeError("provider exploded")),
+    )
+
+    with pytest.raises(AlphaReasonerError, match="provider exploded"):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "match"),
+    [
+        ("score", "0.7", "score"),
+        ("confidence", True, "confidence"),
+        ("confidence", 1.2, "confidence"),
+        ("rationale", " ", "rationale"),
+    ],
+)
+def test_single_prompt_analyzer_rejects_malformed_successful_reasoner_output(
+    analysis_context: AlphaAnalysisContext,
+    field_name: str,
+    field_value: object,
+    match: str,
+) -> None:
+    response_payload = {
+        "score": 0.5,
+        "confidence": 0.6,
+        "rationale": "usable answer",
+        "similar_cases": [],
+    }
+    response_payload[field_name] = field_value
+    analyzer = SinglePromptAnalyzer(
+        RecordingReasonerPort(AlphaReasonerResponse(**response_payload)),
+    )
+
+    with pytest.raises(AlphaReasonerError, match=match):
+        analyzer.analyze("ENT_A", analysis_context)
+
+
+@pytest.mark.parametrize(
+    "context_update",
+    [
+        {"cycle_id": "cycle_other"},
+        {"entity_id": "ENT_OTHER"},
+    ],
+)
+def test_alpha_analysis_context_rejects_upstream_consistency_mismatch(
+    analysis_context: AlphaAnalysisContext,
+    context_update: dict[str, object],
+) -> None:
+    payload = analysis_context.model_dump(mode="python")
+    payload.update(context_update)
+
+    with pytest.raises(ValidationError):
+        AlphaAnalysisContext(**payload)
 
 
 def test_single_prompt_analyzer_does_not_reapply_feature_multipliers(

--- a/tests/l7_recommendation/test_override.py
+++ b/tests/l7_recommendation/test_override.py
@@ -13,6 +13,7 @@ from main_core.l7_recommendation import (
     InMemoryOverrideStore,
     apply_override,
     find_override,
+    rating_for_action,
     submit_override,
 )
 
@@ -57,6 +58,18 @@ def test_submit_override_accepts_mapping_and_stores_validated_record() -> None:
         OverrideRecord.model_validate({**override.model_dump(), "action_type": "sell"})
 
 
+def test_submit_override_honors_explicit_falsey_store() -> None:
+    class FalseyOverrideStore(InMemoryOverrideStore):
+        def __len__(self) -> int:
+            return 0
+
+    store = FalseyOverrideStore()
+
+    override = submit_override(_override_payload(), store=store)
+
+    assert store.records == (override,)
+
+
 def test_submit_override_accepts_existing_record() -> None:
     store = InMemoryOverrideStore()
     override = OverrideRecord(**_override_payload(action_type="reduce"))
@@ -76,6 +89,23 @@ def test_find_override_returns_matching_cycle_entity_record() -> None:
     assert find_override([first, second], "cycle_l7", "ENT_Z") is None
 
 
+def test_find_override_uses_latest_submitted_at_for_duplicate_cycle_entity() -> None:
+    older = OverrideRecord(
+        **_override_payload(
+            action_type="buy",
+            submitted_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+        )
+    )
+    newer = OverrideRecord(
+        **_override_payload(
+            action_type="reduce",
+            submitted_at=datetime(2026, 1, 2, 3, 4, 6, tzinfo=UTC),
+        )
+    )
+
+    assert find_override([newer, older], "cycle_l7", "ENT_A") == newer
+
+
 def test_apply_override_sets_human_audit_fields_and_keeps_constraints() -> None:
     override = OverrideRecord(**_override_payload(action_type="reduce"))
 
@@ -93,3 +123,9 @@ def test_apply_override_rejects_non_matching_override() -> None:
 
     with pytest.raises(MainCoreError, match="entity_id"):
         apply_override(_candidate(), override)
+
+
+def test_rating_for_action_shared_mapping() -> None:
+    assert rating_for_action("buy") == "A"
+    assert rating_for_action("hold") == "B"
+    assert rating_for_action("reduce") == "C"

--- a/tests/l7_recommendation/test_service.py
+++ b/tests/l7_recommendation/test_service.py
@@ -292,6 +292,62 @@ def test_submit_override_default_store_latest_matching_submission_wins(
     assert "regime_gate" not in recommendation.constraints_applied
 
 
+def test_generate_recommendations_uses_latest_submitted_override_when_input_is_unsorted() -> None:
+    pool = _pool(("ENT_A",))
+    newer = _override(
+        "ENT_A",
+        "reduce",
+        submitted_at=datetime(2026, 1, 2, 3, 4, 6, tzinfo=UTC),
+    )
+    older = _override(
+        "ENT_A",
+        "buy",
+        submitted_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+    )
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.5)],
+        _world_state(),
+        overrides=[newer, older],
+    )
+
+    assert recommendation.action_type == "reduce"
+    assert recommendation.rating == "C"
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
+
+
+def test_generate_recommendations_uses_latest_submitted_override_from_store() -> None:
+    pool = _pool(("ENT_A",))
+    override_store = InMemoryOverrideStore(
+        [
+            _override(
+                "ENT_A",
+                "reduce",
+                submitted_at=datetime(2026, 1, 2, 3, 4, 6, tzinfo=UTC),
+            ),
+            _override(
+                "ENT_A",
+                "buy",
+                submitted_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+            ),
+        ],
+    )
+
+    [recommendation] = generate_recommendations(
+        pool,
+        [_analysis("ENT_A", 0.5)],
+        _world_state(),
+        override_store=override_store,
+    )
+
+    assert recommendation.action_type == "reduce"
+    assert recommendation.rating == "C"
+    assert recommendation.triggered_by == "human_decision"
+    assert recommendation.override_applied is True
+
+
 def test_generate_recommendations_honors_explicit_falsey_override_store(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/l8_publish/test_assembler.py
+++ b/tests/l8_publish/test_assembler.py
@@ -91,6 +91,14 @@ def test_prepare_publish_bundle_returns_canonical_formal_object_entries() -> Non
         FORMAL_REPORT_KEY: SINGLE_OBJECT_COUNT,
     }
     assert bundle_payload["audit_payload"]["inconclusive_count"] == SINGLE_OBJECT_COUNT
+    assert (
+        bundle_payload["audit_payload"]["alpha_inconclusive_count"]
+        == SINGLE_OBJECT_COUNT
+    )
+    assert (
+        bundle_payload["audit_payload"]["recommendation_inconclusive_count"]
+        == SINGLE_OBJECT_COUNT
+    )
     assert bundle_payload["audit_payload"]["override_applied_count"] == SINGLE_OBJECT_COUNT
     assert bundle_payload["retrospective_seed"]["selected_entity_ids"] == [
         "ENT_A",

--- a/tests/l8_publish/test_dashboard.py
+++ b/tests/l8_publish/test_dashboard.py
@@ -60,6 +60,18 @@ def test_build_dashboard_snapshot_rejects_cycle_mismatch() -> None:
         build_dashboard_snapshot("cycle_l8", bundle)
 
 
+def test_build_dashboard_snapshot_rejects_stale_formal_object_ref() -> None:
+    bundle = _mutated_bundle(
+        lambda payload: payload["formal_objects"][WORLD_STATE_SNAPSHOT_KEY].__setitem__(
+            "ref",
+            "world_state_snapshot/cycle_old/ref",
+        )
+    )
+
+    with pytest.raises(ManifestPublishError, match="requested cycle_id"):
+        build_dashboard_snapshot("cycle_l8", bundle)
+
+
 def test_build_dashboard_snapshot_keeps_inconclusive_recommendations_visible() -> None:
     dashboard = build_dashboard_snapshot("cycle_l8", _base_bundle()).model_dump(
         mode="json"
@@ -121,4 +133,4 @@ def _base_bundle(source: FakeFormalObjectSource | None = None) -> PublishBundle:
 def _mutated_bundle(mutator: Callable[[dict[str, Any]], None]) -> PublishBundle:
     payload = _base_bundle().model_dump(mode="python")
     mutator(payload)
-    return PublishBundle(**payload)
+    return PublishBundle.model_construct(**payload)

--- a/tests/l8_publish/test_publish_integration.py
+++ b/tests/l8_publish/test_publish_integration.py
@@ -125,6 +125,8 @@ def test_publish_consumes_current_l7_output_without_previous_recommendations() -
     assert recommendation_payload[1]["action_type"] == "inconclusive"
     assert bundle_payload["audit_payload"]["override_applied_count"] == 1
     assert bundle_payload["audit_payload"]["inconclusive_count"] == 1
+    assert bundle_payload["audit_payload"]["alpha_inconclusive_count"] == 1
+    assert bundle_payload["audit_payload"]["recommendation_inconclusive_count"] == 1
 
     serialized_bundle = json.dumps(bundle_payload, sort_keys=True)
     assert "previous_recommendation" not in serialized_bundle

--- a/tests/l8_publish/test_report.py
+++ b/tests/l8_publish/test_report.py
@@ -36,7 +36,6 @@ def test_build_formal_report_happy_path() -> None:
         "alpha_result_ref": "alpha_result_snapshot/cycle_l8/ref",
         "recommendation_ref": "recommendation_snapshot/cycle_l8/ref",
         "manifest_ref": "manifest/cycle_l8",
-        "audit_payload_ref": "audit_payload/cycle_l8",
     }
 
 
@@ -65,6 +64,19 @@ def test_build_formal_report_rejects_cycle_mismatch() -> None:
 
     with pytest.raises(ManifestPublishError, match="cycle_id"):
         build_formal_report("cycle_l8", bundle)
+
+
+def test_build_formal_report_allows_opaque_manifest_ref() -> None:
+    bundle = prepare_publish_bundle(
+        "cycle_l8",
+        source=FakeFormalObjectSource(),
+        publish_port=RecordingPublishPort(manifest_ref="pg://cycle_publish_manifest/42"),
+        derived_builders=(),
+    )
+
+    report = build_formal_report("cycle_l8", bundle)
+
+    assert report.appendix_refs["manifest_ref"] == "pg://cycle_publish_manifest/42"
 
 
 def test_build_formal_report_keeps_inconclusive_outcomes_visible() -> None:
@@ -125,4 +137,4 @@ def _base_bundle(source: FakeFormalObjectSource | None = None) -> PublishBundle:
 def _mutated_bundle(mutator: Callable[[dict[str, Any]], None]) -> PublishBundle:
     payload = _base_bundle().model_dump(mode="python")
     mutator(payload)
-    return PublishBundle(**payload)
+    return PublishBundle.model_construct(**payload)

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -106,4 +106,4 @@ def test_multi_agent_analyzer_returns_multi_agent_result() -> None:
     result = analyzer.analyze(ENTITY_ID, _analysis_context())
 
     assert result.analyzer_type == MULTI_AGENT_ANALYZER
-    assert result.status == "ok"
+    assert result.status == "inconclusive"

--- a/tests/protocols/test_graph_engine_contract.py
+++ b/tests/protocols/test_graph_engine_contract.py
@@ -52,8 +52,12 @@ def test_l3_graph_exports_are_compatibility_aliases() -> None:
     assert l3_features.GraphSnapshotError is GraphSnapshotError
 
 
-def test_l3_adapter_only_exports_adapter_helpers() -> None:
+def test_l3_adapter_exports_adapter_helpers_and_deprecated_runtime_aliases() -> None:
     assert set(l3_graph_adapter.__all__) == {
+        "GraphEnginePort",
+        "GraphImpactRecord",
+        "GraphRegimeContext",
+        "GraphSnapshotError",
         "load_graph_features",
         "merge_graph_features",
     }

--- a/tests/schemas/test_alpha.py
+++ b/tests/schemas/test_alpha.py
@@ -69,3 +69,21 @@ def test_alpha_result_rejects_inconclusive_with_score() -> None:
 
     with pytest.raises(ValidationError, match="score=None"):
         AlphaResultSnapshot(**payload)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("score", float("nan")),
+        ("confidence", float("inf")),
+    ],
+)
+def test_alpha_result_rejects_non_finite_numeric_fields(
+    field_name: str,
+    field_value: float,
+) -> None:
+    payload = _alpha_payload()
+    payload[field_name] = field_value
+
+    with pytest.raises(ValidationError):
+        AlphaResultSnapshot(**payload)

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -59,7 +59,7 @@ def test_feature_signal_bundle_missing_field_fails() -> None:
 
 @pytest.mark.parametrize(
     "multiplier",
-    [0.0, -0.1, float("inf")],
+    [0.0, -0.1],
 )
 def test_feature_signal_bundle_rejects_non_positive_or_non_finite_multiplier(
     multiplier: float,
@@ -68,6 +68,28 @@ def test_feature_signal_bundle_rejects_non_positive_or_non_finite_multiplier(
     payload["feature_weight_multiplier"] = {"momentum": multiplier}
 
     with pytest.raises(ValidationError, match="finite and > 0"):
+        FeatureSignalBundle(**payload)
+
+
+@pytest.mark.parametrize("multiplier", [float("nan"), float("inf")])
+def test_feature_signal_bundle_rejects_non_finite_multiplier(
+    multiplier: float,
+) -> None:
+    payload = _bundle_payload()
+    payload["feature_weight_multiplier"] = {"momentum": multiplier}
+
+    with pytest.raises(ValidationError):
+        FeatureSignalBundle(**payload)
+
+
+@pytest.mark.parametrize("feature_value", [float("nan"), float("inf")])
+def test_feature_signal_bundle_rejects_non_finite_feature_values(
+    feature_value: float,
+) -> None:
+    payload = _bundle_payload()
+    payload["feature_values"] = {"momentum": feature_value}
+
+    with pytest.raises(ValidationError):
         FeatureSignalBundle(**payload)
 
 
@@ -215,3 +237,4 @@ def test_all_schema_models_inherit_frozen_forbid_strict_base() -> None:
         assert model.model_config["frozen"] is True
         assert model.model_config["extra"] == "forbid"
         assert model.model_config["strict"] is True
+        assert model.model_config["allow_inf_nan"] is False

--- a/tests/schemas/test_feature_bundle.py
+++ b/tests/schemas/test_feature_bundle.py
@@ -196,8 +196,19 @@ def test_feature_signal_bundle_deep_freezes_nested_payload_containers() -> None:
         (
             PublishBundle(
                 cycle_id="cycle_001",
-                formal_objects={"world_state": {"ref": "world_state_snapshot/cycle_001"}},
-                manifest_candidate={"snapshot_id": "snap_001"},
+                formal_objects={
+                    "world_state_snapshot": {
+                        "ref": "world_state_snapshot/cycle_001/ref",
+                        "payload": {"cycle_id": "cycle_001"},
+                        "count": 1,
+                    },
+                },
+                manifest_candidate={
+                    "snapshot_id": "snap_001",
+                    "object_refs": {
+                        "world_state_snapshot": "world_state_snapshot/cycle_001/ref",
+                    },
+                },
                 audit_payload={"actor": "system"},
                 retrospective_seed={"window": "1d"},
             ),

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -42,6 +42,23 @@ def test_official_alpha_pool_rejects_selected_entities_over_capacity() -> None:
         OfficialAlphaPool(**payload)
 
 
+def test_official_alpha_pool_rejects_negative_observation_pool_size() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = -1
+
+    with pytest.raises(ValidationError):
+        OfficialAlphaPool(**payload)
+
+
+def test_official_alpha_pool_rejects_selected_entities_over_observation_size() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = 1
+    payload["official_alpha_pool_capacity"] = 2
+
+    with pytest.raises(ValidationError, match="observation_pool_size"):
+        OfficialAlphaPool(**payload)
+
+
 def test_official_alpha_pool_selected_entities_cannot_mutate_past_capacity() -> None:
     payload = _pool_payload()
     payload["official_alpha_pool_capacity"] = 1

--- a/tests/schemas/test_publish.py
+++ b/tests/schemas/test_publish.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from main_core.common.schemas import OverrideRecord, PublishBundle
+from main_core.l8_publish.refs import WORLD_STATE_SNAPSHOT_KEY
 
 
 def _publish_payload() -> dict[str, object]:
@@ -50,6 +51,60 @@ def test_publish_bundle_rejects_wrong_formal_objects_type() -> None:
     payload["formal_objects"] = []
 
     with pytest.raises(ValidationError):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_stale_formal_object_ref() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = {
+        WORLD_STATE_SNAPSHOT_KEY: {
+            "ref": "world_state_snapshot/cycle_old/ref",
+            "payload": {"cycle_id": "cycle_001"},
+            "count": 1,
+        },
+    }
+
+    with pytest.raises(ValidationError, match="bundle.cycle_id"):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_stale_manifest_object_ref() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = {
+        WORLD_STATE_SNAPSHOT_KEY: {
+            "ref": "world_state_snapshot/cycle_001/ref",
+            "payload": {"cycle_id": "cycle_001"},
+            "count": 1,
+        },
+    }
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "object_refs": {
+            WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot/cycle_old/ref",
+        },
+    }
+
+    with pytest.raises(ValidationError, match="bundle.cycle_id"):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_manifest_ref_that_disagrees_with_formal_entry() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = {
+        WORLD_STATE_SNAPSHOT_KEY: {
+            "ref": "world_state_snapshot/cycle_001/ref",
+            "payload": {"cycle_id": "cycle_001"},
+            "count": 1,
+        },
+    }
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "object_refs": {
+            WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot/cycle_001/other_ref",
+        },
+    }
+
+    with pytest.raises(ValidationError, match="formal_objects entry ref"):
         PublishBundle(**payload)
 
 

--- a/tests/schemas/test_publish.py
+++ b/tests/schemas/test_publish.py
@@ -14,8 +14,19 @@ from main_core.l8_publish.refs import WORLD_STATE_SNAPSHOT_KEY
 def _publish_payload() -> dict[str, object]:
     return {
         "cycle_id": "cycle_001",
-        "formal_objects": {"world_state": {"ref": "world_state_snapshot/cycle_001"}},
-        "manifest_candidate": {"snapshot_id": "snap_001"},
+        "formal_objects": {
+            WORLD_STATE_SNAPSHOT_KEY: {
+                "ref": "world_state_snapshot/cycle_001/ref",
+                "payload": {"cycle_id": "cycle_001"},
+                "count": 1,
+            },
+        },
+        "manifest_candidate": {
+            "snapshot_id": "snap_001",
+            "object_refs": {
+                WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot/cycle_001/ref",
+            },
+        },
         "audit_payload": {"actor": "system"},
         "retrospective_seed": {"window": "1d"},
     }
@@ -65,6 +76,54 @@ def test_publish_bundle_rejects_stale_formal_object_ref() -> None:
     }
 
     with pytest.raises(ValidationError, match="bundle.cycle_id"):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_non_mapping_formal_object_entry() -> None:
+    payload = _publish_payload()
+    payload["formal_objects"] = {WORLD_STATE_SNAPSHOT_KEY: "not-an-entry"}
+
+    with pytest.raises(ValidationError, match="formal object entry"):
+        PublishBundle(**payload)
+
+
+@pytest.mark.parametrize("field_name", ["ref", "payload", "count"])
+def test_publish_bundle_rejects_formal_object_entry_missing_required_field(
+    field_name: str,
+) -> None:
+    payload = _publish_payload()
+    formal_objects = payload["formal_objects"]
+    assert isinstance(formal_objects, dict)
+    entry = dict(formal_objects[WORLD_STATE_SNAPSHOT_KEY])
+    entry.pop(field_name)
+    payload["formal_objects"] = {WORLD_STATE_SNAPSHOT_KEY: entry}
+
+    with pytest.raises(ValidationError, match=field_name):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_manifest_object_refs_missing_formal_object_key() -> None:
+    payload = _publish_payload()
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "object_refs": {},
+    }
+
+    with pytest.raises(ValidationError, match="object_refs keys"):
+        PublishBundle(**payload)
+
+
+def test_publish_bundle_rejects_manifest_object_ref_for_absent_formal_object_key() -> None:
+    payload = _publish_payload()
+    payload["manifest_candidate"] = {
+        "cycle_id": "cycle_001",
+        "object_refs": {
+            WORLD_STATE_SNAPSHOT_KEY: "world_state_snapshot/cycle_001/ref",
+            "unbacked_object": "unbacked_object/cycle_001/ref",
+        },
+    }
+
+    with pytest.raises(ValidationError, match="object_refs keys"):
         PublishBundle(**payload)
 
 

--- a/tests/schemas/test_recommendation.py
+++ b/tests/schemas/test_recommendation.py
@@ -50,3 +50,11 @@ def test_recommendation_rejects_inconclusive_with_confidence() -> None:
 
     with pytest.raises(ValidationError, match="confidence=None"):
         RecommendationSnapshot(**payload)
+
+
+def test_recommendation_rejects_non_finite_confidence() -> None:
+    payload = _recommendation_payload()
+    payload["confidence"] = float("nan")
+
+    with pytest.raises(ValidationError):
+        RecommendationSnapshot(**payload)


### PR DESCRIPTION
Closes #51

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/main_core/common/schemas/publish.py`, `src/main_core/l3_features/multiplier_validation.py`, `src/main_core/l6_alpha/ab_runner.py`, `src/main_core/l6_alpha/single_prompt_analyzer.py`, `unknown`


---
## P1 Backlog Cleanup (33 findings across 18 files)

Consolidated cleanup of P1 findings accumulated from milestone reviews. 
These are non-blocking improvements identified during code review.

**Fix all (or as many as feasible) in a single PR.** Items are grouped by file:


### `cross-cutting` (5 items)


- **L1** (conf=0.74, from PR #-92625): Multiplier store validation is split across multiple layers
  - Recommendation: Extract a single L3 multiplier validation helper and use it in the write API, store implementations, and builder read path. Add tests with a deliberately invalid custom store so the public builder always raises the same L3 error class.

- **L1** (conf=0.9, from PR #-36312): Milestone lacks cross-layer integration coverage
  - Recommendation: Add a minimal pure-market closed-loop test that derives world state, selects a pool, builds L6 contexts from the selected entities, generates recommendations, and verifies override plus constraint behavior. Include one task-level L6 inconclusive case and one stale-freeze case.

- **L1** (conf=0.86, from PR #-36682): Bundle parsing and object ordering logic is duplicated across L8 modules
  - Recommendation: Extract shared L8 utilities for ordered formal object keys and typed PublishBundle entry parsing. Keep dashboard/report-specific summarization separate, but make ref/payload/count validation a single public helper used by all L8 builders.

- **L1** (conf=0.84, from PR #-96178): Adapter merge and serialization rules are duplicated and inconsistent
  - Recommendation: Extract a shared JSON-like normalization helper and define explicit merge policies for external payloads. Prefer namespaced payloads such as graph_impact and candidate_signals, and make overwrite behavior either impossible or explicitly audited.

- **L1** (conf=0.78, from PR #-4093): Role-level evidence is discarded from formal and A/B outputs
  - Recommendation: Define a structured role diagnostics payload for multi_agent_v1, either as an Alpha