### PR TITLE
Add MVP20 decision pool selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install (full, incl. cross-repo contracts + shared fixtures)
         run: pip install -e ".[dev,contracts-schemas,shared-fixtures]"
       - name: Tests
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install (offline-first dev only)
         run: pip install -e ".[dev]"
       - name: test-fast (unit + boundary)
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install (offline-first dev only)
         run: pip install -e ".[dev]"
       - name: smoke
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install (with shared-fixtures git extra)
         run: pip install -e ".[dev,shared-fixtures]"
       - name: regression (must really consume audit_eval_fixtures)
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install (with cross-repo contracts-schemas extra)
         run: pip install -e ".[dev,contracts-schemas]"
       - name: contract (incl. cross-repo alignment)

--- a/src/main_core/l5_universe/__init__.py
+++ b/src/main_core/l5_universe/__init__.py
@@ -1,12 +1,22 @@
 """L5 package — observation and core pool work; see §14 of main-core.project-doc.md."""
 
+from main_core.l5_universe.mvp20 import select_mvp20_decision_pool
 from main_core.l5_universe.rules import rank_candidates, score_candidate
 from main_core.l5_universe.service import select_official_alpha_pool
-from main_core.l5_universe.types import PoolSelectionConfig
+from main_core.l5_universe.types import (
+    MVP20_DECISION_POOL_CAPACITY,
+    MVP20_MANIFEST_TARGET_FREEZE_REASON,
+    MVP20DecisionPoolSpec,
+    PoolSelectionConfig,
+)
 
 __all__ = [
+    "MVP20_DECISION_POOL_CAPACITY",
+    "MVP20_MANIFEST_TARGET_FREEZE_REASON",
+    "MVP20DecisionPoolSpec",
     "PoolSelectionConfig",
     "rank_candidates",
     "score_candidate",
     "select_official_alpha_pool",
+    "select_mvp20_decision_pool",
 ]

--- a/src/main_core/l5_universe/freezer.py
+++ b/src/main_core/l5_universe/freezer.py
@@ -29,10 +29,7 @@ def merge_frozen_entities(
         ):
             merged.setdefault(EntityId(str(entity_id)), reason)
 
-    for entity_id, reason in sorted(
-        dict(frozen_entities or {}).items(),
-        key=lambda item: str(item[0]),
-    ):
+    for entity_id, reason in dict(frozen_entities or {}).items():
         merged.setdefault(EntityId(str(entity_id)), reason)
 
     return merged

