### PR TITLE
feat(#58): [milestone-99 review] P0: Pool schema invariant conflicts with frozen selection semantics

### DIFF
--- a/src/main_core/common/schemas/pool.py
+++ b/src/main_core/common/schemas/pool.py
@@ -15,9 +15,10 @@ class OfficialAlphaPool(FormalObjectBase):
     observation_pool_size: int = Field(
         ge=0,
         description=(
-            "Number of ranked current-cycle observation candidates after configured "
-            "L5 filters and limits. Frozen selected entities with current feature "
-            "bundles are eligible in addition to this count."
+            "Number of service-validated current-cycle entities eligible for L5 "
+            "selection, including ranked observation candidates plus any "
+            "service-validated frozen entities. freeze_reason_map is audit metadata and "
+            "does not expand this eligibility bound."
         ),
     )
     official_alpha_pool_capacity: int = Field(default=100, ge=1, le=100)
@@ -32,16 +33,14 @@ class OfficialAlphaPool(FormalObjectBase):
 
         if len(self.selected_entities) > self.official_alpha_pool_capacity:
             raise ValueError("selected_entities length must be <= official_alpha_pool_capacity")
-        frozen_entity_ids = {str(entity_id) for entity_id in self.freeze_reason_map}
-        non_frozen_selected_count = sum(
-            1
-            for entity_id in self.selected_entities
-            if str(entity_id) not in frozen_entity_ids
-        )
-        if non_frozen_selected_count > self.observation_pool_size:
+        if len(self.selected_entities) > self.observation_pool_size:
             raise ValueError(
-                "non-frozen selected_entities length must be <= observation_pool_size",
+                "selected_entities length must be <= observation_pool_size",
             )
+        selected_entity_ids = {str(entity_id) for entity_id in self.selected_entities}
+        freeze_reason_entity_ids = {str(entity_id) for entity_id in self.freeze_reason_map}
+        if not freeze_reason_entity_ids <= selected_entity_ids:
+            raise ValueError("freeze_reason_map keys must be present in selected_entities")
         return self
 
 

--- a/src/main_core/common/schemas/pool.py
+++ b/src/main_core/common/schemas/pool.py
@@ -12,7 +12,14 @@ class OfficialAlphaPool(FormalObjectBase):
     """Formal L5 official alpha pool described in §9.3."""
 
     cycle_id: CycleId
-    observation_pool_size: int = Field(ge=0)
+    observation_pool_size: int = Field(
+        ge=0,
+        description=(
+            "Number of ranked current-cycle observation candidates after configured "
+            "L5 filters and limits. Frozen selected entities with current feature "
+            "bundles are eligible in addition to this count."
+        ),
+    )
     official_alpha_pool_capacity: int = Field(default=100, ge=1, le=100)
     selected_entities: list[EntityId]
     added_entities: list[EntityId]
@@ -25,8 +32,16 @@ class OfficialAlphaPool(FormalObjectBase):
 
         if len(self.selected_entities) > self.official_alpha_pool_capacity:
             raise ValueError("selected_entities length must be <= official_alpha_pool_capacity")
-        if len(self.selected_entities) > self.observation_pool_size:
-            raise ValueError("selected_entities length must be <= observation_pool_size")
+        frozen_entity_ids = {str(entity_id) for entity_id in self.freeze_reason_map}
+        non_frozen_selected_count = sum(
+            1
+            for entity_id in self.selected_entities
+            if str(entity_id) not in frozen_entity_ids
+        )
+        if non_frozen_selected_count > self.observation_pool_size:
+            raise ValueError(
+                "non-frozen selected_entities length must be <= observation_pool_size",
+            )
         return self
 
 

--- a/src/main_core/l5_universe/service.py
+++ b/src/main_core/l5_universe/service.py
@@ -52,7 +52,10 @@ def select_official_alpha_pool(  # noqa: PLR0913
 
     return OfficialAlphaPool(
         cycle_id=world_state.cycle_id,
-        observation_pool_size=len(observation_candidates),
+        observation_pool_size=_count_eligible_entities(
+            observation_candidates,
+            freeze_reason_map,
+        ),
         official_alpha_pool_capacity=active_config.capacity,
         selected_entities=selected_entities,
         added_entities=added_entities,
@@ -123,6 +126,17 @@ def _select_entities(
         )
 
     return selected_entities
+
+
+def _count_eligible_entities(
+    observation_candidates: Sequence[FeatureSignalBundle],
+    freeze_reason_map: Mapping[EntityId, str],
+) -> int:
+    """Count the validated frozen-inclusive pool the schema uses as its bound."""
+
+    eligible_entity_ids = {str(bundle.entity_id) for bundle in observation_candidates}
+    eligible_entity_ids.update(str(entity_id) for entity_id in freeze_reason_map)
+    return len(eligible_entity_ids)
 
 
 def _append_if_room(

--- a/tests/l5_universe/test_service.py
+++ b/tests/l5_universe/test_service.py
@@ -13,6 +13,7 @@ from main_core.l5_universe.types import MAX_OFFICIAL_ALPHA_POOL_CAPACITY
 
 DEFAULT_OBSERVATION_SIZE = 3
 THRESHOLDED_OBSERVATION_SIZE = 2
+FROZEN_INCLUSIVE_OBSERVATION_SIZE = 2
 TWO_ENTITY_CAPACITY = 2
 
 
@@ -141,7 +142,29 @@ def test_select_official_alpha_pool_carries_frozen_entities_outside_threshold() 
         config=PoolSelectionConfig(capacity=2, min_candidate_score=1.0),
     )
 
-    assert pool.observation_pool_size == 1
+    assert pool.observation_pool_size == FROZEN_INCLUSIVE_OBSERVATION_SIZE
+    assert pool.selected_entities == ("ENT_C", "ENT_A")
+    assert pool.freeze_reason_map == {"ENT_C": "existing core freeze"}
+
+
+def test_select_official_alpha_pool_counts_frozen_entities_outside_observation_limit() -> None:
+    previous_pool = _pool(
+        selected_entities=["ENT_C"],
+        freeze_reason_map={"ENT_C": "existing core freeze"},
+    )
+
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 10.0),
+            _bundle("ENT_B", 9.0),
+            _bundle("ENT_C", 0.0),
+        ],
+        previous_pool=previous_pool,
+        config=PoolSelectionConfig(capacity=2, observation_limit=1),
+    )
+
+    assert pool.observation_pool_size == FROZEN_INCLUSIVE_OBSERVATION_SIZE
     assert pool.selected_entities == ("ENT_C", "ENT_A")
     assert pool.freeze_reason_map == {"ENT_C": "existing core freeze"}
 

