### PR TITLE
feat(#59): [milestone-99 review] P0: Analyzer context validation is inconsistent across implementations

### DIFF
--- a/src/main_core/common/contexts.py
+++ b/src/main_core/common/contexts.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from main_core.common.errors import AlphaAnalyzerError
 from main_core.common.schemas import (
     FeatureSignalBundle,
     WorldStateSnapshot,
@@ -23,6 +24,28 @@ class AlphaAnalysisContext(BaseModel):
     feature_bundle: FeatureSignalBundle
     world_state: WorldStateSnapshot
     similar_cases: list[dict[str, Any]] = Field(default_factory=list)
+
+
+def validate_alpha_analysis_context(
+    entity_id: EntityId,
+    context: AlphaAnalysisContext,
+) -> None:
+    """Validate the L6 analyzer input contract before provider work."""
+
+    if entity_id != context.entity_id:
+        raise AlphaAnalyzerError("entity_id must match context.entity_id")
+    if context.feature_bundle.cycle_id != context.cycle_id:
+        raise AlphaAnalyzerError(
+            "context.feature_bundle.cycle_id must match context.cycle_id",
+        )
+    if context.world_state.cycle_id != context.cycle_id:
+        raise AlphaAnalyzerError(
+            "context.world_state.cycle_id must match context.cycle_id",
+        )
+    if context.feature_bundle.entity_id != context.entity_id:
+        raise AlphaAnalyzerError(
+            "context.feature_bundle.entity_id must match context.entity_id",
+        )
 
 
 class WorldStateInputs(BaseModel):
@@ -49,4 +72,5 @@ __all__ = [
     "AlphaAnalysisContext",
     "RecommendationConstraintInputs",
     "WorldStateInputs",
+    "validate_alpha_analysis_context",
 ]

--- a/src/main_core/l6_alpha/multi_agent_analyzer.py
+++ b/src/main_core/l6_alpha/multi_agent_analyzer.py
@@ -8,7 +8,10 @@ from math import fsum, isfinite
 from types import MappingProxyType
 from typing import Any, ClassVar, Protocol, runtime_checkable
 
-from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.contexts import (
+    AlphaAnalysisContext,
+    validate_alpha_analysis_context,
+)
 from main_core.common.errors import AlphaAnalyzerError, InconclusiveError, MainCoreError
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot
@@ -199,8 +202,7 @@ class MultiAgentAnalyzer(AnalyzerBase):
     ) -> AlphaResultSnapshot:
         """Analyze one entity by invoking each configured role exactly once."""
 
-        if entity_id != context.entity_id:
-            raise AlphaAnalyzerError("entity_id must match context.entity_id")
+        validate_alpha_analysis_context(entity_id, context)
 
         payload = build_multi_agent_input_payload(entity_id, context)
         role_results: list[MultiAgentRoleResult] = []

--- a/src/main_core/l6_alpha/single_prompt_analyzer.py
+++ b/src/main_core/l6_alpha/single_prompt_analyzer.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.contexts import (
+    AlphaAnalysisContext,
+    validate_alpha_analysis_context,
+)
 from main_core.common.errors import AlphaAnalyzerError
 from main_core.common.protocols import AnalyzerBase
 from main_core.common.schemas import AlphaResultSnapshot, single_prompt_result
@@ -34,20 +37,7 @@ class SinglePromptAnalyzer(AnalyzerBase):
     ) -> AlphaResultSnapshot:
         """Analyze one entity and downgrade only task-level failures."""
 
-        if entity_id != context.entity_id:
-            raise AlphaAnalyzerError("entity_id must match context.entity_id")
-        if context.feature_bundle.cycle_id != context.cycle_id:
-            raise AlphaAnalyzerError(
-                "context.feature_bundle.cycle_id must match context.cycle_id",
-            )
-        if context.world_state.cycle_id != context.cycle_id:
-            raise AlphaAnalyzerError(
-                "context.world_state.cycle_id must match context.cycle_id",
-            )
-        if context.feature_bundle.entity_id != context.entity_id:
-            raise AlphaAnalyzerError(
-                "context.feature_bundle.entity_id must match context.entity_id",
-            )
+        validate_alpha_analysis_context(entity_id, context)
 
         try:
             response = self._reasoner_port.analyze_alpha(entity_id, context)