--- a/src/main_core/l5_universe/mvp20.py
+++ b/src/main_core/l5_universe/mvp20.py
@@ -1,0 +1,101 @@
+"""MVP20 fixed decision pool helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas.feature_bundle import FeatureSignalBundle
+from main_core.common.schemas.pool import OfficialAlphaPool
+from main_core.common.schemas.world_state import WorldStateSnapshot
+from main_core.common.types import EntityId
+from main_core.l5_universe.service import select_official_alpha_pool
+from main_core.l5_universe.types import (
+    MVP20_DECISION_POOL_CAPACITY,
+    MVP20_MANIFEST_TARGET_FREEZE_REASON,
+    MVP20DecisionPoolSpec,
+    PoolSelectionConfig,
+)
+
+
+def select_mvp20_decision_pool(
+    world_state: WorldStateSnapshot,
+    bundles: Sequence[FeatureSignalBundle],
+    manifest_targets: Sequence[EntityId] | MVP20DecisionPoolSpec,
+    *,
+    target_freeze_reason: str = MVP20_MANIFEST_TARGET_FREEZE_REASON,
+) -> OfficialAlphaPool:
+    """Select the fixed 20-entity official alpha pool from manifest targets only.
+
+    Extra bundles may be supplied for related-entity context, but they are not
+    eligible for L5 pool selection or downstream L7 recommendations.
+    """
+
+    spec = _resolve_spec(
+        manifest_targets,
+        target_freeze_reason=target_freeze_reason,
+    )
+    bundle_by_entity = _current_bundle_by_entity(world_state, bundles)
+    target_bundles = _target_bundles(spec, bundle_by_entity)
+
+    return select_official_alpha_pool(
+        world_state,
+        target_bundles,
+        config=PoolSelectionConfig(
+            capacity=MVP20_DECISION_POOL_CAPACITY,
+            observation_limit=MVP20_DECISION_POOL_CAPACITY,
+        ),
+        frozen_entities=spec.frozen_entities(),
+    )
+
+
+def _resolve_spec(
+    manifest_targets: Sequence[EntityId] | MVP20DecisionPoolSpec,
+    *,
+    target_freeze_reason: str,
+) -> MVP20DecisionPoolSpec:
+    if isinstance(manifest_targets, MVP20DecisionPoolSpec):
+        return manifest_targets
+    return MVP20DecisionPoolSpec.from_manifest_targets(
+        tuple(manifest_targets),
+        target_freeze_reason=target_freeze_reason,
+    )
+
+
+def _current_bundle_by_entity(
+    world_state: WorldStateSnapshot,
+    bundles: Sequence[FeatureSignalBundle],
+) -> dict[str, FeatureSignalBundle]:
+    bundle_by_entity: dict[str, FeatureSignalBundle] = {}
+    for bundle in bundles:
+        if bundle.cycle_id != world_state.cycle_id:
+            raise MainCoreError("bundle cycle_id must match world_state.cycle_id")
+
+        entity_id = str(bundle.entity_id)
+        if entity_id in bundle_by_entity:
+            raise MainCoreError("duplicate entity_id in FeatureSignalBundle input")
+        bundle_by_entity[entity_id] = bundle
+    return bundle_by_entity
+
+
+def _target_bundles(
+    spec: MVP20DecisionPoolSpec,
+    bundle_by_entity: dict[str, FeatureSignalBundle],
+) -> list[FeatureSignalBundle]:
+    missing_entity_ids = [
+        str(entity_id)
+        for entity_id in spec.manifest_targets
+        if str(entity_id) not in bundle_by_entity
+    ]
+    if missing_entity_ids:
+        raise MainCoreError(
+            "manifest_targets must be present in current FeatureSignalBundle input: "
+            f"{', '.join(missing_entity_ids)}",
+        )
+    return [
+        bundle_by_entity[str(entity_id)]
+        for entity_id in spec.manifest_targets
+    ]
+
+
+__all__ = ["select_mvp20_decision_pool"]

--- a/src/main_core/l5_universe/types.py
+++ b/src/main_core/l5_universe/types.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Self
 
 from main_core.common.errors import MainCoreError
+from main_core.common.types import EntityId
 
 MAX_OFFICIAL_ALPHA_POOL_CAPACITY = 100
+MVP20_DECISION_POOL_CAPACITY = 20
+MVP20_MANIFEST_TARGET_FREEZE_REASON = "mvp20 manifest target"
 
 
 @dataclass(frozen=True)
@@ -37,4 +42,74 @@ class PoolSelectionConfig:
             raise MainCoreError("observation_limit must be a non-negative integer")
 
 
-__all__ = ["MAX_OFFICIAL_ALPHA_POOL_CAPACITY", "PoolSelectionConfig"]
+@dataclass(frozen=True)
+class MVP20DecisionPoolSpec:
+    """Runtime manifest target spec for the fixed 20-entity decision pool."""
+
+    manifest_targets: tuple[EntityId, ...]
+    target_freeze_reason: str = MVP20_MANIFEST_TARGET_FREEZE_REASON
+
+    def __post_init__(self) -> None:
+        """Normalize and validate manifest targets without changing public contracts."""
+
+        object.__setattr__(
+            self,
+            "manifest_targets",
+            _normalize_manifest_targets(self.manifest_targets),
+        )
+        if (
+            not isinstance(self.target_freeze_reason, str)
+            or not self.target_freeze_reason.strip()
+        ):
+            raise MainCoreError("target_freeze_reason must be a non-empty string")
+
+    @classmethod
+    def from_manifest_targets(
+        cls,
+        manifest_targets: Sequence[EntityId],
+        *,
+        target_freeze_reason: str = MVP20_MANIFEST_TARGET_FREEZE_REASON,
+    ) -> Self:
+        """Build a validated MVP20 decision pool spec from manifest target ids."""
+
+        return cls(
+            manifest_targets=tuple(manifest_targets),
+            target_freeze_reason=target_freeze_reason,
+        )
+
+    def frozen_entities(self) -> dict[EntityId, str]:
+        """Return freeze metadata that pins every manifest target into the pool."""
+
+        return {
+            EntityId(str(entity_id)): self.target_freeze_reason
+            for entity_id in self.manifest_targets
+        }
+
+
+def _normalize_manifest_targets(
+    manifest_targets: Sequence[EntityId],
+) -> tuple[EntityId, ...]:
+    normalized_targets: list[EntityId] = []
+    seen_entity_ids: set[str] = set()
+
+    for entity_id in manifest_targets:
+        entity_id_value = str(entity_id).strip()
+        if not entity_id_value:
+            raise MainCoreError("manifest_targets must contain non-empty entity_id")
+        if entity_id_value in seen_entity_ids:
+            raise MainCoreError("manifest_targets must not contain duplicate entity_id")
+        seen_entity_ids.add(entity_id_value)
+        normalized_targets.append(EntityId(entity_id_value))
+
+    if len(normalized_targets) != MVP20_DECISION_POOL_CAPACITY:
+        raise MainCoreError("mvp20 decision pool requires exactly 20 manifest_targets")
+    return tuple(normalized_targets)
+
+
+__all__ = [
+    "MAX_OFFICIAL_ALPHA_POOL_CAPACITY",
+    "MVP20_DECISION_POOL_CAPACITY",
+    "MVP20_MANIFEST_TARGET_FREEZE_REASON",
+    "MVP20DecisionPoolSpec",
+    "PoolSelectionConfig",
+]

--- a/tests/l5_universe/test_freezer.py
+++ b/tests/l5_universe/test_freezer.py
@@ -45,9 +45,19 @@ def test_merge_frozen_entities_preserves_previous_reasons_and_adds_explicit() ->
 
 
 def test_merge_frozen_entities_accepts_explicit_without_previous_pool() -> None:
-    frozen = merge_frozen_entities(None, {"ENT_Z": "manual freeze"})
+    frozen = merge_frozen_entities(
+        None,
+        {
+            "ENT_Z": "manual freeze Z",
+            "ENT_A": "manual freeze A",
+        },
+    )
 
-    assert frozen == {"ENT_Z": "manual freeze"}
+    assert list(frozen) == ["ENT_Z", "ENT_A"]
+    assert frozen == {
+        "ENT_Z": "manual freeze Z",
+        "ENT_A": "manual freeze A",
+    }
 
 
 def test_ensure_frozen_entities_fit_capacity_rejects_overflow() -> None:

--- a/tests/l5_universe/test_mvp20.py
+++ b/tests/l5_universe/test_mvp20.py
@@ -1,0 +1,106 @@
+"""Tests for MVP20 fixed manifest target decision pool selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from main_core.common.errors import MainCoreError
+from main_core.common.schemas import FeatureSignalBundle, WorldStateSnapshot
+from main_core.l5_universe import (
+    MVP20_DECISION_POOL_CAPACITY,
+    MVP20DecisionPoolSpec,
+    select_mvp20_decision_pool,
+)
+
+
+def _world_state(cycle_id: str = "cycle_mvp20") -> WorldStateSnapshot:
+    return WorldStateSnapshot(
+        cycle_id=cycle_id,
+        baseline_regime="neutral",
+        llm_delta=0,
+        final_regime="neutral",
+        llm_rationale="fixture",
+        actual_model_used="fixture",
+        actual_provider="local",
+        fallback_path=[],
+    )
+
+
+def _bundle(
+    entity_id: str,
+    score: float,
+    *,
+    cycle_id: str = "cycle_mvp20",
+) -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_values={"momentum": score},
+        signal_values={"candidate_score": score},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+
+
+def _manifest_targets() -> tuple[str, ...]:
+    ordered_indexes = (5, 1, 4, 2, 3, *range(6, MVP20_DECISION_POOL_CAPACITY + 1))
+    return tuple(f"ENT_T{index:02d}" for index in ordered_indexes)
+
+
+def test_mvp20_spec_freezes_manifest_targets_in_manifest_order() -> None:
+    manifest_targets = _manifest_targets()
+
+    spec = MVP20DecisionPoolSpec.from_manifest_targets(manifest_targets)
+
+    assert spec.manifest_targets == manifest_targets
+    assert tuple(spec.frozen_entities()) == manifest_targets
+
+
+def test_select_mvp20_decision_pool_uses_only_manifest_targets() -> None:
+    manifest_targets = _manifest_targets()
+    target_bundles = [
+        _bundle(entity_id, float(index))
+        for index, entity_id in enumerate(manifest_targets)
+    ]
+    related_bundles = [
+        _bundle("ENT_RELATED_HIGH_A", 999.0),
+        _bundle("ENT_RELATED_HIGH_B", 998.0),
+    ]
+
+    pool = select_mvp20_decision_pool(
+        _world_state(),
+        [*related_bundles, *target_bundles],
+        manifest_targets,
+    )
+
+    assert pool.official_alpha_pool_capacity == MVP20_DECISION_POOL_CAPACITY
+    assert pool.observation_pool_size == MVP20_DECISION_POOL_CAPACITY
+    assert pool.selected_entities == manifest_targets
+    assert tuple(pool.freeze_reason_map) == manifest_targets
+    assert "ENT_RELATED_HIGH_A" not in pool.selected_entities
+    assert "ENT_RELATED_HIGH_B" not in pool.selected_entities
+
+
+@pytest.mark.parametrize("target_count", [19, 21])
+def test_select_mvp20_decision_pool_requires_exactly_20_manifest_targets(
+    target_count: int,
+) -> None:
+    manifest_targets = tuple(f"ENT_T{index:02d}" for index in range(1, target_count + 1))
+    bundles = [
+        _bundle(entity_id, float(index))
+        for index, entity_id in enumerate(manifest_targets)
+    ]
+
+    with pytest.raises(MainCoreError, match="exactly 20"):
+        select_mvp20_decision_pool(_world_state(), bundles, manifest_targets)
+
+
+def test_select_mvp20_decision_pool_requires_current_bundle_for_each_target() -> None:
+    manifest_targets = _manifest_targets()
+    bundles = [
+        _bundle(entity_id, float(index))
+        for index, entity_id in enumerate(manifest_targets[:-1])
+    ]
+
+    with pytest.raises(MainCoreError, match="manifest_targets must be present"):
+        select_mvp20_decision_pool(_world_state(), bundles, manifest_targets)