--- a/tests/l5_universe/test_service.py
+++ b/tests/l5_universe/test_service.py
@@ -124,6 +124,28 @@ def test_select_official_alpha_pool_prioritizes_frozen_entities() -> None:
     assert pool.freeze_reason_map == {"ENT_C": "existing core freeze"}
 
 
+def test_select_official_alpha_pool_carries_frozen_entities_outside_threshold() -> None:
+    previous_pool = _pool(
+        selected_entities=["ENT_C"],
+        freeze_reason_map={"ENT_C": "existing core freeze"},
+    )
+
+    pool = select_official_alpha_pool(
+        _world_state(),
+        [
+            _bundle("ENT_A", 10.0),
+            _bundle("ENT_B", 0.5),
+            _bundle("ENT_C", 0.0),
+        ],
+        previous_pool=previous_pool,
+        config=PoolSelectionConfig(capacity=2, min_candidate_score=1.0),
+    )
+
+    assert pool.observation_pool_size == 1
+    assert pool.selected_entities == ("ENT_C", "ENT_A")
+    assert pool.freeze_reason_map == {"ENT_C": "existing core freeze"}
+
+
 def test_select_official_alpha_pool_merges_explicit_frozen_entities() -> None:
     pool = select_official_alpha_pool(
         _world_state(),

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -129,9 +129,9 @@ def test_official_alpha_pool_rejects_selected_exceeding_observation_pool() -> No
         OfficialAlphaPool(**payload)
 
 
-def test_official_alpha_pool_allows_frozen_selected_entities_outside_observation_pool() -> None:
+def test_official_alpha_pool_allows_selected_frozen_entities_with_eligible_count() -> None:
     payload = _pool_payload()
-    payload["observation_pool_size"] = 1
+    payload["observation_pool_size"] = 2
     payload["official_alpha_pool_capacity"] = 5
     payload["selected_entities"] = ["ENT_001", "ENT_002"]
     payload["freeze_reason_map"] = {"ENT_001": "existing core freeze"}
@@ -139,3 +139,25 @@ def test_official_alpha_pool_allows_frozen_selected_entities_outside_observation
     pool = OfficialAlphaPool(**payload)
 
     assert pool.selected_entities == ("ENT_001", "ENT_002")
+
+
+def test_official_alpha_pool_rejects_freeze_reason_map_as_eligibility_proof() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = 0
+    payload["official_alpha_pool_capacity"] = 5
+    payload["selected_entities"] = ["ENT_001", "ENT_002"]
+    payload["freeze_reason_map"] = {
+        "ENT_001": "forged freeze",
+        "ENT_002": "forged freeze",
+    }
+
+    with pytest.raises(ValidationError, match="observation_pool_size"):
+        OfficialAlphaPool(**payload)
+
+
+def test_official_alpha_pool_rejects_freeze_reason_for_unselected_entity() -> None:
+    payload = _pool_payload()
+    payload["freeze_reason_map"] = {"ENT_003": "unselected freeze"}
+
+    with pytest.raises(ValidationError, match="freeze_reason_map keys"):
+        OfficialAlphaPool(**payload)

--- a/tests/schemas/test_pool.py
+++ b/tests/schemas/test_pool.py
@@ -123,6 +123,19 @@ def test_official_alpha_pool_rejects_selected_exceeding_observation_pool() -> No
     payload["observation_pool_size"] = 1
     payload["official_alpha_pool_capacity"] = 5
     payload["selected_entities"] = ["ENT_001", "ENT_002"]
+    payload["freeze_reason_map"] = {}
 
     with pytest.raises(ValidationError, match="observation_pool_size"):
         OfficialAlphaPool(**payload)
+
+
+def test_official_alpha_pool_allows_frozen_selected_entities_outside_observation_pool() -> None:
+    payload = _pool_payload()
+    payload["observation_pool_size"] = 1
+    payload["official_alpha_pool_capacity"] = 5
+    payload["selected_entities"] = ["ENT_001", "ENT_002"]
+    payload["freeze_reason_map"] = {"ENT_001": "existing core freeze"}
+
+    pool = OfficialAlphaPool(**payload)
+
+    assert pool.selected_entities == ("ENT_001", "ENT_002")


### PR DESCRIPTION
Closes #58

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/main_core/common/schemas/base.py`, `src/main_core/common/schemas/override.py`, `src/main_core/l5_universe/service.py`, `src/main_core/l6_alpha/ab_runner.py`, `src/main_core/l8_publish/dashboard.py`, `unknown`


---
## 背景与目标
Milestone review for milestone-99 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The new `selected_entities <= observation_pool_size` schema rule is not aligned with L5 selection behavior. `select_official_alpha_pool` sets `observation_pool_size` from ranked `observation_candidates` after filters such as `min_candidate_score` or `observation_limit`, while `_select_entities` prepends frozen entities that only need current feature bundles. A frozen entity can therefore be validly selected while absent from the filtered observation candidates, causing `OfficialAlphaPool` construction to fail and breaking the freeze guarantee.

## 实现范围
- 修改文件: `src/main_core/common/schemas/pool.py`
- Define `observation_pool_size` semantics explicitly. Either set it to the raw current bundle count, include frozen entities in the observation candidate count before validation, or change the validator to compare selected entities against a frozen-inclusive eligible pool. Add an L5 integration test with frozen carry-over plus `min_candidate_score` or `observation_limit`.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/main-core/.venv/bin/python -m pytest
```