--- a/tests/protocols/test_analyzer_interface.py
+++ b/tests/protocols/test_analyzer_interface.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from inspect import signature
 
+import pytest
+
 from main_core.common.contexts import AlphaAnalysisContext
+from main_core.common.errors import AlphaAnalyzerError
 from main_core.common.protocols import AnalyzerBase, AnalyzerInterface
 from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
 from main_core.l6_alpha import (
@@ -51,6 +55,42 @@ def _analysis_context() -> AlphaAnalysisContext:
         feature_bundle=_feature_bundle(),
         world_state=_world_state(),
         similar_cases=[],
+    )
+
+
+def _feature_bundle_cycle_mismatch(
+    context: AlphaAnalysisContext,
+) -> AlphaAnalysisContext:
+    return context.model_copy(
+        update={
+            "feature_bundle": context.feature_bundle.model_copy(
+                update={"cycle_id": "cycle_other"},
+            ),
+        },
+    )
+
+
+def _world_state_cycle_mismatch(
+    context: AlphaAnalysisContext,
+) -> AlphaAnalysisContext:
+    return context.model_copy(
+        update={
+            "world_state": context.world_state.model_copy(
+                update={"cycle_id": "cycle_other"},
+            ),
+        },
+    )
+
+
+def _feature_bundle_entity_mismatch(
+    context: AlphaAnalysisContext,
+) -> AlphaAnalysisContext:
+    return context.model_copy(
+        update={
+            "feature_bundle": context.feature_bundle.model_copy(
+                update={"entity_id": "ENT_OTHER"},
+            ),
+        },
     )
 
 
@@ -107,3 +147,48 @@ def test_multi_agent_analyzer_returns_multi_agent_result() -> None:
 
     assert result.analyzer_type == MULTI_AGENT_ANALYZER
     assert result.status == "ok"
+
+
+@pytest.mark.parametrize(
+    "analyzer_factory",
+    [
+        SinglePromptAnalyzer,
+        MultiAgentAnalyzer,
+    ],
+)
+@pytest.mark.parametrize(
+    ("entity_id", "context_mutation", "message"),
+    [
+        (
+            "ENT_OTHER",
+            lambda context: context,
+            "entity_id must match context.entity_id",
+        ),
+        (
+            ENTITY_ID,
+            _feature_bundle_cycle_mismatch,
+            "context.feature_bundle.cycle_id must match context.cycle_id",
+        ),
+        (
+            ENTITY_ID,
+            _world_state_cycle_mismatch,
+            "context.world_state.cycle_id must match context.cycle_id",
+        ),
+        (
+            ENTITY_ID,
+            _feature_bundle_entity_mismatch,
+            "context.feature_bundle.entity_id must match context.entity_id",
+        ),
+    ],
+)
+def test_analyzer_implementations_reject_mismatched_contexts(
+    analyzer_factory: Callable[[], AnalyzerInterface],
+    entity_id: str,
+    context_mutation: Callable[[AlphaAnalysisContext], AlphaAnalysisContext],
+    message: str,
+) -> None:
+    analyzer = analyzer_factory()
+    context = context_mutation(_analysis_context())
+
+    with pytest.raises(AlphaAnalyzerError, match=message):
+        analyzer.analyze(entity_id, context)


### PR DESCRIPTION
Closes #59

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/override.py`, `src/main_core/l5_universe/service.py`, `src/main_core/l6_alpha/ab_runner.py`, `src/main_core/l8_publish/dashboard.py`, `unknown`


---
## 背景与目标
Milestone review for milestone-99 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The milestone adds cycle/entity consistency checks to `SinglePromptAnalyzer`, but `MultiAgentAnalyzer` still only checks the top-level `entity_id`. That means the same `AnalyzerInterface` contract accepts stale or mismatched `feature_bundle` and `world_state` inputs in one implementation while rejecting them in the other. This can produce L6 results whose output cycle comes from `context.cycle_id` while the supporting L3/L4 inputs came from a different cycle.

## 实现范围
- 修改文件: `src/main_core/l6_alpha/multi_agent_analyzer.py`
- Move the consistency checks into a shared helper or an `AlphaAnalysisContext` model validator, and use the same validation path for both single-prompt and multi-agent analyzers. Add parametrized analyzer-interface tests that exercise both implementations for cycle and entity mismatches.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