--- a/tests/l7_recommendation/test_service.py
+++ b/tests/l7_recommendation/test_service.py
@@ -12,11 +12,13 @@ from main_core.common.contexts import RecommendationConstraintInputs
 from main_core.common.errors import MainCoreError
 from main_core.common.schemas import (
     AlphaResultSnapshot,
+    FeatureSignalBundle,
     OfficialAlphaPool,
     OverrideRecord,
     RecommendationSnapshot,
     WorldStateSnapshot,
 )
+from main_core.l5_universe import select_mvp20_decision_pool
 from main_core.l7_recommendation import (
     InMemoryOverrideStore,
     generate_recommendations,
@@ -90,6 +92,22 @@ def _analysis(
     )
 
 
+def _feature_bundle(
+    entity_id: str,
+    score: float,
+    *,
+    cycle_id: str = "cycle_l7",
+) -> FeatureSignalBundle:
+    return FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_values={"momentum": score},
+        signal_values={"candidate_score": score},
+        graph_features={},
+        feature_weight_multiplier={"momentum": 1.0},
+    )
+
+
 def _override(
     entity_id: str,
     action_type: str,
@@ -128,6 +146,40 @@ def test_generate_recommendations_maps_scores_in_pool_order() -> None:
         "reduce",
     ]
     assert [recommendation.rating for recommendation in recommendations] == ["B", "A", "C"]
+
+
+def test_generate_recommendations_with_mvp20_pool_ignores_related_risk_entities() -> None:
+    manifest_targets = tuple(f"ENT_T{index:02d}" for index in range(1, 21))
+    related_entities = ("ENT_RELATED_A", "ENT_RELATED_B")
+    world_state = _world_state()
+    bundles = [
+        *[
+            _feature_bundle(entity_id, float(index))
+            for index, entity_id in enumerate(manifest_targets)
+        ],
+        _feature_bundle(related_entities[0], 999.0),
+        _feature_bundle(related_entities[1], 998.0),
+    ]
+    pool = select_mvp20_decision_pool(world_state, bundles, manifest_targets)
+    analyses = [
+        _analysis(entity_id, BUY_SCORE_THRESHOLD)
+        for entity_id in manifest_targets
+    ]
+
+    recommendations = generate_recommendations(
+        pool,
+        analyses,
+        world_state,
+        risk_context={"related_entities": related_entities},
+    )
+
+    assert [recommendation.entity_id for recommendation in recommendations] == list(
+        manifest_targets
+    )
+    assert not any(
+        recommendation.entity_id in related_entities
+        for recommendation in recommendations
+    )
 
 
 def test_generate_recommendations_passes_inconclusive_through_explicitly() -> None:


### PR DESCRIPTION
## Summary
- add fixed 20-target MVP20 decision pool helper
- keep related/context entities out of L5/L7 decision output
- preserve manifest order for explicit frozen entities

## Tests
- python3 -m pytest tests/l5_universe tests/l7_recommendation tests/schemas/test_pool.py tests/schemas/test_recommendation.py
- python3 -m pytest -rs tests/test_package_boundaries.py tests/unit/test_public_entrypoints.py tests/smoke/test_public_smoke.py
- python3 -m ruff check src/main_core/l5_universe tests/l5_universe tests/l7_recommendation/test_service.py
- git diff --check